### PR TITLE
fix(qlty): make smells non-blocking in QLTY Zero gate

### DIFF
--- a/scripts/quality/run_qlty_zero.py
+++ b/scripts/quality/run_qlty_zero.py
@@ -295,7 +295,7 @@ def _run_checks(repo_dir: Path) -> Tuple[List[Dict[str, Any]], int]:
             smells_exclude_patterns=exclude_patterns if name == "smells" else None,
         )
         entries.append(entry)
-        if final_return_code == 0 and entry["status"] != "pass":
+        if final_return_code == 0 and entry["status"] != "pass" and name != "smells":
             final_return_code = int(result.returncode) or 1
     return entries, final_return_code
 


### PR DESCRIPTION
Smells findings are informational — qlty check is the authoritative gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quality check result reporting and status calculation. Secondary quality metrics no longer negatively affect the primary check status when primary checks pass. This provides more precise control over how different categories of quality failures are reported and handled, enabling enhanced granularity in build pipeline feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->