### PR TITLE
fix(airline): switch pr_behavior to introduced_only

### DIFF
--- a/profiles/repos/airline-reservations-system.yml
+++ b/profiles/repos/airline-reservations-system.yml
@@ -4,7 +4,7 @@ verify_command: bash scripts/verify
 required_contexts_mode: replace
 issue_policy:
   mode: zero
-  pr_behavior: absolute
+  pr_behavior: introduced_only
   main_behavior: absolute
 coverage:
   command: |


### PR DESCRIPTION
## **User description**
## Summary

Airline-Reservations-System currently pins commit `d7a94db4` of this platform. In that version, `.github/workflows/reusable-scanner-matrix.yml` gates the `--pull-request` CLI flag behind:

```python
if pull_request_number and pr_issue_behavior == "introduced_only":
  cmd.extend(["--pull-request", pull_request_number])
elif branch_name:
  cmd.extend(["--branch", branch_name])
```

The airline profile sets `pr_behavior: absolute`, so every PR-triggered run falls through to `--branch <head-ref>`. `check_sonar_zero.py` then calls `/api/qualitygates/project_status?projectKey=Prekzursil_Airline-Reservations-System&branch=<head-ref>` and SonarCloud returns **HTTP 404** because it only indexes PR analyses under the `pullRequest=<n>` scope — the feature branch simply doesn't exist on Sonar's side.

The Codacy Zero gate has the same issue from the other direction: it inherits the repo-wide count (currently tracked against `main`), so a PR can't clear the gate until its fix is already on `main`, creating a chicken-and-egg lock.

Switch to `introduced_only` so PR runs compare against the PR scope in both vendors. `main_behavior: absolute` stays, preserving the zero guarantee on pushes to `main`.

## Verified on Airline-Reservations-System today

- `https://sonarcloud.io/api/issues/search?componentKeys=Prekzursil_Airline-Reservations-System&pullRequest=39` → `total: 0`
- `https://sonarcloud.io/api/qualitygates/project_status?projectKey=…&pullRequest=39` → `status: OK`
- `https://app.codacy.com/api/v3/.../pull-requests/40` → `isUpToStandards=true, newIssues=0`

All three vendor analyses report clean on recent Airline PRs, but the gate script was never asking them because of the branch fallback.

## Test plan
- [ ] Re-run a PR on Airline-Reservations-System after this lands; `shared-scanner-matrix / Sonar Zero` and `shared-scanner-matrix / Codacy Zero` should both turn green without admin bypass.
- [ ] Main pushes still enforce `absolute` via `main_behavior` — no regression on `main`.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch `pr_behavior` to `introduced_only` in the Airline profile so PR runs use PR scope and the zero gates check only new issues. Fixes SonarCloud 404s and Codacy’s repo-wide counter on PRs; `main_behavior: absolute` stays to enforce zero on `main`.

<sup>Written for commit 7f85082aed3b671d013b64621871b92c7f6a782c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make Airline PR checks use PR-specific scan results**

### What Changed
- Airline pull requests now use PR-scoped results instead of falling back to the branch view
- This removes the false failures caused by SonarCloud and Codacy not indexing the feature branch the same way
- Main branch checks still use the existing strict zero-issue rule

### Impact
`✅ Fewer broken Airline PR checks`
`✅ Clearer PR pass/fail results`
`✅ Main branch zero-issue protection stays in place`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=nMcgRLrNAUuBkRT-hwYG35VE7ztOEg6YB3ZJ-5aKcpw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
