### PR TITLE
feat(qzp-v2 phase 3 inc-6): python-tooling stack ci.yml.j2 template

### DIFF
--- a/profiles/templates/stack/python-tooling/ci.yml.j2
+++ b/profiles/templates/stack/python-tooling/ci.yml.j2
@@ -1,0 +1,54 @@
+{#- python-tooling stack CI template.
+
+   Targets CLI tools + library packages (including the platform's
+   own scripts). Similar to python-only but adds complexity + lint
+   gates that matter for published tools. Frontend-less, pure Python.
+
+   Consumed variables:
+      default_branch              - typically ``main``
+      coverage.setup.python       - Python series; defaults to 3.12
+      coverage.command            - shell command to produce coverage.xml
+-#}
+name: Python Tooling CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["{{ default_branch | default('main', true) }}"]
+  pull_request:
+    branches: ["{{ default_branch | default('main', true) }}"]
+
+concurrency:
+  group: python-tooling-ci-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+{% include 'common/ci-fragments/setup-python.yml.j2' %}
+      - name: Install dev dependencies
+        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt
+      - name: Run tests with coverage
+        shell: bash
+        run: |
+          {{ (coverage | default({}, true)).get('command') or 'pytest --cov --cov-branch --cov-report=xml' }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+{% include 'common/ci-fragments/setup-python.yml.j2' %}
+      - name: Install lint tools
+        run: python -m pip install --upgrade pip && pip install ruff lizard
+      - name: Ruff lint
+        run: ruff check scripts/ tests/
+      - name: Lizard cyclomatic complexity
+        run: lizard scripts/ -C 15

--- a/tests/test_python_tooling_template.py
+++ b/tests/test_python_tooling_template.py
@@ -1,0 +1,63 @@
+"""Render tests for ``profiles/templates/stack/python-tooling/ci.yml.j2``.
+
+Phase 3 of ``docs/QZP-V2-DESIGN.md`` §4: python-tooling targets
+CLI tools + library packages (including the platform itself).
+Adds a ``lint`` job to the python-only base contract — ruff + lizard.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.quality import template_render as tr
+
+
+class PythonToolingCiTemplateTests(unittest.TestCase):
+    """``stack/python-tooling/ci.yml.j2`` renders test + lint jobs."""
+
+    @staticmethod
+    def _render(profile: dict) -> str:
+        """Render the template against ``profile``."""
+        return tr.render_template("stack/python-tooling/ci.yml.j2", profile)
+
+    def test_renders_test_and_lint_jobs(self) -> None:
+        """Both ``test`` and ``lint`` jobs are present in the rendered workflow."""
+        rendered = self._render({
+            "default_branch": "main",
+            "coverage": {"command": "pytest --cov"},
+        })
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc["name"], "Python Tooling CI")
+        self.assertIn("test", doc["jobs"])
+        self.assertIn("lint", doc["jobs"])
+
+    def test_lint_job_installs_ruff_and_lizard(self) -> None:
+        """The lint job pulls in the exact CLI tools the platform uses."""
+        rendered = self._render({"coverage": {"command": "pytest"}})
+        self.assertIn("pip install ruff lizard", rendered)
+        self.assertIn("ruff check scripts/ tests/", rendered)
+        # Lizard's complexity ceiling defaults to 15, matching the
+        # platform's own ``lizard src/ -C 15`` gate.
+        self.assertIn("lizard scripts/ -C 15", rendered)
+
+    def test_default_coverage_command_includes_branch_flag(self) -> None:
+        """Default command produces branch coverage so the 100% gate works."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("pytest --cov --cov-branch --cov-report=xml", rendered)
+
+    def test_concurrency_group_is_stack_specific(self) -> None:
+        """Concurrency group name distinguishes python-tooling from python-only."""
+        rendered = self._render({"coverage": {"command": "pytest"}})
+        self.assertIn("group: python-tooling-ci-${{ github.ref }}", rendered)
+
+    def test_list_templates_includes_python_tooling_ci(self) -> None:
+        """``list_templates('python-tooling')`` surfaces the new file."""
+        mapping = tr.list_templates("python-tooling")
+        self.assertIn("stack/python-tooling/ci.yml.j2", mapping)
+        self.assertEqual(mapping["stack/python-tooling/ci.yml.j2"], "ci.yml")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Second stack-specific template. `python-tooling` targets CLI tools + library packages (including the platform itself). Extends `python-only`'s `test` job with a `lint` job that pins ruff + `lizard -C 15` — the same complexity ceiling the platform enforces on its own `scripts/`.

## Contract pinned by 5 new tests

- Emits `name: Python Tooling CI` with both `test` and `lint` jobs
- Lint job installs ruff + lizard; runs `ruff check scripts/ tests/` and `lizard scripts/ -C 15`
- Default coverage command produces branch coverage + XML (so the 100% gate works out-of-the-box)
- Concurrency group is stack-specific (`python-tooling-ci-${{ github.ref }}`)
- `list_templates('python-tooling')` surfaces the file at `ci.yml`

## Scope

Two of ten stack templates now done (python-only + python-tooling). Eight more to follow: `python-web`, `fullstack-web`, `react-vite-vitest`, `go`, `rust`, `swift`, `cpp-cmake`, `dotnet-wpf`, `gradle-java`.

## Test plan

- [x] 1086 tests pass locally (5 new for python-tooling)
- [x] Ruff clean on new files
- [x] Renders valid GitHub Actions YAML against a minimal profile
- [ ] CI on this PR green (SonarCloud "0% new code" may flag — pre-existing pattern)


___

## **CodeAnt-AI Description**
**Add CI for Python tooling projects with test and lint checks**

### What Changed
- Added a new Python tooling CI workflow with both test and lint jobs
- The lint job now checks `scripts/` and `tests/` with Ruff and enforces a complexity limit with Lizard
- The default test command now includes branch coverage and XML output so coverage checks work without extra setup
- Runs for this stack use a separate concurrency group
- The Python tooling template now shows up in template listings

### Impact
`✅ Earlier lint checks for CLI and library projects`
`✅ Fewer coverage setup failures`
`✅ Separate CI runs for Python tooling stacks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bw_U8oAi93mTKZLmwyWoBbBOD8SsDsypnVahhUc912Y&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
