### PR TITLE
feat(qzp-v2 phase 4 inc-2): severity-aware rollup helper

### DIFF
--- a/scripts/quality/severity_rollup.py
+++ b/scripts/quality/severity_rollup.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Severity-aware rollup helper for the v2 profile's ``scanners.*.severity``.
+
+Phase 4 of ``docs/QZP-V2-DESIGN.md`` §5.2. The existing
+``build_quality_rollup.py`` aggregates per-lane gate statuses into a
+single overall verdict without looking at severity — every failing
+lane is treated as blocking. With v2 profiles, each scanner declares
+its severity (``block`` | ``warn`` | ``info``), and the rollup must
+respect it:
+
+* ``block`` — failing lane fails the aggregate gate.
+* ``warn``  — failing lane surfaces as a warning annotation but does
+              not fail the gate.
+* ``info``  — failing lane is recorded in the rollup output but never
+              affects the gate verdict.
+
+This module is the severity mapper the rollup calls. It takes the
+resolved profile + a ``{lane: status}`` map and returns a structured
+verdict listing the blocker set, the warning set, and the info set.
+
+Kept as a standalone module so the existing rollup can adopt it
+incrementally — start by wrapping ``classify_lanes`` around its
+existing per-lane loop, then migrate more logic over in follow-up
+increments.
+"""
+
+from __future__ import absolute_import
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+VALID_SEVERITIES: Tuple[str, ...] = ("block", "warn", "info")
+DEFAULT_SEVERITY = "block"
+
+
+@dataclass(frozen=True)
+class RollupVerdict:
+    """Outcome of rolling up a lane-status map through profile severities.
+
+    ``verdict`` is one of ``pass`` | ``warn`` | ``fail``:
+
+    * ``pass`` — no failures, or every failure is ``info``-severity.
+    * ``warn`` — failures exist but every one is ``warn``- or ``info``-severity.
+    * ``fail`` — at least one ``block``-severity lane failed.
+    """
+
+    verdict: str
+    blockers: List[str]
+    warnings: List[str]
+    infos: List[str]
+
+
+def _normalise_severity(raw: Any) -> str:
+    """Map ``raw`` onto one of ``block``/``warn``/``info`` (default ``block``)."""
+    if isinstance(raw, str):
+        cleaned = raw.strip().lower()
+        if cleaned in VALID_SEVERITIES:
+            return cleaned
+    return DEFAULT_SEVERITY
+
+
+def severity_map(profile: Mapping[str, Any]) -> Dict[str, str]:
+    """Return ``{scanner_id: severity}`` flattened from ``profile['scanners']``.
+
+    v2 profiles declare:
+
+    .. code-block:: yaml
+
+        scanners:
+          codecov:
+            severity: block
+          socket_project_report:
+            severity: info
+
+    Entries where ``severity`` is missing or unparseable default to
+    ``block`` — matching the platform's zero-tolerance ethos: unknown
+    means strict.
+    """
+    raw = profile.get("scanners") if isinstance(profile, Mapping) else None
+    if not isinstance(raw, Mapping):
+        return {}
+    flat: Dict[str, str] = {}
+    for name, entry in raw.items():
+        if not isinstance(name, str):
+            continue
+        severity = None
+        if isinstance(entry, Mapping):
+            severity = entry.get("severity")
+        flat[name] = _normalise_severity(severity)
+    return flat
+
+
+def _status_is_failure(status: str) -> bool:
+    """Return whether ``status`` counts as a failure for the rollup."""
+    return str(status).strip().lower() in {"fail", "failure", "error", "red"}
+
+
+def classify_lanes(
+    profile: Mapping[str, Any],
+    lane_statuses: Mapping[str, str],
+) -> RollupVerdict:
+    """Bucket each failing lane into blockers / warnings / infos.
+
+    ``lane_statuses`` is ``{lane_id: status_string}`` — typically the
+    output of a reusable-scanner-matrix run where each lane writes
+    ``pass`` / ``fail``. Lanes not declared in the profile default to
+    ``block`` severity (same as :func:`severity_map`).
+    """
+    sev = severity_map(profile)
+    blockers: List[str] = []
+    warnings: List[str] = []
+    infos: List[str] = []
+    for lane, status in lane_statuses.items():
+        if not _status_is_failure(status):
+            continue
+        bucket = sev.get(lane, DEFAULT_SEVERITY)
+        if bucket == "block":
+            blockers.append(lane)
+        elif bucket == "warn":
+            warnings.append(lane)
+        else:
+            infos.append(lane)
+    verdict = "pass"
+    if blockers:
+        verdict = "fail"
+    elif warnings:
+        verdict = "warn"
+    return RollupVerdict(
+        verdict=verdict,
+        blockers=sorted(blockers),
+        warnings=sorted(warnings),
+        infos=sorted(infos),
+    )
+
+
+def failing_lanes_to_gate_output(verdict: RollupVerdict) -> Dict[str, Any]:
+    """Serialise a ``RollupVerdict`` for CI step-summary consumption."""
+    return {
+        "verdict": verdict.verdict,
+        "blockers": list(verdict.blockers),
+        "warnings": list(verdict.warnings),
+        "infos": list(verdict.infos),
+    }
+
+
+def iter_severity_entries(
+    profile: Mapping[str, Any],
+) -> Iterable[Tuple[str, str]]:
+    """Yield ``(scanner_id, severity)`` in stable sorted order.
+
+    Used by the docs generator + dashboard so the public severity map
+    is deterministic.
+    """
+    sev = severity_map(profile)
+    for name in sorted(sev):
+        yield name, sev[name]
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import json
+
+    _payload = json.loads(sys.stdin.read())
+    _verdict = classify_lanes(
+        _payload.get("profile") or {},
+        _payload.get("lane_statuses") or {},
+    )
+    print(json.dumps(failing_lanes_to_gate_output(_verdict), indent=2))

--- a/tests/test_severity_rollup.py
+++ b/tests/test_severity_rollup.py
@@ -1,0 +1,188 @@
+"""Coverage for the Phase 4 severity-aware rollup helper."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from scripts.quality import severity_rollup as sr
+
+
+class SeverityMapTests(unittest.TestCase):
+    """``severity_map`` flattens ``profile['scanners']`` to ``{id: severity}``."""
+
+    def test_empty_profile_yields_empty_map(self) -> None:
+        """No ``scanners`` key → empty mapping."""
+        self.assertEqual(sr.severity_map({}), {})
+
+    def test_profile_scanners_extracted_with_severity(self) -> None:
+        """Each declared scanner's severity surfaces in the map."""
+        profile = {
+            "scanners": {
+                "codecov": {"severity": "block"},
+                "socket_project_report": {"severity": "info"},
+                "sentry_zero": {"severity": "warn"},
+            },
+        }
+        self.assertEqual(
+            sr.severity_map(profile),
+            {
+                "codecov": "block",
+                "socket_project_report": "info",
+                "sentry_zero": "warn",
+            },
+        )
+
+    def test_missing_severity_defaults_to_block(self) -> None:
+        """Per platform zero-tolerance: unknown = strict."""
+        profile = {
+            "scanners": {
+                "codecov": {},  # no severity
+                "sonar_zero": {"severity": "unknown-value"},
+            },
+        }
+        result = sr.severity_map(profile)
+        self.assertEqual(result["codecov"], "block")
+        self.assertEqual(result["sonar_zero"], "block")
+
+    def test_non_string_scanner_names_skipped(self) -> None:
+        """Keys that aren't strings don't crash the loader."""
+        profile = {"scanners": {123: {"severity": "block"}, "ok": {"severity": "info"}}}
+        self.assertEqual(sr.severity_map(profile), {"ok": "info"})
+
+    def test_non_mapping_scanners_yields_empty(self) -> None:
+        """Lists/strings under ``scanners`` return empty map."""
+        self.assertEqual(sr.severity_map({"scanners": []}), {})
+        self.assertEqual(sr.severity_map({"scanners": "nope"}), {})
+
+    def test_non_mapping_entry_defaults_to_block(self) -> None:
+        """Scanner entries that aren't mappings still map to ``block`` default."""
+        profile = {"scanners": {"legacy": "legacy-string", "ok": None}}
+        result = sr.severity_map(profile)
+        self.assertEqual(result["legacy"], "block")
+        self.assertEqual(result["ok"], "block")
+
+
+class ClassifyLanesTests(unittest.TestCase):
+    """``classify_lanes`` buckets failing lanes by profile-declared severity."""
+
+    def _profile(self) -> dict:
+        """A sample profile with one scanner of each severity."""
+        return {
+            "scanners": {
+                "codecov": {"severity": "block"},
+                "sentry_zero": {"severity": "warn"},
+                "socket_project_report": {"severity": "info"},
+            },
+        }
+
+    def test_all_pass_yields_pass_verdict(self) -> None:
+        """Pass-only statuses produce verdict=pass with empty buckets."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {"codecov": "pass", "sentry_zero": "pass"},
+        )
+        self.assertEqual(verdict.verdict, "pass")
+        self.assertEqual(verdict.blockers, [])
+        self.assertEqual(verdict.warnings, [])
+        self.assertEqual(verdict.infos, [])
+
+    def test_block_severity_failure_yields_fail(self) -> None:
+        """One block-severity failure → verdict=fail."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {"codecov": "fail", "sentry_zero": "pass"},
+        )
+        self.assertEqual(verdict.verdict, "fail")
+        self.assertEqual(verdict.blockers, ["codecov"])
+
+    def test_warn_severity_failure_yields_warn(self) -> None:
+        """Only warn-severity failures → verdict=warn."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {"codecov": "pass", "sentry_zero": "fail"},
+        )
+        self.assertEqual(verdict.verdict, "warn")
+        self.assertEqual(verdict.warnings, ["sentry_zero"])
+
+    def test_info_severity_failure_does_not_escalate(self) -> None:
+        """Info-only failures stay info, verdict remains pass."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {"socket_project_report": "fail"},
+        )
+        self.assertEqual(verdict.verdict, "pass")
+        self.assertEqual(verdict.infos, ["socket_project_report"])
+
+    def test_mixed_severity_failures_use_highest(self) -> None:
+        """Block trumps warn trumps info in the aggregate verdict."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {
+                "codecov": "fail",
+                "sentry_zero": "fail",
+                "socket_project_report": "fail",
+            },
+        )
+        self.assertEqual(verdict.verdict, "fail")
+        self.assertEqual(verdict.blockers, ["codecov"])
+        self.assertEqual(verdict.warnings, ["sentry_zero"])
+        self.assertEqual(verdict.infos, ["socket_project_report"])
+
+    def test_unknown_lane_defaults_to_block(self) -> None:
+        """Lanes not in the profile's severity map default to block."""
+        verdict = sr.classify_lanes(
+            self._profile(),
+            {"brand_new_scanner": "fail"},
+        )
+        self.assertEqual(verdict.verdict, "fail")
+        self.assertEqual(verdict.blockers, ["brand_new_scanner"])
+
+    def test_various_failure_strings_recognised(self) -> None:
+        """``fail`` / ``failure`` / ``error`` / ``red`` are all failures."""
+        for status in ("fail", "failure", "error", "red", "FAIL", " Failure "):
+            with self.subTest(status=status):
+                verdict = sr.classify_lanes(
+                    self._profile(), {"codecov": status}
+                )
+                self.assertEqual(verdict.verdict, "fail")
+
+
+class SerialisationTests(unittest.TestCase):
+    """``failing_lanes_to_gate_output`` produces JSON-safe dicts."""
+
+    def test_serialises_verdict_and_buckets(self) -> None:
+        """The dict has verdict + blockers + warnings + infos keys."""
+        verdict = sr.RollupVerdict(
+            verdict="fail",
+            blockers=["a"],
+            warnings=["b"],
+            infos=["c"],
+        )
+        out = sr.failing_lanes_to_gate_output(verdict)
+        self.assertEqual(out["verdict"], "fail")
+        self.assertEqual(out["blockers"], ["a"])
+        self.assertEqual(out["warnings"], ["b"])
+        self.assertEqual(out["infos"], ["c"])
+
+
+class IterSeverityEntriesTests(unittest.TestCase):
+    """``iter_severity_entries`` yields deterministic (id, severity) pairs."""
+
+    def test_yields_sorted_by_id(self) -> None:
+        """Alphabetical id order so downstream docs/dashboards are stable."""
+        profile = {
+            "scanners": {
+                "zebra": {"severity": "info"},
+                "apple": {"severity": "block"},
+                "mango": {"severity": "warn"},
+            },
+        }
+        pairs = list(sr.iter_severity_entries(profile))
+        self.assertEqual(
+            pairs,
+            [("apple", "block"), ("mango", "warn"), ("zebra", "info")],
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Second Phase 4 deliverable per `docs/QZP-V2-DESIGN.md` §5.2. New `scripts/quality/severity_rollup.py` module consumes the v2 profile's `scanners.*.severity` field and maps a per-lane status dict onto an aggregate verdict.

## Verdict rules

- **`pass`** — no failures, or all failures are `info` severity
- **`warn`** — failures exist but all are `warn` or `info` severity
- **`fail`** — at least one `block` severity lane failed

## Public surface

- `severity_map(profile)` — flatten `scanners.*.severity` to `{id: severity}`; defaults to `block` for malformed entries (zero-tolerance ethos)
- `classify_lanes(profile, lane_statuses)` → `RollupVerdict`
- `failing_lanes_to_gate_output(verdict)` — JSON-safe dict for CI step-summary
- `iter_severity_entries(profile)` — `(id, severity)` pairs in sorted order for dashboard / docs generators

## Scope

Kept standalone rather than baked into `build_quality_rollup.py` so the existing rollup can adopt it incrementally — wrap `classify_lanes` around the per-lane loop first, migrate deeper in follow-ups.

## Test plan

- [x] 15 tests + 6 subtests covering all severity combinations, malformed inputs (non-mapping scanners, non-mapping entries, non-string names), various failure-status aliases (`fail`/`failure`/`error`/`red` + case/whitespace)
- [x] 100% branch+line coverage (61 stmts / 26 branches)
- [x] 1170 tests pass on full suite
- [ ] CI on this PR green

## Next Phase 4 increments

- Wire `classify_lanes` into existing `build_quality_rollup.py`
- `quality-zero:break-glass` label handler (audit jsonl + post-merge tracking issue)
- `quality-zero:skip` label handler (audit jsonl)
- QRv2 Codex-prompt integration
- Security-class always-PR verification

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a severity-aware rollup helper for the v2 quality profile. It classifies failing lanes by `block|warn|info` and returns a `pass|warn|fail` verdict for gates.

- **New Features**
  - Added `scripts/quality/severity_rollup.py` to roll up lane statuses using `scanners.*.severity` and bucket failures into `blockers`, `warnings`, and `infos`.
  - Exposes `severity_map(profile)`, `classify_lanes(profile, lane_statuses)` → `RollupVerdict`, `failing_lanes_to_gate_output(verdict)`, and `iter_severity_entries(profile)`.
  - Defaults to `block` for missing/unknown severities and for lanes not in the profile; failure aliases recognized: `fail|failure|error|red`.

<sup>Written for commit 88bfb2290242438bbbfd1c316135115f0b26b01a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add severity-aware rollup for scanner failures**

### What Changed
- Scanner failures are now grouped by severity, so only `block` failures fail the overall result.
- `warn` failures now surface as warnings without failing the gate, and `info` failures are recorded without affecting the verdict.
- Unknown or malformed scanner severity values default to `block`, keeping new or broken entries strict by default.
- The rollup output now includes the final verdict plus separate blocker, warning, and info lists for CI output and reporting.
- Coverage was added for severity mapping, verdict rules, malformed inputs, and stable output ordering.

### Impact
`✅ Fewer non-blocking scanner failures stop the gate`
`✅ Clearer CI summaries for warnings and informational issues`
`✅ Safer handling of missing or invalid scanner severity`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=DlAbVuSTazqBcic6Avu8YRiE0CrWL0-tzwjFbWD5ypM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
