### PR TITLE
feat(qzp-v2 phase 3 inc-11): drift_sync.py comparator

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -28,6 +28,7 @@ engines:
       - "scripts/quality/validate_codecov_flags.py"
       - "scripts/quality/marker_regions.py"
       - "scripts/quality/template_render.py"
+      - "scripts/quality/drift_sync.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/profiles/templates/common/codecov.yml.j2
+++ b/profiles/templates/common/codecov.yml.j2
@@ -17,7 +17,7 @@ codecov:
   require_ci_to_pass: true
 
 flags:
-{% for item in coverage.inputs %}
+{% for item in coverage.get('inputs') or [] %}
   {{ item.flag }}:
     paths:
 {% if item.get('sources') %}

--- a/scripts/quality/drift_sync.py
+++ b/scripts/quality/drift_sync.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Detect drift between a consumer repo and the rendered platform templates.
+
+Phase 3 of ``docs/QZP-V2-DESIGN.md`` §4 ships per-stack templates that
+the drift-sync workflow renders into consumer repos. This module is
+the core comparator the workflow invokes before opening a PR:
+
+1. Load the resolved profile JSON (output of ``export_profile.py``).
+2. For every template in ``list_templates(profile['stack'])`` render
+   it against the profile as context.
+3. For every rendered output compare against the consumer repo's
+   actual file. Report one of three statuses:
+
+   * ``missing``   — template would create a new file.
+   * ``drift``     — file exists but the body that would render differs
+                     from the current bytes.
+   * ``in_sync``   — file exists and matches the rendered body byte-for-byte.
+
+4. Emit a unified diff for every ``drift`` + ``missing`` entry so the
+   workflow can stage a PR.
+
+Intentionally does NOT open PRs itself — that's the workflow's job so
+this module stays testable without a GitHub credential.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import difflib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+from scripts.quality.template_render import (  # noqa: E402
+    list_templates,
+    render_template,
+)
+
+
+@dataclass(frozen=True)
+class DriftEntry:
+    """One per-file drift result."""
+
+    template_path: str
+    output_path: str
+    status: str  # "missing" | "drift" | "in_sync"
+    diff: str  # unified diff text; empty for in_sync
+    proposed_content: str
+
+
+def _unified_diff(
+    actual: str, proposed: str, output_path: str
+) -> str:
+    """Return a standard unified diff text between ``actual`` and ``proposed``."""
+    return "".join(
+        difflib.unified_diff(
+            actual.splitlines(keepends=True),
+            proposed.splitlines(keepends=True),
+            fromfile=f"a/{output_path}",
+            tofile=f"b/{output_path}",
+        )
+    )
+
+
+def _classify_entry(
+    proposed: str, current_path: Path, output_path: str
+) -> DriftEntry:
+    """Compute the drift status for a single template->output mapping."""
+    if not current_path.is_file():
+        return DriftEntry(
+            template_path="",  # filled in by caller
+            output_path=output_path,
+            status="missing",
+            diff=_unified_diff("", proposed, output_path),
+            proposed_content=proposed,
+        )
+    actual = current_path.read_text(encoding="utf-8")
+    if actual == proposed:
+        return DriftEntry(
+            template_path="",
+            output_path=output_path,
+            status="in_sync",
+            diff="",
+            proposed_content=proposed,
+        )
+    return DriftEntry(
+        template_path="",
+        output_path=output_path,
+        status="drift",
+        diff=_unified_diff(actual, proposed, output_path),
+        proposed_content=proposed,
+    )
+
+
+def detect_drift(
+    profile: Mapping[str, Any], repo_root: Path
+) -> List[DriftEntry]:
+    """Return a ``DriftEntry`` for each template that belongs to this stack.
+
+    ``profile`` is the resolved profile JSON; ``profile['stack']`` selects
+    which stack-specific templates to render. ``repo_root`` is the path to
+    the checked-out consumer repo.
+    """
+    stack = str(profile.get("stack", "")).strip()
+    if not stack:
+        return []
+    mapping = list_templates(stack)
+    entries: List[DriftEntry] = []
+    for template_path, output_path in sorted(mapping.items()):
+        proposed = render_template(template_path, profile)
+        entry = _classify_entry(proposed, repo_root / output_path, output_path)
+        entries.append(
+            DriftEntry(
+                template_path=template_path,
+                output_path=entry.output_path,
+                status=entry.status,
+                diff=entry.diff,
+                proposed_content=entry.proposed_content,
+            )
+        )
+    return entries
+
+
+def drift_summary(entries: Iterable[DriftEntry]) -> Dict[str, int]:
+    """Return a ``{status: count}`` dict. Useful for CI rollup output."""
+    summary: Dict[str, int] = {"missing": 0, "drift": 0, "in_sync": 0}
+    for entry in entries:
+        summary[entry.status] = summary.get(entry.status, 0) + 1
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-json", required=True,
+        help="Path to the resolved profile JSON (output of export_profile.py).",
+    )
+    parser.add_argument(
+        "--repo-root", required=True,
+        help="Path to the consumer repo's checkout.",
+    )
+    parser.add_argument(
+        "--out-json", default="",
+        help="Where to write the drift report JSON (stdout if empty).",
+    )
+    parser.add_argument(
+        "--fail-on-drift", action="store_true",
+        help="Exit non-zero when drift or missing entries are detected.",
+    )
+    return parser.parse_args()
+
+
+def _build_report(entries: Iterable[DriftEntry]) -> Dict[str, Any]:
+    """Build the JSON report that downstream tooling consumes."""
+    entry_list = list(entries)
+    return {
+        "summary": drift_summary(entry_list),
+        "entries": [
+            {
+                "template_path": e.template_path,
+                "output_path": e.output_path,
+                "status": e.status,
+                "diff": e.diff,
+                "proposed_content": e.proposed_content,
+            }
+            for e in entry_list
+        ],
+    }
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    args = _parse_args()
+    profile_path = Path(args.profile_json)
+    if not profile_path.is_file():
+        print(
+            f"drift_sync: profile JSON not found: {profile_path}",
+            file=sys.stderr, flush=True,
+        )
+        return 2
+    repo_root = Path(args.repo_root)
+    if not repo_root.is_dir():
+        print(
+            f"drift_sync: repo root not found: {repo_root}",
+            file=sys.stderr, flush=True,
+        )
+        return 2
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    entries = detect_drift(profile, repo_root)
+    report = _build_report(entries)
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.out_json:
+        Path(args.out_json).write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    summary = report["summary"]
+    out_of_sync = summary.get("missing", 0) + summary.get("drift", 0)
+    if args.fail_on_drift and out_of_sync:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_drift_sync.py
+++ b/tests/test_drift_sync.py
@@ -1,0 +1,221 @@
+"""Coverage for ``scripts.quality.drift_sync`` — the Phase 3 comparator.
+
+Tests exercise every DriftEntry status (missing, drift, in_sync), the
+CLI exit contract (0 / 1 / 2), and the report JSON shape.
+"""
+
+from __future__ import absolute_import
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.quality import drift_sync as ds
+
+
+def _make_temp_repo(files: dict) -> Path:
+    """Create a temp repo with ``files``: ``{relative_path: content}``."""
+    root = Path(tempfile.mkdtemp())
+    for rel, body in files.items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    return root
+
+
+class DetectDriftTests(unittest.TestCase):
+    """``detect_drift`` reports missing / drift / in_sync per template."""
+
+    def test_empty_stack_returns_no_entries(self) -> None:
+        """Profiles without a ``stack`` value produce no entries."""
+        self.assertEqual(ds.detect_drift({}, Path(".")), [])
+
+    def test_missing_output_flags_missing(self) -> None:
+        """When the consumer repo has no file, the template is ``missing``."""
+        repo = _make_temp_repo({})
+        profile = {
+            "stack": "python-only",
+            "default_branch": "main",
+            "coverage": {
+                "command": "pytest",
+                "inputs": [
+                    {"name": "x", "flag": "x", "path": "x.xml"},
+                ],
+            },
+        }
+        entries = ds.detect_drift(profile, repo)
+        self.assertTrue(entries, "template list must not be empty")
+        for entry in entries:
+            self.assertEqual(entry.status, "missing")
+        # At least one of the rendered templates must be non-empty so we
+        # also exercise the diff-contains-new-content path.
+        non_empty = [e for e in entries if e.proposed_content]
+        self.assertTrue(non_empty)
+        self.assertIn("+++ b/", non_empty[0].diff)
+
+    def test_exact_match_flags_in_sync(self) -> None:
+        """When the consumer file equals the rendered body, status is ``in_sync``."""
+        profile = {
+            "stack": "python-only",
+            "default_branch": "main",
+            "coverage": {"command": "pytest --cov"},
+        }
+        # Render the template the same way drift_sync will, then write it
+        # into the fake consumer repo at the expected output path.
+        from scripts.quality import template_render as tr
+
+        mapping = tr.list_templates("python-only")
+        files = {}
+        for template_path, output_path in mapping.items():
+            files[output_path] = tr.render_template(template_path, profile)
+        repo = _make_temp_repo(files)
+        entries = ds.detect_drift(profile, repo)
+        for entry in entries:
+            self.assertEqual(entry.status, "in_sync")
+            self.assertEqual(entry.diff, "")
+
+    def test_changed_content_flags_drift(self) -> None:
+        """When the consumer file diverges from the rendered body, status is ``drift``."""
+        profile = {
+            "stack": "python-only",
+            "default_branch": "main",
+            "coverage": {"command": "pytest --cov"},
+        }
+        # Seed the repo with a modified version of each output.
+        from scripts.quality import template_render as tr
+
+        mapping = tr.list_templates("python-only")
+        files = {}
+        for template_path, output_path in mapping.items():
+            rendered = tr.render_template(template_path, profile)
+            files[output_path] = "# DRIFTED\n" + rendered
+        repo = _make_temp_repo(files)
+        entries = ds.detect_drift(profile, repo)
+        self.assertTrue(entries)
+        self.assertTrue(all(e.status == "drift" for e in entries))
+        self.assertTrue(all("# DRIFTED" in e.diff for e in entries))
+
+
+class DriftSummaryTests(unittest.TestCase):
+    """``drift_summary`` counts entries by status."""
+
+    def test_counts_each_status(self) -> None:
+        """Every status appears in the output even when zero."""
+        entries = [
+            ds.DriftEntry(
+                template_path="a", output_path="a", status="missing",
+                diff="", proposed_content="",
+            ),
+            ds.DriftEntry(
+                template_path="b", output_path="b", status="drift",
+                diff="", proposed_content="",
+            ),
+            ds.DriftEntry(
+                template_path="c", output_path="c", status="drift",
+                diff="", proposed_content="",
+            ),
+            ds.DriftEntry(
+                template_path="d", output_path="d", status="in_sync",
+                diff="", proposed_content="",
+            ),
+        ]
+        self.assertEqual(
+            ds.drift_summary(entries),
+            {"missing": 1, "drift": 2, "in_sync": 1},
+        )
+
+
+class CliTests(unittest.TestCase):
+    """End-to-end CLI: exit codes 0 / 1 / 2."""
+
+    @staticmethod
+    def _run(argv: list) -> int:
+        """Invoke ``main()`` with patched ``sys.argv``."""
+        with patch.object(sys, "argv", ["drift_sync.py", *argv]):
+            return ds.main()
+
+    def test_missing_profile_json_returns_2(self) -> None:
+        """Exit 2 when profile JSON path doesn't exist."""
+        rc = self._run([
+            "--profile-json", "/does/not/exist.json",
+            "--repo-root", str(Path.cwd()),
+        ])
+        self.assertEqual(rc, 2)
+
+    def test_missing_repo_root_returns_2(self) -> None:
+        """Exit 2 when repo root path doesn't exist or isn't a directory."""
+        profile_path = Path(tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json"
+        ).name)
+        self.addCleanup(profile_path.unlink, missing_ok=True)
+        profile_path.write_text(
+            json.dumps({"stack": "python-only", "coverage": {}}),
+            encoding="utf-8",
+        )
+        rc = self._run([
+            "--profile-json", str(profile_path),
+            "--repo-root", "/nope/not/here",
+        ])
+        self.assertEqual(rc, 2)
+
+    def test_fail_on_drift_flag_returns_1_when_out_of_sync(self) -> None:
+        """Exit 1 with ``--fail-on-drift`` and at least one missing/drift entry."""
+        profile = {"stack": "python-only", "coverage": {"command": "pytest"}}
+        profile_path = Path(tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json"
+        ).name)
+        self.addCleanup(profile_path.unlink, missing_ok=True)
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+        repo = _make_temp_repo({})  # empty repo = everything missing
+        rc = self._run([
+            "--profile-json", str(profile_path),
+            "--repo-root", str(repo),
+            "--fail-on-drift",
+        ])
+        self.assertEqual(rc, 1)
+
+    def test_no_fail_on_drift_returns_0_even_with_drift(self) -> None:
+        """Without ``--fail-on-drift`` the CLI always returns 0."""
+        profile = {"stack": "python-only", "coverage": {"command": "pytest"}}
+        profile_path = Path(tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json"
+        ).name)
+        self.addCleanup(profile_path.unlink, missing_ok=True)
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+        repo = _make_temp_repo({})
+        rc = self._run([
+            "--profile-json", str(profile_path),
+            "--repo-root", str(repo),
+        ])
+        self.assertEqual(rc, 0)
+
+    def test_out_json_writes_report_file(self) -> None:
+        """``--out-json`` writes the report instead of printing to stdout."""
+        profile = {"stack": "python-only", "coverage": {"command": "pytest"}}
+        profile_path = Path(tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json"
+        ).name)
+        self.addCleanup(profile_path.unlink, missing_ok=True)
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+        repo = _make_temp_repo({})
+        out_path = Path(tempfile.NamedTemporaryFile(
+            delete=False, suffix=".json"
+        ).name)
+        self.addCleanup(out_path.unlink, missing_ok=True)
+        rc = self._run([
+            "--profile-json", str(profile_path),
+            "--repo-root", str(repo),
+            "--out-json", str(out_path),
+        ])
+        self.assertEqual(rc, 0)
+        report = json.loads(out_path.read_text(encoding="utf-8"))
+        self.assertIn("summary", report)
+        self.assertIn("entries", report)
+        self.assertGreaterEqual(report["summary"]["missing"], 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Core of the Phase 3 drift-sync pipeline. Renders every template for the profile's stack, compares against the consumer repo's actual files, emits a `DriftEntry` with `missing` / `drift` / `in_sync` status + unified diff + proposed content.

Does **NOT** open PRs — that's the workflow wrapper's job. This module stays testable without any GitHub credential, which is what lets coverage hit 100% (73 stmts / 18 branches) with the 10 new tests.

## CLI exit contract

- `0` — success (or out-of-sync with `--fail-on-drift` absent)
- `1` — out-of-sync and `--fail-on-drift` was passed
- `2` — profile JSON or repo root doesn't exist / isn't a directory

## Template fix

`common/codecov.yml.j2` hardened to tolerate profiles without `coverage.inputs` declared — uses `coverage.get('inputs') or []` instead of direct attribute access. Necessary for the drift-sync smoke tests where minimal profiles render against the whole template set.

## Next increment

`reusable-drift-sync.yml` workflow that wraps this script and opens PRs on detected drift. That's the last Phase 3 deliverable before the first fleet-wide sync wave.

## Test plan

- [x] 10 new drift-sync tests, all pass
- [x] 1138 tests on full suite
- [x] 100% branch+line coverage on `drift_sync.py`
- [x] `ruff check` clean
- [ ] CI on this PR green

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the core Phase 3 drift-sync comparator that renders stack templates, compares them to the consumer repo, and outputs a JSON report with status, unified diff, and proposed content. This stays credential-free and will be wrapped by a workflow that opens PRs.

- **New Features**
  - Introduced `scripts/quality/drift_sync.py` CLI to detect drift and output a JSON report (summary + entries).
  - Emits unified diffs for `missing` and `drift` entries; includes proposed file content.
  - Exit codes: 0 (success), 1 (out-of-sync with `--fail-on-drift`), 2 (invalid profile JSON or repo root).

- **Bug Fixes**
  - Hardened `profiles/templates/common/codecov.yml.j2` for profiles without `coverage.inputs`; excluded `scripts/quality/drift_sync.py` from `.codacy.yaml` metrics delta.

<sup>Written for commit 7ec75a0e689b97f4097e5c507b6d9aa4bc7a1359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add drift detection for rendered templates and relax Codecov config for empty inputs**

### What Changed
- Added a drift-check command that compares rendered templates against a consumer repo and reports each file as missing, changed, or in sync.
- The drift report now includes a summary, per-file diffs for missing or changed files, and an optional exit code when drift is found.
- Updated the Codecov template so profiles without coverage inputs no longer fail during rendering.
- Added coverage for all drift states, CLI exit codes, and report output.

### Impact
`✅ Faster template drift reviews`
`✅ Fewer false failures on minimal profiles`
`✅ Clearer drift reports for automated PRs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=OFItk-yEFBzPcSUEIYcsZGLA3-ydkDVg6UEIwptRkAg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
