### PR TITLE
feat(qzp-v2 phase 3 inc-9): rust stack ci.yml.j2 template

### DIFF
--- a/profiles/templates/stack/rust/ci.yml.j2
+++ b/profiles/templates/stack/rust/ci.yml.j2
@@ -1,0 +1,58 @@
+{#- Rust stack CI template.
+
+   Renders Rust CI with cargo test, llvm-cov coverage, clippy, and
+   rustfmt. Pins ``dtolnay/rust-toolchain`` by SHA per §A.2.4.
+
+   Consumed variables:
+      default_branch              - typically ``main``
+      coverage.setup.rust_channel - Rust channel: stable, beta, nightly; defaults stable
+      coverage.command            - shell command to produce lcov; defaults to cargo-llvm-cov
+-#}
+name: Rust CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["{{ default_branch | default('main', true) }}"]
+  pull_request:
+    branches: ["{{ default_branch | default('main', true) }}"]
+
+concurrency:
+  group: rust-ci-${{ '{{' }} github.ref {{ '}}' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        with:
+          toolchain: {{ (coverage | default({}, true)).get('setup', {}).get('rust_channel') or 'stable' }}
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Run tests with coverage
+        shell: bash
+        run: |
+          {{ (coverage | default({}, true)).get('command') or 'cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info' }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        with:
+          toolchain: {{ (coverage | default({}, true)).get('setup', {}).get('rust_channel') or 'stable' }}
+          components: clippy, rustfmt
+      - name: Clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
+      - name: rustfmt
+        run: cargo fmt --all -- --check

--- a/tests/test_rust_template.py
+++ b/tests/test_rust_template.py
@@ -1,0 +1,73 @@
+"""Render tests for ``profiles/templates/stack/rust/ci.yml.j2``."""
+
+from __future__ import absolute_import
+
+import unittest
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.quality import template_render as tr
+
+
+class RustCiTemplateTests(unittest.TestCase):
+    """``stack/rust/ci.yml.j2`` renders a Rust CI workflow."""
+
+    @staticmethod
+    def _render(profile: dict) -> str:
+        """Render against ``profile``."""
+        return tr.render_template("stack/rust/ci.yml.j2", profile)
+
+    def test_renders_test_and_lint_jobs(self) -> None:
+        """Rust stack has both ``test`` and ``lint`` jobs."""
+        rendered = self._render({"coverage": {}})
+        doc = yaml.safe_load(rendered)
+        self.assertEqual(doc["name"], "Rust CI")
+        self.assertIn("test", doc["jobs"])
+        self.assertIn("lint", doc["jobs"])
+
+    def test_default_channel_is_stable(self) -> None:
+        """``rust_channel`` defaults to ``stable``."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("toolchain: stable", rendered)
+
+    def test_custom_channel_propagates(self) -> None:
+        """``coverage.setup.rust_channel`` overrides default."""
+        rendered = self._render({
+            "coverage": {"setup": {"rust_channel": "nightly"}}
+        })
+        self.assertIn("toolchain: nightly", rendered)
+
+    def test_llvm_cov_coverage_command(self) -> None:
+        """Default coverage command uses cargo-llvm-cov with lcov output."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("cargo llvm-cov", rendered)
+        self.assertIn("--lcov", rendered)
+        self.assertIn("lcov.info", rendered)
+
+    def test_clippy_all_warnings_are_errors(self) -> None:
+        """Clippy is run with ``-D warnings`` to treat all warnings as errors."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("cargo clippy --all-features --all-targets -- -D warnings", rendered)
+
+    def test_rustfmt_check_mode(self) -> None:
+        """rustfmt runs in ``--check`` mode so it fails on un-formatted code."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn("cargo fmt --all -- --check", rendered)
+
+    def test_rust_toolchain_action_pinned(self) -> None:
+        """``dtolnay/rust-toolchain`` is pinned by SHA per §A.2.4."""
+        rendered = self._render({"coverage": {}})
+        self.assertIn(
+            "dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7",
+            rendered,
+        )
+
+    def test_list_templates_includes_rust_ci(self) -> None:
+        """``list_templates('rust')`` surfaces the file."""
+        mapping = tr.list_templates("rust")
+        self.assertIn("stack/rust/ci.yml.j2", mapping)
+        self.assertEqual(mapping["stack/rust/ci.yml.j2"], "ci.yml")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Fifth stack template. Renders Rust CI with `cargo test` + `cargo-llvm-cov` coverage + `clippy` + `rustfmt`. Pins `dtolnay/rust-toolchain` by the same SHA the reusable-scanner-matrix coverage lane already uses.

## Contract (8 tests)

- `name: Rust CI` with `test` + `lint` jobs
- Default channel `stable`; `coverage.setup.rust_channel` overrides
- Default coverage via `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info`
- Clippy runs with `-D warnings` (all warnings = errors)
- rustfmt runs in `--check` mode
- `dtolnay/rust-toolchain` SHA-pinned (`631a55b12751854ce901bb631d5902ceb48146f7`)
- `list_templates('rust')` surfaces the file at `ci.yml`

## Scope

5 of 10 stack templates done. Half-way to Phase 3's template contract.


___

## **CodeAnt-AI Description**
Add a Rust CI workflow with tests, coverage, lint, and format checks

### What Changed
- Added a Rust CI workflow for pull requests and main branch pushes with separate test and lint jobs
- Tests now run with coverage output by default, and the Rust channel can be overridden when needed
- Linting now fails on all Clippy warnings, and rustfmt checks formatting instead of fixing it
- The Rust toolchain is pinned to a fixed version, and the Rust template is available as `ci.yml`
- Added tests that verify the workflow content and template mapping

### Impact
`✅ Consistent Rust CI on pull requests`
`✅ Coverage reports generated by default`
`✅ Clearer Rust lint and format failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=QuthO1JJ0FQ9DePzIZiV6FIdWZV2460gGsqrpPy2SCk&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
