### PR TITLE
feat(qzp-v2 phase 3 inc-8): go stack ci.yml.j2 template

### DIFF
--- a/profiles/templates/stack/go/ci.yml.j2
+++ b/profiles/templates/stack/go/ci.yml.j2
@@ -1,0 +1,55 @@
+{#- Go stack CI template.
+
+   Renders a minimal Go CI workflow that sets up Go, runs ``go test``
+   with a coverage profile, and lints with ``golangci-lint``.
+
+   Consumed variables:
+      default_branch              - typically ``main``
+      coverage.setup.go           - Go series; defaults to 1.23
+      coverage.command            - shell command to produce coverage; defaults
+                                    to the standard ``go test`` invocation
+-#}
+name: Go CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["{{ default_branch | default('main', true) }}"]
+  pull_request:
+    branches: ["{{ default_branch | default('main', true) }}"]
+
+concurrency:
+  group: go-ci-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "{{ (coverage | default({}, true)).get('setup', {}).get('go') or '1.23' }}"
+      - name: Run tests with coverage
+        shell: bash
+        run: |
+          {{ (coverage | default({}, true)).get('command') or 'go test -race -coverprofile=coverage.out -covermode=atomic ./...' }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "{{ (coverage | default({}, true)).get('setup', {}).get('go') or '1.23' }}"
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
+        with:
+          version: latest

--- a/tests/test_go_template.py
+++ b/tests/test_go_template.py
@@ -1,0 +1,61 @@
+"""Render tests for ``profiles/templates/stack/go/ci.yml.j2``."""
+
+from __future__ import absolute_import
+
+import unittest
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.quality import template_render as tr
+
+
+class GoCiTemplateTests(unittest.TestCase):
+    """``stack/go/ci.yml.j2`` renders a Go CI workflow."""
+
+    @staticmethod
+    def _render(profile: dict) -> str:
+        """Render against ``profile``."""
+        return tr.render_template("stack/go/ci.yml.j2", profile)
+
+    def test_renders_test_and_lint_jobs(self) -> None:
+        """Go stack has both ``test`` and ``lint`` jobs."""
+        rendered = self._render({"coverage": {}})
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc["name"], "Go CI")
+        self.assertIn("test", doc["jobs"])
+        self.assertIn("lint", doc["jobs"])
+
+    def test_default_go_version(self) -> None:
+        """Default Go version is 1.23 when profile omits ``coverage.setup.go``."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn('go-version: "1.23"', rendered)
+
+    def test_custom_go_version_propagates(self) -> None:
+        """``coverage.setup.go`` propagates into setup-go@v5."""
+        rendered = self._render({"coverage": {"setup": {"go": "1.24"}}})
+        self.assertIn('go-version: "1.24"', rendered)
+
+    def test_default_coverage_command_has_race_and_atomic(self) -> None:
+        """Default command enables ``-race`` + ``-covermode=atomic``."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("-race", rendered)
+        self.assertIn("-covermode=atomic", rendered)
+        self.assertIn("-coverprofile=coverage.out", rendered)
+
+    def test_golangci_lint_action_pinned(self) -> None:
+        """golangci-lint action is pinned by SHA per supply-chain contract."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn(
+            "golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837",
+            rendered,
+        )
+
+    def test_list_templates_includes_go_ci(self) -> None:
+        """``list_templates('go')`` surfaces the file."""
+        mapping = tr.list_templates("go")
+        self.assertIn("stack/go/ci.yml.j2", mapping)
+        self.assertEqual(mapping["stack/go/ci.yml.j2"], "ci.yml")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Fourth stack template. Renders Go CI with `test` and `lint` jobs pinning `actions/setup-go@v5` and `golangci/golangci-lint-action` by full SHA.

## Contract (6 tests)

- `name: Go CI` with `test` + `lint` jobs on ubuntu-latest
- Default Go version 1.23; `coverage.setup.go` override propagates
- Default coverage command uses `-race`, `-covermode=atomic`, `-coverprofile=coverage.out`
- golangci-lint action SHA pinned (`2226d7cb06a077cd73e56eedd38eecad18e5d837`) per §A.2.4
- `list_templates('go')` surfaces the file at `ci.yml`

## Scope

4 of 10 stack templates done (python-only, python-tooling, react-vite-vitest, go). 6 to go: `python-web`, `fullstack-web`, `rust`, `swift`, `cpp-cmake`, `dotnet-wpf`, `gradle-java`.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a Go stack CI template for GitHub Actions with `test` and `lint` jobs, and pins `golangci/golangci-lint-action` by full SHA to meet the supply-chain contract.

- **New Features**
  - Adds `stack/go/ci.yml.j2` that renders a "Go CI" workflow with `test` and `lint` on `ubuntu-latest` using `actions/setup-go@v5`.
  - Runs `go test` with `-race`, `-covermode=atomic`, and `-coverprofile=coverage.out`; Go version is overrideable via `coverage.setup.go` (default 1.23).
  - Lint uses `golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837`.
  - Surfaced by `list_templates('go')` as `ci.yml`; 6 unit tests added to validate the template contract.

<sup>Written for commit 551b6f33c4af75a371286b26558d3bc289e85d62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add a Go CI workflow for testing and linting**

### What Changed
- Added a Go CI workflow with separate test and lint jobs for pull requests and pushes to the main branch
- Tests run with coverage enabled, including race detection and atomic coverage output by default
- Go version defaults to 1.23, and a custom version from the profile now carries through to the workflow
- Linting now uses a pinned GolangCI-Lint action version
- Added render tests to verify the workflow name, jobs, Go version handling, coverage command, pinned lint action, and template listing

### Impact
`✅ Fewer missed Go test failures in CI`
`✅ Clearer Go coverage output`
`✅ Safer lint runs with pinned CI actions`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=M4NFmCPq19RDe0OFaZAqrunOy6fqvw8-s9yOG40Ey0E&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
