### PR TITLE
feat(qzp-v2 phase 3 inc-7): react-vite-vitest stack ci.yml.j2 template

### DIFF
--- a/profiles/templates/common/ci-fragments/setup-node.yml.j2
+++ b/profiles/templates/common/ci-fragments/setup-node.yml.j2
@@ -9,9 +9,9 @@
       coverage.setup.node  - Node major version, e.g. ``20`` or ``24``.
 #}
 {%- set node = (coverage | default({}, true)).get('setup', {}).get('node') -%}
-{%- if node %}
+{% if node %}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "{{ node }}"
-{%- endif %}
+{% endif %}

--- a/profiles/templates/stack/react-vite-vitest/ci.yml.j2
+++ b/profiles/templates/stack/react-vite-vitest/ci.yml.j2
@@ -1,0 +1,45 @@
+{#- react-vite-vitest stack CI template.
+
+   Targets frontend-only repos: vitest + v8 coverage + eslint +
+   prettier + tsc. Mirror-image of ``python-only`` for the JS side.
+
+   Consumed variables:
+      default_branch                - typically ``main``
+      coverage.setup.node           - Node major version; defaults to 20
+      coverage.command              - shell command to produce coverage
+-#}
+name: React Vite Vitest CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["{{ default_branch | default('main', true) }}"]
+  pull_request:
+    branches: ["{{ default_branch | default('main', true) }}"]
+
+concurrency:
+  group: react-vite-vitest-ci-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+{% include 'common/ci-fragments/setup-node.yml.j2' %}
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npx eslint .
+      - name: Prettier check
+        run: npx prettier --check .
+      - name: Run tests with coverage
+        shell: bash
+        run: |
+          {{ (coverage | default({}, true)).get('command') or 'npx vitest run --coverage' }}

--- a/tests/test_react_vite_vitest_template.py
+++ b/tests/test_react_vite_vitest_template.py
@@ -1,0 +1,76 @@
+"""Render tests for ``profiles/templates/stack/react-vite-vitest/ci.yml.j2``.
+
+Phase 3 of ``docs/QZP-V2-DESIGN.md`` §4: react-vite-vitest is the
+frontend-only complement to python-only (vitest + v8 + eslint +
+prettier + tsc).
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.quality import template_render as tr
+
+
+class ReactViteVitestCiTemplateTests(unittest.TestCase):
+    """``stack/react-vite-vitest/ci.yml.j2`` renders the frontend workflow."""
+
+    @staticmethod
+    def _render(profile: dict) -> str:
+        """Render against ``profile``."""
+        return tr.render_template(
+            "stack/react-vite-vitest/ci.yml.j2", profile
+        )
+
+    def test_workflow_has_all_frontend_gates(self) -> None:
+        """Test + lint + prettier + tsc gates all render in the single job."""
+        rendered = self._render({
+            "default_branch": "main",
+            "coverage": {"setup": {"node": "20"}, "command": "npx vitest run --coverage"},
+        })
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc["name"], "React Vite Vitest CI")
+        self.assertIn("test", doc["jobs"])
+        rendered_lower = rendered.lower()
+        self.assertIn("tsc --noemit", rendered_lower)
+        self.assertIn("eslint .", rendered_lower)
+        self.assertIn("prettier --check", rendered_lower)
+        self.assertIn("vitest run --coverage", rendered_lower)
+
+    def test_setup_node_fragment_renders_inside_job(self) -> None:
+        """``coverage.setup.node`` propagates into setup-node@v4."""
+        rendered = self._render({"coverage": {"setup": {"node": "24"}}})
+        self.assertIn("actions/setup-node@v4", rendered)
+        self.assertIn('node-version: "24"', rendered)
+
+    def test_concurrency_group_distinguishes_from_python(self) -> None:
+        """Each stack has its own concurrency group name."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn(
+            "group: react-vite-vitest-ci-${{ github.ref }}", rendered
+        )
+
+    def test_default_branch_override(self) -> None:
+        """Repos on non-``main`` default branches honour the profile field."""
+        rendered = self._render({
+            "default_branch": "trunk",
+            "coverage": {"setup": {"node": "20"}},
+        })
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc[True]["push"]["branches"], ["trunk"])
+
+    def test_list_templates_surfaces_react_vite_vitest_ci(self) -> None:
+        """``list_templates('react-vite-vitest')`` finds the template."""
+        mapping = tr.list_templates("react-vite-vitest")
+        self.assertIn(
+            "stack/react-vite-vitest/ci.yml.j2", mapping
+        )
+        self.assertEqual(
+            mapping["stack/react-vite-vitest/ci.yml.j2"], "ci.yml"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Third stack template — the frontend-only complement to `python-only` (PR #92). Renders vitest + v8 coverage + eslint + prettier + tsc in a single job. Pins `actions/setup-node@v4`, composes the common `setup-node.yml.j2` fragment.

## Contract (5 tests)

- `name: React Vite Vitest CI` with single `test` job on ubuntu-latest
- Four frontend gates all render: `tsc --noEmit`, `eslint .`, `prettier --check .`, `vitest run --coverage`
- `coverage.setup.node` propagates into `setup-node@v4`'s version
- Concurrency group is stack-specific (`react-vite-vitest-ci-${{ github.ref }}`)
- `list_templates('react-vite-vitest')` surfaces the file at `ci.yml`
- `default_branch` override honoured

## Fragment fix

Also updates `common/ci-fragments/setup-node.yml.j2` to use non-stripping `{% endif %}` so the consuming workflow keeps a newline between the Node setup step and the next step. Previous `{%- endif %}` was merging `node-version:` into the following `- name:` line, producing invalid YAML. No existing tests broke.

## Scope

3 of 10 stack templates done (python-only, python-tooling, react-vite-vitest). 7 to go: `python-web`, `fullstack-web`, `go`, `rust`, `swift`, `cpp-cmake`, `dotnet-wpf`, `gradle-java`.

## Test plan

- [x] 1093 tests pass locally (5 new for react-vite-vitest)
- [x] Template renders valid GitHub Actions YAML
- [x] Fragment fix doesn't regress python-only or python-tooling tests
- [ ] CI on this PR green


___

## **CodeAnt-AI Description**
Add a frontend CI workflow for React Vite Vitest projects and fix Node setup rendering

### What Changed
- Adds a new CI workflow for React Vite Vitest projects with one test job on push and pull request
- The workflow now runs type checking, linting, Prettier checks, and Vitest coverage in one place
- The Node setup step now renders with the correct spacing so the workflow stays valid when Node is included
- The workflow respects the repository’s default branch and uses a stack-specific concurrency group

### Impact
`✅ Frontend checks run in one CI workflow`
`✅ Fewer invalid workflow renders`
`✅ CI works on non-main default branches`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=geOGCyl06qy8DpILAdPuygfE-8j5Id7j1uKb8goEW1w&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `react-vite-vitest` CI template that runs type check, lint, format, and tests with coverage in one job. Also fixes the Node setup fragment so the workflow renders valid YAML.

- **New Features**
  - Adds workflow "React Vite Vitest CI" with a single `test` job on `ubuntu-latest` (push/PR to `default_branch`).
  - Runs `tsc --noEmit`, `eslint .`, `prettier --check .`, and `vitest run --coverage`.
  - Uses `actions/setup-node@v4` with the version from `coverage.setup.node`.
  - Stack-specific concurrency: `react-vite-vitest-ci-${{ github.ref }}`; surfaced via `list_templates('react-vite-vitest')` as `ci.yml`.

- **Bug Fixes**
  - Switches `common/ci-fragments/setup-node.yml.j2` to `{% endif %}` to preserve the newline after `node-version:`, preventing invalid YAML.
  - No regressions to existing templates.

<sup>Written for commit 3c27e901fba8ee92984f65aaa32ac9b9f3ddbb73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

