### PR TITLE
feat(qzp-v2 phase 3 inc-12): reusable-drift-sync workflow + apply_drift_pr

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -28,6 +28,8 @@ engines:
       - "scripts/quality/validate_codecov_flags.py"
       - "scripts/quality/marker_regions.py"
       - "scripts/quality/template_render.py"
+      - "scripts/quality/drift_sync.py"
+      - "scripts/quality/apply_drift_pr.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/.github/workflows/reusable-drift-sync.yml
+++ b/.github/workflows/reusable-drift-sync.yml
@@ -1,0 +1,158 @@
+name: Reusable Drift Sync
+
+# QZP v2 Phase 3 §4 — render profile templates against a consumer repo
+# and open a PR when the rendered output diverges from the repo's
+# current state. Each fleet repo wires this workflow via a thin caller
+# that supplies the ``repo_slug`` + secrets.
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      repo_slug:
+        type: string
+        required: true
+        description: "owner/name of the target consumer repo."
+      default_branch:
+        type: string
+        required: false
+        default: main
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+        description: "When true, report drift but do not open a PR."
+      platform_repository:
+        type: string
+        required: false
+        default: Prekzursil/quality-zero-platform
+      platform_ref:
+        type: string
+        required: false
+        default: main
+    secrets:
+      DRIFT_SYNC_PAT:
+        required: false
+        description: "Fine-grained PAT with ``pull-requests:write`` + ``contents:write`` on the target repo. Absent = dry-run mode."
+
+jobs:
+  drift-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.platform_repository }}
+          ref: ${{ inputs.platform_ref }}
+          path: platform
+          persist-credentials: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo_slug }}
+          ref: ${{ inputs.default_branch }}
+          path: repo
+          token: ${{ secrets.DRIFT_SYNC_PAT || github.token }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r platform/requirements-dev.txt
+
+      - name: Export resolved profile
+        id: profile
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+        run: |
+          python platform/scripts/quality/export_profile.py \
+            --repo-slug "$REPO_SLUG" \
+            --out-json "$RUNNER_TEMP/profile.json"
+
+      - name: Detect template drift
+        id: detect
+        run: |
+          python platform/scripts/quality/drift_sync.py \
+            --profile-json "$RUNNER_TEMP/profile.json" \
+            --repo-root "$GITHUB_WORKSPACE/repo" \
+            --out-json "$RUNNER_TEMP/drift.json"
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report-${{ inputs.repo_slug == '' && 'unknown' || inputs.repo_slug }}
+          path: ${{ runner.temp }}/drift.json
+
+      - name: Summarise drift
+        env:
+          DRIFT_REPORT_PATH: ${{ runner.temp }}/drift.json
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["DRIFT_REPORT_PATH"]).read_text(encoding="utf-8"))
+          summary = report.get("summary", {})
+          missing = int(summary.get("missing", 0))
+          drift = int(summary.get("drift", 0))
+          in_sync = int(summary.get("in_sync", 0))
+          print(f"Drift summary: missing={missing} drift={drift} in_sync={in_sync}", flush=True)
+          out_of_sync = missing + drift
+          step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if step_summary:
+            with open(step_summary, "a", encoding="utf-8") as handle:
+              handle.write(f"## Drift Sync\n\n- missing: {missing}\n- drift: {drift}\n- in_sync: {in_sync}\n")
+              if out_of_sync:
+                handle.write("\nOut-of-sync entries:\n\n")
+                for entry in report.get("entries", []):
+                  if entry["status"] in ("missing", "drift"):
+                    handle.write(f"- `{entry['output_path']}` ({entry['status']})\n")
+          PY
+
+      - name: Apply drift fixes + open PR
+        if: ${{ !inputs.dry_run && env.DRIFT_SYNC_PAT_PRESENT == 'true' }}
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+          DEFAULT_BRANCH: ${{ inputs.default_branch }}
+          PLATFORM_REF: ${{ inputs.platform_ref }}
+          DRIFT_REPORT_PATH: ${{ runner.temp }}/drift.json
+          GH_TOKEN: ${{ secrets.DRIFT_SYNC_PAT }}
+          DRIFT_SYNC_PAT_PRESENT: ${{ secrets.DRIFT_SYNC_PAT != '' }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          # Run the applier + open a PR. Keeps the body of the step in
+          # a Python here-doc so env-var indirection replaces every
+          # ``${{ github.* }}`` interpolation (Semgrep CWE-78).
+          python "$GITHUB_WORKSPACE/platform/scripts/quality/apply_drift_pr.py" \
+            --report "$DRIFT_REPORT_PATH" \
+            --repo-slug "$REPO_SLUG" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --platform-ref "$PLATFORM_REF"
+
+      - name: Fail on drift when dry_run
+        if: ${{ inputs.dry_run }}
+        env:
+          DRIFT_REPORT_PATH: ${{ runner.temp }}/drift.json
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["DRIFT_REPORT_PATH"]).read_text(encoding="utf-8"))
+          summary = report.get("summary", {})
+          out_of_sync = int(summary.get("missing", 0)) + int(summary.get("drift", 0))
+          if out_of_sync:
+              print(f"drift-sync (dry-run): {out_of_sync} entries out of sync", flush=True)
+              sys.exit(1)
+          print("drift-sync (dry-run): fully in sync.", flush=True)
+          PY

--- a/scripts/quality/apply_drift_pr.py
+++ b/scripts/quality/apply_drift_pr.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Apply drift-sync fixes + open a PR on the consumer repo.
+
+Called by ``reusable-drift-sync.yml`` after ``drift_sync.py`` has
+emitted the drift report JSON. Writes the ``proposed_content`` for
+every ``missing`` / ``drift`` entry to its ``output_path``, commits
+to a fresh branch, and opens a pull request via ``gh pr create``.
+
+Intentionally does not manipulate the consumer repo when the report
+shows ``in_sync`` for every entry — that path yields exit 0 with no
+side effects so the workflow can always call this step.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import os
+import subprocess  # noqa: S404 — gh CLI wrapper; args are controlled
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+_BRANCH_PREFIX = "quality-zero/drift-sync"
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--repo-slug", required=True)
+    parser.add_argument("--default-branch", default="main")
+    parser.add_argument("--platform-ref", default="main")
+    parser.add_argument(
+        "--cwd", default=".",
+        help="Working directory (consumer repo checkout). Defaults to current dir.",
+    )
+    parser.add_argument(
+        "--runner",
+        default=None,
+        help=argparse.SUPPRESS,  # test-only injection of a subprocess.run stub
+    )
+    return parser.parse_args()
+
+
+def _collect_out_of_sync(entries: List[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
+    """Return only entries whose status is ``missing`` or ``drift``."""
+    return [e for e in entries if e.get("status") in ("missing", "drift")]
+
+
+def _apply_entries(entries: List[Mapping[str, Any]], cwd: Path) -> List[str]:
+    """Write each entry's proposed content to disk; return staged paths."""
+    applied: List[str] = []
+    for entry in entries:
+        rel = str(entry.get("output_path", "")).strip()
+        body = str(entry.get("proposed_content", ""))
+        if not rel:
+            continue
+        target = cwd / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+        applied.append(rel)
+    return applied
+
+
+def _git(
+    args: List[str],
+    cwd: Path,
+    runner,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command, streaming output through ``runner``."""
+    return runner(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _gh_pr_create(
+    branch: str,
+    default_branch: str,
+    summary_body: str,
+    cwd: Path,
+    runner,
+) -> None:
+    """Invoke ``gh pr create`` with the staged branch."""
+    runner(
+        [
+            "gh", "pr", "create",
+            "--base", default_branch,
+            "--head", branch,
+            "--title", "chore(drift-sync): apply template updates from quality-zero-platform",
+            "--body", summary_body,
+        ],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _build_body(
+    out_of_sync: List[Mapping[str, Any]], platform_ref: str
+) -> str:
+    """Build the PR body summary from the drift entries."""
+    lines = [
+        "Automated template-drift sync from quality-zero-platform.",
+        "",
+        f"Platform ref: `{platform_ref}`",
+        "",
+        "Updated files:",
+    ]
+    for entry in out_of_sync:
+        status = entry.get("status", "")
+        path = entry.get("output_path", "")
+        lines.append(f"- `{path}` ({status})")
+    return "\n".join(lines) + "\n"
+
+
+def _run_drift_pr(args: argparse.Namespace, runner) -> int:
+    """Body of :func:`main`, split out so tests can inject ``runner``."""
+    report_path = Path(args.report)
+    if not report_path.is_file():
+        print(
+            f"apply_drift_pr: drift report not found: {report_path}",
+            file=sys.stderr, flush=True,
+        )
+        return 2
+    payload: Dict[str, Any] = json.loads(
+        report_path.read_text(encoding="utf-8")
+    )
+    entries = list(payload.get("entries") or [])
+    out_of_sync = _collect_out_of_sync(entries)
+    if not out_of_sync:
+        print(
+            "apply_drift_pr: fleet already in sync; nothing to do.",
+            flush=True,
+        )
+        return 0
+
+    cwd = Path(args.cwd).resolve()
+    branch = f"{_BRANCH_PREFIX}/{os.environ.get('GITHUB_RUN_ID', 'manual')}"
+
+    applied = _apply_entries(out_of_sync, cwd)
+    if not applied:
+        print(
+            "apply_drift_pr: no entries had output paths to apply.",
+            flush=True,
+        )
+        return 0
+
+    _git(["checkout", "-b", branch], cwd, runner)
+    _git(["add", *applied], cwd, runner)
+    _git(
+        [
+            "-c", "user.email=platform-bot@quality-zero.local",
+            "-c", "user.name=quality-zero-platform drift-sync",
+            "commit",
+            "-m", "chore(drift-sync): apply template updates",
+        ],
+        cwd, runner,
+    )
+    _git(["push", "--set-upstream", "origin", branch], cwd, runner)
+    _gh_pr_create(
+        branch, args.default_branch, _build_body(out_of_sync, args.platform_ref),
+        cwd, runner,
+    )
+    print(
+        f"apply_drift_pr: opened PR on {args.repo_slug} "
+        f"with {len(applied)} file(s) updated.",
+        flush=True,
+    )
+    return 0
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    args = _parse_args()
+    return _run_drift_pr(args, subprocess.run)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/quality/apply_drift_pr.py
+++ b/scripts/quality/apply_drift_pr.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import argparse
 import json
 import os
-import subprocess  # noqa: S404 — gh CLI wrapper; args are controlled
+import subprocess  # nosec B404 # noqa: S404 — gh CLI wrapper; args are controlled
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
@@ -119,38 +119,21 @@ def _build_body(
     return "\n".join(lines) + "\n"
 
 
-def _run_drift_pr(args: argparse.Namespace, runner) -> int:
-    """Body of :func:`main`, split out so tests can inject ``runner``."""
-    report_path = Path(args.report)
+def _load_report(report_path: Path) -> Dict[str, Any] | None:
+    """Return the drift report JSON or ``None`` when missing."""
     if not report_path.is_file():
         print(
             f"apply_drift_pr: drift report not found: {report_path}",
             file=sys.stderr, flush=True,
         )
-        return 2
-    payload: Dict[str, Any] = json.loads(
-        report_path.read_text(encoding="utf-8")
-    )
-    entries = list(payload.get("entries") or [])
-    out_of_sync = _collect_out_of_sync(entries)
-    if not out_of_sync:
-        print(
-            "apply_drift_pr: fleet already in sync; nothing to do.",
-            flush=True,
-        )
-        return 0
+        return None
+    return json.loads(report_path.read_text(encoding="utf-8"))
 
-    cwd = Path(args.cwd).resolve()
-    branch = f"{_BRANCH_PREFIX}/{os.environ.get('GITHUB_RUN_ID', 'manual')}"
 
-    applied = _apply_entries(out_of_sync, cwd)
-    if not applied:
-        print(
-            "apply_drift_pr: no entries had output paths to apply.",
-            flush=True,
-        )
-        return 0
-
+def _git_commit_and_push(
+    branch: str, applied: List[str], cwd: Path, runner,
+) -> None:
+    """Run the git checkout/add/commit/push sequence."""
     _git(["checkout", "-b", branch], cwd, runner)
     _git(["add", *applied], cwd, runner)
     _git(
@@ -163,6 +146,24 @@ def _run_drift_pr(args: argparse.Namespace, runner) -> int:
         cwd, runner,
     )
     _git(["push", "--set-upstream", "origin", branch], cwd, runner)
+
+
+def _run_drift_pr(args: argparse.Namespace, runner) -> int:
+    """Body of :func:`main`, split out so tests can inject ``runner``."""
+    payload = _load_report(Path(args.report))
+    if payload is None:
+        return 2
+    out_of_sync = _collect_out_of_sync(list(payload.get("entries") or []))
+    if not out_of_sync:
+        print("apply_drift_pr: fleet already in sync; nothing to do.", flush=True)
+        return 0
+    cwd = Path(args.cwd).resolve()
+    branch = f"{_BRANCH_PREFIX}/{os.environ.get('GITHUB_RUN_ID', 'manual')}"
+    applied = _apply_entries(out_of_sync, cwd)
+    if not applied:
+        print("apply_drift_pr: no entries had output paths to apply.", flush=True)
+        return 0
+    _git_commit_and_push(branch, applied, cwd, runner)
     _gh_pr_create(
         branch, args.default_branch, _build_body(out_of_sync, args.platform_ref),
         cwd, runner,

--- a/tests/test_apply_drift_pr.py
+++ b/tests/test_apply_drift_pr.py
@@ -1,0 +1,217 @@
+"""Unit coverage for ``scripts.quality.apply_drift_pr``.
+
+The workflow step invokes this CLI *after* ``drift_sync.py`` has
+emitted its report. The tests stub ``subprocess.run`` so git + gh are
+never actually called, and assert on the argument lists the script
+constructs.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+from scripts.quality import apply_drift_pr as apr
+
+
+class _FakeRunner:
+    """Collect every ``(cmd, cwd)`` pair routed through the stub."""
+
+    def __init__(self) -> None:
+        """Initialise an empty call log."""
+        self.calls: List[List[str]] = []
+
+    def __call__(
+        self, cmd, cwd=None, check=False, capture_output=False, text=False
+    ) -> subprocess.CompletedProcess:
+        """Record the invocation and return a success result."""
+        self.calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+
+def _write_report(payload: dict) -> Path:
+    """Write ``payload`` to a temp file and return its path."""
+    fd, name = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    path = Path(name)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class CollectOutOfSyncTests(unittest.TestCase):
+    """``_collect_out_of_sync`` filters to missing + drift entries."""
+
+    def test_only_missing_and_drift_retained(self) -> None:
+        """in_sync entries are excluded."""
+        entries = [
+            {"status": "in_sync", "output_path": "x"},
+            {"status": "drift", "output_path": "y"},
+            {"status": "missing", "output_path": "z"},
+        ]
+        out = apr._collect_out_of_sync(entries)
+        self.assertEqual([e["output_path"] for e in out], ["y", "z"])
+
+
+class ApplyEntriesTests(unittest.TestCase):
+    """``_apply_entries`` writes proposed content to disk under ``cwd``."""
+
+    def test_writes_files_and_returns_staged_paths(self) -> None:
+        """New files land in nested directories; return value lists them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            entries = [
+                {
+                    "status": "missing",
+                    "output_path": ".github/workflows/ci.yml",
+                    "proposed_content": "name: CI\n",
+                },
+                {
+                    "status": "drift",
+                    "output_path": "codecov.yml",
+                    "proposed_content": "codecov:\n  require_ci_to_pass: true\n",
+                },
+            ]
+            applied = apr._apply_entries(entries, cwd)
+        self.assertEqual(
+            sorted(applied),
+            sorted([".github/workflows/ci.yml", "codecov.yml"]),
+        )
+
+    def test_empty_output_path_is_skipped(self) -> None:
+        """Entries without an output_path don't create empty files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            applied = apr._apply_entries(
+                [{"status": "drift", "output_path": "", "proposed_content": "x"}],
+                cwd,
+            )
+        self.assertEqual(applied, [])
+
+
+class BuildBodyTests(unittest.TestCase):
+    """``_build_body`` composes a human-readable summary."""
+
+    def test_summary_lists_each_out_of_sync_entry(self) -> None:
+        """Each entry appears as a bullet with its status."""
+        body = apr._build_body(
+            [
+                {"status": "drift", "output_path": "ci.yml"},
+                {"status": "missing", "output_path": "codecov.yml"},
+            ],
+            "main",
+        )
+        self.assertIn("- `ci.yml` (drift)", body)
+        self.assertIn("- `codecov.yml` (missing)", body)
+        self.assertIn("Platform ref: `main`", body)
+
+
+class RunDriftPrTests(unittest.TestCase):
+    """``_run_drift_pr`` drives the apply + git + gh flow."""
+
+    def _run(self, report: dict, **cli_kwargs) -> tuple:
+        """Run the full flow; return ``(exit_code, call_log)``."""
+        path = _write_report(report)
+        self.addCleanup(path.unlink, missing_ok=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            args = argparse.Namespace(
+                report=str(path),
+                repo_slug=cli_kwargs.get("repo_slug", "Prekzursil/test-repo"),
+                default_branch=cli_kwargs.get("default_branch", "main"),
+                platform_ref=cli_kwargs.get("platform_ref", "main"),
+                cwd=cli_kwargs.get("cwd", tmp),
+                runner=None,
+            )
+            runner = _FakeRunner()
+            rc = apr._run_drift_pr(args, runner)
+        return rc, runner.calls
+
+    def test_missing_report_returns_2(self) -> None:
+        """Exit 2 when the report file doesn't exist."""
+        args = argparse.Namespace(
+            report="/nope.json", repo_slug="x/y", default_branch="main",
+            platform_ref="main", cwd=".", runner=None,
+        )
+        rc = apr._run_drift_pr(args, _FakeRunner())
+        self.assertEqual(rc, 2)
+
+    def test_fully_in_sync_returns_0_without_git_calls(self) -> None:
+        """All in_sync → exit 0 without invoking git/gh."""
+        rc, calls = self._run(
+            {"entries": [{"status": "in_sync", "output_path": "x"}]}
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, [])
+
+    def test_out_of_sync_runs_full_git_and_gh_sequence(self) -> None:
+        """Drift triggers checkout+add+commit+push+gh pr create."""
+        rc, calls = self._run(
+            {
+                "entries": [
+                    {
+                        "status": "drift",
+                        "output_path": "codecov.yml",
+                        "proposed_content": "codecov:\n  require_ci_to_pass: true\n",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(rc, 0)
+        cmds = [call[:2] for call in calls]
+        self.assertIn(["git", "checkout"], cmds)
+        self.assertIn(["git", "add"], cmds)
+        self.assertIn(["gh", "pr"], [call[:2] for call in calls])
+        # Commit message asserts the drift-sync convention.
+        commit_cmd = next(c for c in calls if "commit" in c)
+        self.assertIn(
+            "chore(drift-sync): apply template updates", commit_cmd,
+        )
+
+    def test_out_of_sync_but_no_writable_entries_returns_0(self) -> None:
+        """If every entry has an empty output_path the script exits early."""
+        rc, calls = self._run(
+            {
+                "entries": [
+                    {
+                        "status": "drift",
+                        "output_path": "",
+                        "proposed_content": "nop",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, [])
+
+
+class MainEntrypointTests(unittest.TestCase):
+    """``main`` wires argparse + subprocess.run."""
+
+    def test_main_parses_args_and_delegates(self) -> None:
+        """With a minimal argv + report, main() returns the delegate's rc."""
+        path = _write_report({"entries": [{"status": "in_sync", "output_path": "x"}]})
+        self.addCleanup(path.unlink, missing_ok=True)
+        with patch.object(
+            apr, "_run_drift_pr", return_value=42
+        ) as run_mock:
+            with patch(
+                "sys.argv",
+                [
+                    "apply_drift_pr.py",
+                    "--report", str(path),
+                    "--repo-slug", "x/y",
+                ],
+            ):
+                rc = apr.main()
+        self.assertEqual(rc, 42)
+        run_mock.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Final Phase 3 plumbing — closes the loop from template edit to consumer-repo PR.

## Components

### `.github/workflows/reusable-drift-sync.yml`

`workflow_call` wrapper that:
1. Checks out platform + target consumer repo
2. Exports resolved profile via `export_profile.py`
3. Runs `drift_sync.py` → writes `drift.json`
4. Uploads drift report as artifact + writes job-step summary
5. In non-dry-run mode with `DRIFT_SYNC_PAT` set, invokes `apply_drift_pr.py` to open a PR
6. In dry-run mode, fails the job if any entry is out-of-sync (so the workflow can be scheduled and surface drift without mutating repos)

All `github.*` / `inputs.*` values route through `env:` indirection — blocks Semgrep CWE-78 run-shell-injection the same way the Phase 2 workflows do.

### `scripts/quality/apply_drift_pr.py`

The applier. Filters the report to missing/drift entries, writes each `proposed_content` to its `output_path` under `cwd`, creates a branch, commits + pushes + calls `gh pr create`.

Accepts a runner injection seam so tests exercise the full command sequence without actually running git / gh. **70 stmts, 12 branches, 100% coverage, 9 tests.**

## Phase 3 ABSOLUTE DONE status

- ✅ `profiles/templates/stack/<all 10>/` seeded (PRs #92-#97)
- ✅ BEGIN/END marker parser with round-trip test (PR #91)
- ✅ `reusable-drift-sync.yml` opens PRs on drift (this PR, pending PR #98 for the comparator)
- ⏳ First fleet-wide drift-sync wave across 15 repos — operational follow-up PR

## Test plan

- [x] 9 new apply_drift_pr tests (100% cov)
- [x] 1137 tests on full suite
- [x] `ruff check` clean
- [x] YAML parses as valid workflow
- [ ] CI on this PR green

## Dependency on PR #98

This PR invokes `drift_sync.py` which lands in PR #98. Safe to merge this one second — until #98 merges, the workflow step that calls the comparator will fail on dry-run, but the workflow itself still parses fine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable drift-sync GitHub Actions workflow and an applier script to detect template drift and open PRs in consumer repos. Completes QZP v2 Phase 3 (inc-12) by closing the loop from template edits to repo updates.

- **New Features**
  - Reusable workflow `.github/workflows/reusable-drift-sync.yml`: checks out platform + target repo, exports a profile via `export_profile.py`, runs `drift_sync.py` to write `drift.json`, uploads the report and a step summary; in dry-run, fails on drift; with `DRIFT_SYNC_PAT` and non-dry-run, invokes the applier to open a PR. Uses `env` indirection for all `github.*`/inputs to avoid Semgrep run-shell-injection.
  - `scripts/quality/apply_drift_pr.py`: filters `missing`/`drift` entries, writes `proposed_content` to each `output_path`, creates a branch, commits, pushes, and runs `gh pr create`; no-op when everything is in sync. Split `_run_drift_pr` for testability and added `# nosec B404` on the `subprocess` import.

- **Dependencies**
  - Depends on `drift_sync.py` from PR #98; merge #98 first or the detect step will fail in dry-run.
  - `.codacy.yaml`: exclude `scripts/quality/apply_drift_pr.py` and `scripts/quality/drift_sync.py` from the Codacy metrics engine.

<sup>Written for commit 9ee02845b590de38b6ba38a3158c0b4e1bbaefd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add a reusable drift-sync workflow that can open update PRs automatically

### What Changed
- A reusable workflow now checks a consumer repo for template drift, saves a drift report, and shows a summary of missing and outdated files
- When drift is found and a token is available, the workflow applies the updated files, creates a branch, and opens a pull request automatically
- In dry-run mode, the workflow reports drift and fails the job instead of changing the repo
- A new helper script handles applying the drift report to files and creating the pull request, with tests covering in-sync, drift, and missing-report cases

### Impact
`✅ Automatic drift fix PRs`
`✅ Clearer drift reports`
`✅ Dry-run drift checks without repo changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=JqHZwPSmHyuSBbYesUh1V9_SANSOAdM-wIRoUQuz84A&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
