### PR TITLE
feat(qzp-v2 phase 3 inc-5): python-only stack ci.yml.j2 template

### DIFF
--- a/profiles/templates/stack/python-only/ci.yml.j2
+++ b/profiles/templates/stack/python-only/ci.yml.j2
@@ -1,0 +1,42 @@
+{#- python-only stack CI template.
+
+   Renders a minimal consumer ``ci.yml`` that runs the profile's
+   ``coverage.command`` on push/PR. Stack-specific variants
+   (``python-web``, ``python-desktop``, ``python-tooling``) can
+   compose this fragment via ``{% include %}`` and add their own
+   extra jobs.
+
+   Consumed variables:
+      default_branch              - typically ``main``
+      coverage.setup.python       - Python series; defaults to 3.12
+      coverage.command            - shell command to produce coverage.xml
+-#}
+name: Python CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["{{ default_branch | default('main', true) }}"]
+  pull_request:
+    branches: ["{{ default_branch | default('main', true) }}"]
+
+concurrency:
+  group: python-ci-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+{% include 'common/ci-fragments/setup-python.yml.j2' %}
+      - name: Install dev dependencies
+        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt
+      - name: Run tests with coverage
+        shell: bash
+        run: |
+          {{ (coverage | default({}, true)).get('command') or 'pytest --cov' }}

--- a/tests/test_python_only_template.py
+++ b/tests/test_python_only_template.py
@@ -1,0 +1,82 @@
+"""Render tests for ``profiles/templates/stack/python-only/ci.yml.j2``.
+
+Phase 3 of ``docs/QZP-V2-DESIGN.md`` ships per-stack workflow templates
+the drift-sync pipeline renders into consumer repos. This suite pins
+the python-only stack's ``ci.yml`` contract.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.quality import template_render as tr
+
+
+class PythonOnlyCiTemplateTests(unittest.TestCase):
+    """``stack/python-only/ci.yml.j2`` renders a valid GitHub Actions workflow."""
+
+    @staticmethod
+    def _render(profile: dict) -> str:
+        """Render the template against ``profile``."""
+        return tr.render_template("stack/python-only/ci.yml.j2", profile)
+
+    def test_default_profile_renders_valid_workflow(self) -> None:
+        """A minimal profile produces parseable YAML with ``test`` job."""
+        rendered = self._render({
+            "default_branch": "main",
+            "coverage": {"command": "pytest --cov"},
+        })
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc["name"], "Python CI")
+        self.assertIn("test", doc["jobs"])
+        self.assertEqual(doc["jobs"]["test"]["runs-on"], "ubuntu-latest")
+        # ``on:`` is parsed as YAML boolean True; GitHub Actions accepts
+        # the unquoted key, so the tests look it up via the bool key.
+        on_block = doc[True]
+        self.assertEqual(on_block["push"]["branches"], ["main"])
+        self.assertEqual(on_block["pull_request"]["branches"], ["main"])
+
+    def test_default_branch_falls_back_to_main(self) -> None:
+        """Omitting ``default_branch`` still yields ``main``."""
+        rendered = self._render({"coverage": {"command": "pytest"}})
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc[True]["push"]["branches"], ["main"])
+
+    def test_custom_python_version_propagates(self) -> None:
+        """``coverage.setup.python`` reaches the rendered setup-python step."""
+        rendered = self._render({
+            "coverage": {
+                "setup": {"python": "3.13"},
+                "command": "pytest",
+            },
+        })
+        self.assertIn('python-version: "3.13"', rendered)
+
+    def test_pinned_checkout_action(self) -> None:
+        """``actions/checkout@v4`` with ``persist-credentials: false`` is pinned."""
+        rendered = self._render({"coverage": {"command": "pytest"}})
+        self.assertIn("actions/checkout@v4", rendered)
+        self.assertIn("persist-credentials: false", rendered)
+
+    def test_concurrency_group_uses_github_ref(self) -> None:
+        """Concurrency group interpolates ``github.ref`` to dedupe runs per branch."""
+        rendered = self._render({"coverage": {"command": "pytest"}})
+        self.assertIn("concurrency:", rendered)
+        self.assertIn("group: python-ci-${{ github.ref }}", rendered)
+
+    def test_missing_coverage_command_falls_back_to_pytest_cov(self) -> None:
+        """No declared ``coverage.command`` yields the generic ``pytest --cov``."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("pytest --cov", rendered)
+
+    def test_list_templates_includes_python_only_ci(self) -> None:
+        """``list_templates('python-only')`` surfaces the new file."""
+        mapping = tr.list_templates("python-only")
+        self.assertIn("stack/python-only/ci.yml.j2", mapping)
+        self.assertEqual(mapping["stack/python-only/ci.yml.j2"], "ci.yml")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
First stack-specific template on top of the Phase 3 scaffold (merged in PR #91). Renders a minimal GitHub Actions workflow for Python-only repos — pytest + coverage, no frontend.

## Contract pinned by 7 new tests

- Emits `name: Python CI` + single `test` job on `ubuntu-latest`
- `on:` triggers honour `default_branch` from the profile (defaults to `main`)
- `coverage.setup.python` propagates into setup-python's version
- `actions/checkout@v4` pinned with `persist-credentials: false`
- Concurrency group interpolates `github.ref` so pushes dedupe per-branch
- Falls back to `pytest --cov` when `coverage.command` is absent
- `list_templates('python-only')` surfaces the file at `ci.yml`

Composes the common `setup-python.yml.j2` fragment via Jinja `{% include %}` — the pinned action SHAs + default version live in one place.

## Scope

One stack, one workflow file. Nine more stack templates to follow (`python-desktop`, `python-web`, `react-vite-vitest`, `fullstack-web`, `go`, `rust`, `swift`, `cpp-cmake`, `dotnet-wpf`, `gradle-java`). Each as its own focused PR.

## Test plan

- [x] 1088 tests pass locally (7 new)
- [x] `ruff check` clean (ignoring pre-existing PT/S style noise across all test files)
- [x] Dry-renders valid GitHub Actions YAML
- [ ] CI on this PR green (SonarCloud "0% new code" may flag — same pre-existing pattern as PRs #88, #89, #90, #91)


___

## **CodeAnt-AI Description**
**Add a minimal Python-only CI workflow template**

### What Changed
- Adds a new Python CI workflow for Python-only repos with one Ubuntu test job
- Runs on pushes and pull requests for the repo’s default branch, with a fallback to `main` when no branch is set
- Reuses the pinned Python setup step, keeps checkout credentials off, and prevents overlapping runs on the same branch
- Uses the profile’s coverage command when present, and falls back to `pytest --cov` when it is missing
- Adds tests that lock in the rendered workflow and template listing for the new stack

### Impact
`✅ Clearer Python-only CI setup`
`✅ Fewer duplicate branch runs`
`✅ Fewer broken workflow renders`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bsgLW5odB9eJn0aMlT76hZEEWXR_VD2Txq4jddMsOWU&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
