### PR TITLE
feat(qzp-v2 phase 4 inc-3): break-glass + skip label handlers

### DIFF
--- a/scripts/quality/bypass_labels.py
+++ b/scripts/quality/bypass_labels.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Handle ``quality-zero:break-glass`` + ``quality-zero:skip`` label events.
+
+Phase 4 of ``docs/QZP-V2-DESIGN.md`` §5.2. Both labels let a PR
+merge past a red quality-zero gate, but with different audit trails:
+
+* ``quality-zero:break-glass`` — requires an ``Incident: <id>`` line in
+  the PR body. The incident id (plus the PR slug and actor) are
+  appended to ``audit/break-glass.jsonl`` AND a post-merge tracking
+  issue is opened in the platform repo so the incident gets debriefed.
+* ``quality-zero:skip`` — discretionary bypass, no incident required.
+  Appended to ``audit/skip.jsonl`` only; the weekly digest flags
+  frequent users so we don't normalise skipping the gates.
+
+The handler NEVER logs secret values; only PR metadata (number, head
+SHA, actor, body-excerpt) lands in the audit log. Each jsonl record
+is one compact line so ``jq`` can stream it.
+"""
+
+from __future__ import absolute_import
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+BREAK_GLASS_LABEL = "quality-zero:break-glass"
+SKIP_LABEL = "quality-zero:skip"
+
+# Match ``Incident: <id>`` on its own line, case-insensitive.
+# The id grammar is intentionally permissive (letters/digits/dashes/
+# dots/underscores/slashes) so both ``INC-1234`` and
+# ``pagerduty/INC-1234`` are accepted. Whitespace either side of the
+# colon is tolerated.
+_INCIDENT_RE = re.compile(
+    r"^\s*Incident\s*:\s*([A-Za-z0-9_./-]+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class BypassError(ValueError):
+    """Raised when a break-glass label is applied without a valid Incident id."""
+
+
+@dataclass(frozen=True)
+class BypassDecision:
+    """The verdict the handler returns for a label event.
+
+    ``audit_record`` is the structured dict that should be appended to
+    the jsonl audit log (empty for ``allowed=False`` — when the bypass
+    is rejected nothing is logged because the merge didn't happen).
+    """
+
+    label: str
+    allowed: bool
+    incident: Optional[str]
+    audit_record: Optional[Mapping[str, Any]]
+    tracking_issue_title: Optional[str]
+    tracking_issue_body: Optional[str]
+
+
+def extract_incident_id(pr_body: str) -> Optional[str]:
+    """Return the first ``Incident: <id>`` occurrence in ``pr_body``, or ``None``."""
+    if not isinstance(pr_body, str):
+        return None
+    match = _INCIDENT_RE.search(pr_body)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _utc_iso_now() -> str:
+    """Current UTC timestamp in ISO-8601 with ``Z`` suffix."""
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _build_audit_record(
+    label: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+    incident: Optional[str],
+) -> Mapping[str, Any]:
+    """Build the jsonl-safe audit record. No secret values leak here."""
+    record: dict = {
+        "timestamp_utc": _utc_iso_now(),
+        "label": label,
+        "pr": {
+            "slug": pr_slug,
+            "number": pr_number,
+            "head_sha": head_sha,
+        },
+        "actor": actor,
+    }
+    if incident:
+        record["incident"] = incident
+    return record
+
+
+def _build_tracking_issue(
+    pr_slug: str, pr_number: int, actor: str, incident: str,
+) -> tuple:
+    """Return ``(title, body)`` for the post-merge tracking issue."""
+    title = f"break-glass follow-up: {pr_slug}#{pr_number} (Incident: {incident})"
+    body = (
+        f"Automated tracking issue from the `{BREAK_GLASS_LABEL}` handler.\n\n"
+        f"- PR: {pr_slug}#{pr_number}\n"
+        f"- Actor: @{actor}\n"
+        f"- Incident: {incident}\n\n"
+        "Post-merge remediation required: the PR merged past a red\n"
+        "quality-zero gate using break-glass. Debrief the incident,\n"
+        "resolve the underlying failure, and close this issue when the\n"
+        "gate is green again on main.\n"
+    )
+    return title, body
+
+
+def evaluate_break_glass(
+    pr_body: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+) -> BypassDecision:
+    """Decide whether a ``quality-zero:break-glass`` label can proceed."""
+    incident = extract_incident_id(pr_body)
+    if not incident:
+        raise BypassError(
+            "``quality-zero:break-glass`` requires an ``Incident: <id>`` "
+            "line in the PR body (e.g. ``Incident: INC-1234``)."
+        )
+    record = _build_audit_record(
+        BREAK_GLASS_LABEL, pr_slug, pr_number, head_sha, actor, incident,
+    )
+    title, body = _build_tracking_issue(pr_slug, pr_number, actor, incident)
+    return BypassDecision(
+        label=BREAK_GLASS_LABEL,
+        allowed=True,
+        incident=incident,
+        audit_record=record,
+        tracking_issue_title=title,
+        tracking_issue_body=body,
+    )
+
+
+def evaluate_skip(
+    pr_body: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+) -> BypassDecision:
+    """Decide whether a ``quality-zero:skip`` label can proceed.
+
+    Always allows (the label itself is the authorisation); the caller
+    is expected to restrict WHO can add the label via repo settings.
+    ``pr_body`` is accepted for signature symmetry with
+    :func:`evaluate_break_glass` but isn't inspected — skip has no
+    incident requirement.
+    """
+    _ = pr_body  # unused; see docstring
+    record = _build_audit_record(
+        SKIP_LABEL, pr_slug, pr_number, head_sha, actor, incident=None,
+    )
+    return BypassDecision(
+        label=SKIP_LABEL,
+        allowed=True,
+        incident=None,
+        audit_record=record,
+        tracking_issue_title=None,
+        tracking_issue_body=None,
+    )
+
+
+def append_jsonl(audit_path: Path, record: Mapping[str, Any]) -> None:
+    """Append ``record`` to ``audit_path`` as a single compact JSON line.
+
+    Creates the parent directory if necessary. Uses ``sort_keys=True``
+    so the stored records are deterministic — important for diffable
+    audit logs.
+    """
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    if len(sys.argv) < 6:
+        print(
+            "usage: bypass_labels.py <label> <pr_slug> <pr_number> "
+            "<head_sha> <actor> <audit_dir>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    _label, _slug, _pr_num, _sha, _actor, _audit_dir = sys.argv[1:7]
+    _body = sys.stdin.read()
+    if _label == BREAK_GLASS_LABEL:
+        _decision = evaluate_break_glass(_body, _slug, int(_pr_num), _sha, _actor)
+        _filename = "break-glass.jsonl"
+    elif _label == SKIP_LABEL:
+        _decision = evaluate_skip(_body, _slug, int(_pr_num), _sha, _actor)
+        _filename = "skip.jsonl"
+    else:
+        print(f"unknown label: {_label}", file=sys.stderr)
+        raise SystemExit(2)
+    if _decision.audit_record is not None:
+        append_jsonl(Path(_audit_dir) / _filename, _decision.audit_record)
+    print(json.dumps({
+        "label": _decision.label,
+        "allowed": _decision.allowed,
+        "incident": _decision.incident,
+        "tracking_issue_title": _decision.tracking_issue_title,
+    }))

--- a/tests/test_bypass_labels.py
+++ b/tests/test_bypass_labels.py
@@ -1,0 +1,216 @@
+"""Tests for ``scripts.quality.bypass_labels`` — Phase 4 §5.2 handlers."""
+
+from __future__ import absolute_import
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.quality import bypass_labels as bl
+
+
+class ExtractIncidentTests(unittest.TestCase):
+    """``extract_incident_id`` parses the ``Incident: <id>`` line."""
+
+    def test_typical_incident_line_is_matched(self) -> None:
+        """Standard INC-1234 format is recognised."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident: INC-1234"),
+            "INC-1234",
+        )
+
+    def test_match_is_case_insensitive(self) -> None:
+        """``incident:`` and ``INCIDENT:`` are both accepted."""
+        self.assertEqual(
+            bl.extract_incident_id("incident: pd-42"),
+            "pd-42",
+        )
+
+    def test_whitespace_tolerated(self) -> None:
+        """Extra spaces before/after the colon don't break the match."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident :  INC-9"),
+            "INC-9",
+        )
+
+    def test_namespaced_incident_id_allowed(self) -> None:
+        """Slash-delimited providers like ``pagerduty/INC-1234`` work."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident: pagerduty/INC-1234"),
+            "pagerduty/INC-1234",
+        )
+
+    def test_multi_line_body_picks_first(self) -> None:
+        """Two incident lines → the first one wins."""
+        body = "Context line\nIncident: INC-1\nOther: junk\nIncident: INC-2\n"
+        self.assertEqual(bl.extract_incident_id(body), "INC-1")
+
+    def test_no_incident_line_returns_none(self) -> None:
+        """Body without an incident line returns ``None``."""
+        self.assertIsNone(bl.extract_incident_id("No incident here."))
+
+    def test_non_string_body_returns_none(self) -> None:
+        """Defensive: non-string input still returns ``None``."""
+        self.assertIsNone(bl.extract_incident_id(None))  # type: ignore[arg-type]
+        self.assertIsNone(bl.extract_incident_id(42))  # type: ignore[arg-type]
+
+
+class EvaluateBreakGlassTests(unittest.TestCase):
+    """``evaluate_break_glass`` enforces the Incident-id requirement."""
+
+    def test_missing_incident_raises(self) -> None:
+        """Break-glass without Incident: raises BypassError."""
+        with self.assertRaises(bl.BypassError):
+            bl.evaluate_break_glass(
+                pr_body="forgot the incident id",
+                pr_slug="owner/repo",
+                pr_number=42,
+                head_sha="abc123",
+                actor="alice",
+            )
+
+    def test_valid_incident_returns_decision(self) -> None:
+        """With an Incident line the handler returns an allowed decision."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Reason: urgent fix\nIncident: INC-1234",
+            pr_slug="owner/repo",
+            pr_number=42,
+            head_sha="a" * 40,
+            actor="alice",
+        )
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.incident, "INC-1234")
+        self.assertIsNotNone(decision.audit_record)
+        self.assertEqual(
+            decision.audit_record["pr"]["slug"], "owner/repo"
+        )
+        self.assertEqual(decision.audit_record["actor"], "alice")
+        self.assertEqual(decision.label, bl.BREAK_GLASS_LABEL)
+
+    def test_audit_record_contains_timestamp(self) -> None:
+        """Each audit record is timestamped in ISO UTC."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Incident: INC-1",
+            pr_slug="x/y",
+            pr_number=1,
+            head_sha="s",
+            actor="a",
+        )
+        ts = decision.audit_record["timestamp_utc"]
+        self.assertTrue(ts.endswith("Z"))
+        # Parseable back into a datetime.
+        from datetime import datetime
+
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    def test_tracking_issue_body_references_pr_and_actor(self) -> None:
+        """Tracking issue body names the PR, the actor, and the incident."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Incident: INC-99",
+            pr_slug="Prekzursil/event-link",
+            pr_number=77,
+            head_sha="s",
+            actor="bob",
+        )
+        title = decision.tracking_issue_title
+        body = decision.tracking_issue_body
+        self.assertIn("Prekzursil/event-link", title)
+        self.assertIn("#77", title)
+        self.assertIn("INC-99", title)
+        self.assertIn("@bob", body)
+        self.assertIn("Post-merge remediation", body)
+
+
+class EvaluateSkipTests(unittest.TestCase):
+    """``evaluate_skip`` always allows but still audits."""
+
+    def test_skip_always_allowed_without_incident(self) -> None:
+        """No Incident line is needed for the skip label."""
+        decision = bl.evaluate_skip(
+            pr_body="",  # no incident
+            pr_slug="x/y",
+            pr_number=5,
+            head_sha="s",
+            actor="alice",
+        )
+        self.assertTrue(decision.allowed)
+        self.assertIsNone(decision.incident)
+        self.assertIsNotNone(decision.audit_record)
+        self.assertEqual(decision.label, bl.SKIP_LABEL)
+
+    def test_skip_has_no_tracking_issue(self) -> None:
+        """Skip label doesn't require the post-merge follow-up issue."""
+        decision = bl.evaluate_skip(
+            pr_body="", pr_slug="x/y", pr_number=5, head_sha="s", actor="a",
+        )
+        self.assertIsNone(decision.tracking_issue_title)
+        self.assertIsNone(decision.tracking_issue_body)
+
+    def test_skip_audit_record_excludes_incident_key(self) -> None:
+        """Skip records don't include an incident field at all."""
+        decision = bl.evaluate_skip(
+            pr_body="Incident: INC-x",  # ignored
+            pr_slug="x/y", pr_number=5, head_sha="s", actor="a",
+        )
+        self.assertNotIn("incident", decision.audit_record)
+
+
+class AppendJsonlTests(unittest.TestCase):
+    """``append_jsonl`` writes one compact line per record."""
+
+    def test_creates_parent_dir_and_appends_line(self) -> None:
+        """First call creates the directory + file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "nested" / "audit.jsonl"
+            bl.append_jsonl(target, {"a": 1})
+            bl.append_jsonl(target, {"b": 2})
+            lines = target.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[0]), {"a": 1})
+        self.assertEqual(json.loads(lines[1]), {"b": 2})
+
+    def test_records_are_sorted_keys(self) -> None:
+        """``sort_keys=True`` makes the jsonl diff-friendly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "audit.jsonl"
+            bl.append_jsonl(target, {"z": 1, "a": 2})
+            line = target.read_text(encoding="utf-8").strip()
+        self.assertEqual(line, '{"a":2,"z":1}')
+
+
+class IntegrationFlowTests(unittest.TestCase):
+    """End-to-end: evaluate + append → file on disk has the expected line."""
+
+    def test_break_glass_flow_writes_audit_line(self) -> None:
+        """Break-glass happy path ends in one audit line on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            audit = Path(tmp) / "audit" / "break-glass.jsonl"
+            decision = bl.evaluate_break_glass(
+                pr_body="Incident: INC-42",
+                pr_slug="x/y", pr_number=1, head_sha="s", actor="a",
+            )
+            bl.append_jsonl(audit, decision.audit_record)
+            line = audit.read_text(encoding="utf-8").strip()
+        parsed = json.loads(line)
+        self.assertEqual(parsed["incident"], "INC-42")
+        self.assertEqual(parsed["label"], bl.BREAK_GLASS_LABEL)
+        self.assertEqual(parsed["pr"]["number"], 1)
+
+    def test_skip_flow_writes_audit_line(self) -> None:
+        """Skip happy path ends in one audit line on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            audit = Path(tmp) / "audit" / "skip.jsonl"
+            decision = bl.evaluate_skip(
+                pr_body="", pr_slug="x/y",
+                pr_number=2, head_sha="s", actor="a",
+            )
+            bl.append_jsonl(audit, decision.audit_record)
+            line = audit.read_text(encoding="utf-8").strip()
+        parsed = json.loads(line)
+        self.assertEqual(parsed["label"], bl.SKIP_LABEL)
+        self.assertNotIn("incident", parsed)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Third Phase 4 deliverable per `docs/QZP-V2-DESIGN.md` §5.2. New `scripts/quality/bypass_labels.py` handles both bypass labels.

## Contracts

- **`quality-zero:break-glass`** — requires `Incident: <id>` in PR body (case-insensitive; accepts namespaced ids like `pagerduty/INC-1234`). Records to `audit/break-glass.jsonl` + builds a post-merge tracking issue so the incident gets debriefed.
- **`quality-zero:skip`** — discretionary bypass, no incident required. Records to `audit/skip.jsonl` only; downstream weekly digest flags frequent users.

Audit records are one compact JSON line per event, `sort_keys=True` for diff-friendly logs. Only PR metadata (slug, number, head SHA, actor, timestamp, optional incident) is recorded — **never secret values** or the full PR body.

## Public surface

- `extract_incident_id(pr_body)` — regex-parses the `Incident:` marker
- `evaluate_break_glass(...)` → `BypassDecision` or raises `BypassError` when Incident line is missing
- `evaluate_skip(...)` → always-allowed `BypassDecision`
- `append_jsonl(path, record)` — writes compact one-line records

## Test plan

- [x] 18 tests across 5 classes covering incident parsing (case insensitive, whitespace, namespaced, multi-line, missing, non-string input); break-glass happy path + BypassError; skip without incident; tracking-issue body shape; timestamp format; jsonl append
- [x] 100% branch+line coverage (53 stmts / 8 branches)
- [x] Full suite: 1188 tests pass
- [ ] CI on this PR green

## Next Phase 4 increments

- Wire these handlers into a `quality-zero-bypass` GitHub Action workflow
- Extend QRv2 to read `known-issues/` into its Codex prompt
- Security-class QRv2 fixes always-PR verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/quality/bypass_labels.py` to handle `quality-zero:break-glass` and `quality-zero:skip` with strict auditing and optional follow-up tracking. Lets urgent PRs bypass a red quality-zero gate in a safe, documented way.

- **New Features**
  - `quality-zero:break-glass`: requires `Incident: <id>` in the PR body (case-insensitive, supports namespaced IDs); appends to `audit/break-glass.jsonl`; returns a post-merge tracking issue title/body.
  - `quality-zero:skip`: always allowed; appends to `audit/skip.jsonl`; no tracking issue.
  - Audit records: one compact JSON line with sorted keys; include only PR slug, number, head SHA, actor, UTC timestamp, and optional incident.
  - Public API and CLI: `extract_incident_id`, `evaluate_break_glass`, `evaluate_skip`, `append_jsonl`; 18 tests with full coverage.

<sup>Written for commit 6acb8f9ab04039cd5b157dcd2d5e534138fe7f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Handle break-glass and skip bypass labels for quality-zero checks**

### What Changed
- A break-glass label now requires an `Incident: <id>` line in the PR body before the merge can proceed
- Break-glass approvals now write an audit record and create a follow-up tracking issue for incident debriefing
- The skip label now allows the merge without an incident, while still writing an audit record
- Audit entries are written as one compact, stable JSON line and only include PR metadata and the incident id when present
- The command can now be run directly to process a label event and write the matching audit file

### Impact
`✅ Clearer emergency bypass handling`
`✅ Fewer untracked quality gate skips`
`✅ Safer audit logs for merge bypasses`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=pcSTkUpzgDRpkCJIz9WTJnc9tITgI00srBqooGBRGd0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
