### PR TITLE
fix(profile): align devextreme-filter-go-language with Go coverage reality

### DIFF
--- a/profiles/repos/devextreme-filter-go-language.yml
+++ b/profiles/repos/devextreme-filter-go-language.yml
@@ -2,6 +2,13 @@ slug: Prekzursil/DevExtreme-Filter-Go-Language
 stack: go
 verify_command: bash scripts/verify
 coverage:
+  # Go's coverage tooling (go test -cover) only measures statement coverage;
+  # it has no native branch coverage. gocover-cobertura therefore emits
+  # branches-valid=0, and the gate's "go branch coverage data missing"
+  # finding is structural, not a code-quality issue. Override
+  # branch_min_percent to null so the gate enforces only the line threshold
+  # (still 100%) for this repo.
+  branch_min_percent: null
   command: |
     mkdir -p coverage
     packages="$(go list ./... | grep -vE "/ent($|/)")"
@@ -16,12 +23,17 @@ vendors:
   sonar:
     project_key: Prekzursil_DevExtreme-Filter-Go-Language
 codeql:
-  build_mode: autobuild
+  # The `actions` CodeQL extractor does not support autobuild, so the repo
+  # uses its own workflow (.github/workflows/codeql.yml) with per-language
+  # matrix build modes instead of the reusable-codeql.yml pipeline. These
+  # fields remain for profile-contract validation if the reusable pipeline
+  # is reintroduced later.
+  build_mode: none
   languages:
     - actions
     - go
   setup:
-    go: "1.22"
+    go: "1.24"
 dependabot:
   updates:
     - ecosystem: gomod


### PR DESCRIPTION
## **User description**
## Summary
- `branch_min_percent: null` overrides the phase1 default of 100.0 for this repo. Go's `go test -cover` tooling only measures statement coverage; gocover-cobertura therefore emits `branches-valid=0` every time, and the Coverage 100 Gate surfaces a structural "go branch coverage data missing" finding regardless of how many tests cover the actual code. This override keeps the 100% line-coverage requirement intact while removing a threshold the Go ecosystem can't meet.
- `codeql.build_mode: none` because the `actions` CodeQL extractor does not support autobuild. The repo ships its own `.github/workflows/codeql.yml` with per-language matrix build modes, but keeping this accurate prevents confusion if the reusable pipeline is reintroduced.
- `setup.go: \"1.24\"` matches the repo's actual `go.mod` toolchain.

## Context
Without this change, PR #16 on `Prekzursil/DevExtreme-Filter-Go-Language` (which has 23 other green checks) can never clear `shared-scanner-matrix / Coverage 100 Gate`, blocking the quality-zero rollout on that repo.

## Test plan
- [ ] Coverage 100 Gate on downstream repo evaluates only line coverage for Go projects using this repo's profile.
- [ ] Branch coverage is still enforced for repos (non-Go) whose stack does support branch data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Align the Go profile so the Coverage 100 Gate enforces only line coverage and stops false “branch data missing” failures. Also correct the CodeQL build mode and set the Go toolchain to 1.24.

- **Bug Fixes**
  - Set `coverage.branch_min_percent: null` to drop branch thresholds (Go has no native branch coverage) while keeping 100% line coverage.
  - Set `codeql.build_mode: none` since the `actions` extractor doesn’t support autobuild; the repo uses its own `.github/workflows/codeql.yml`.
  - Update CodeQL setup Go version to `1.24` to match `go.mod`.

<sup>Written for commit 520242afe2208b38ad0b560d2ee92477eb2e50cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Align the Go repo profile with how its tests and tooling actually work

### What Changed
- The coverage gate now checks line coverage only, which stops false “branch data missing” failures for this Go project
- CodeQL is marked as not using autobuild, matching the repo’s own workflow setup
- The configured Go version is updated to 1.24 to match the project

### Impact
`✅ Fewer false coverage failures`
`✅ Smoother PR checks for Go projects`
`✅ Fewer toolchain mismatch warnings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=dY5ZUBMfia-9GXjURqQiLe3RR6SsU4c7VjP_f3ejfzE&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
