### PR TITLE
feat(qzp-v2 phase 4 inc-4): QRv2 Codex prompt includes known-issues registry

### DIFF
--- a/scripts/quality/bypass_labels.py
+++ b/scripts/quality/bypass_labels.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Handle ``quality-zero:break-glass`` + ``quality-zero:skip`` label events.
+
+Phase 4 of ``docs/QZP-V2-DESIGN.md`` §5.2. Both labels let a PR
+merge past a red quality-zero gate, but with different audit trails:
+
+* ``quality-zero:break-glass`` — requires an ``Incident: <id>`` line in
+  the PR body. The incident id (plus the PR slug and actor) are
+  appended to ``audit/break-glass.jsonl`` AND a post-merge tracking
+  issue is opened in the platform repo so the incident gets debriefed.
+* ``quality-zero:skip`` — discretionary bypass, no incident required.
+  Appended to ``audit/skip.jsonl`` only; the weekly digest flags
+  frequent users so we don't normalise skipping the gates.
+
+The handler NEVER logs secret values; only PR metadata (number, head
+SHA, actor, body-excerpt) lands in the audit log. Each jsonl record
+is one compact line so ``jq`` can stream it.
+"""
+
+from __future__ import absolute_import
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+BREAK_GLASS_LABEL = "quality-zero:break-glass"
+SKIP_LABEL = "quality-zero:skip"
+
+# Match ``Incident: <id>`` on its own line, case-insensitive.
+# The id grammar is intentionally permissive (letters/digits/dashes/
+# dots/underscores/slashes) so both ``INC-1234`` and
+# ``pagerduty/INC-1234`` are accepted. Whitespace either side of the
+# colon is tolerated.
+_INCIDENT_RE = re.compile(
+    r"^\s*Incident\s*:\s*([A-Za-z0-9_./-]+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class BypassError(ValueError):
+    """Raised when a break-glass label is applied without a valid Incident id."""
+
+
+@dataclass(frozen=True)
+class BypassDecision:
+    """The verdict the handler returns for a label event.
+
+    ``audit_record`` is the structured dict that should be appended to
+    the jsonl audit log (empty for ``allowed=False`` — when the bypass
+    is rejected nothing is logged because the merge didn't happen).
+    """
+
+    label: str
+    allowed: bool
+    incident: Optional[str]
+    audit_record: Optional[Mapping[str, Any]]
+    tracking_issue_title: Optional[str]
+    tracking_issue_body: Optional[str]
+
+
+def extract_incident_id(pr_body: str) -> Optional[str]:
+    """Return the first ``Incident: <id>`` occurrence in ``pr_body``, or ``None``."""
+    if not isinstance(pr_body, str):
+        return None
+    match = _INCIDENT_RE.search(pr_body)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _utc_iso_now() -> str:
+    """Current UTC timestamp in ISO-8601 with ``Z`` suffix."""
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _build_audit_record(
+    label: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+    incident: Optional[str],
+) -> Mapping[str, Any]:
+    """Build the jsonl-safe audit record. No secret values leak here."""
+    record: dict = {
+        "timestamp_utc": _utc_iso_now(),
+        "label": label,
+        "pr": {
+            "slug": pr_slug,
+            "number": pr_number,
+            "head_sha": head_sha,
+        },
+        "actor": actor,
+    }
+    if incident:
+        record["incident"] = incident
+    return record
+
+
+def _build_tracking_issue(
+    pr_slug: str, pr_number: int, actor: str, incident: str,
+) -> tuple:
+    """Return ``(title, body)`` for the post-merge tracking issue."""
+    title = f"break-glass follow-up: {pr_slug}#{pr_number} (Incident: {incident})"
+    body = (
+        f"Automated tracking issue from the `{BREAK_GLASS_LABEL}` handler.\n\n"
+        f"- PR: {pr_slug}#{pr_number}\n"
+        f"- Actor: @{actor}\n"
+        f"- Incident: {incident}\n\n"
+        "Post-merge remediation required: the PR merged past a red\n"
+        "quality-zero gate using break-glass. Debrief the incident,\n"
+        "resolve the underlying failure, and close this issue when the\n"
+        "gate is green again on main.\n"
+    )
+    return title, body
+
+
+def evaluate_break_glass(
+    pr_body: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+) -> BypassDecision:
+    """Decide whether a ``quality-zero:break-glass`` label can proceed."""
+    incident = extract_incident_id(pr_body)
+    if not incident:
+        raise BypassError(
+            "``quality-zero:break-glass`` requires an ``Incident: <id>`` "
+            "line in the PR body (e.g. ``Incident: INC-1234``)."
+        )
+    record = _build_audit_record(
+        BREAK_GLASS_LABEL, pr_slug, pr_number, head_sha, actor, incident,
+    )
+    title, body = _build_tracking_issue(pr_slug, pr_number, actor, incident)
+    return BypassDecision(
+        label=BREAK_GLASS_LABEL,
+        allowed=True,
+        incident=incident,
+        audit_record=record,
+        tracking_issue_title=title,
+        tracking_issue_body=body,
+    )
+
+
+def evaluate_skip(
+    pr_body: str,
+    pr_slug: str,
+    pr_number: int,
+    head_sha: str,
+    actor: str,
+) -> BypassDecision:
+    """Decide whether a ``quality-zero:skip`` label can proceed.
+
+    Always allows (the label itself is the authorisation); the caller
+    is expected to restrict WHO can add the label via repo settings.
+    ``pr_body`` is accepted for signature symmetry with
+    :func:`evaluate_break_glass` but isn't inspected — skip has no
+    incident requirement.
+    """
+    _ = pr_body  # unused; see docstring
+    record = _build_audit_record(
+        SKIP_LABEL, pr_slug, pr_number, head_sha, actor, incident=None,
+    )
+    return BypassDecision(
+        label=SKIP_LABEL,
+        allowed=True,
+        incident=None,
+        audit_record=record,
+        tracking_issue_title=None,
+        tracking_issue_body=None,
+    )
+
+
+def append_jsonl(audit_path: Path, record: Mapping[str, Any]) -> None:
+    """Append ``record`` to ``audit_path`` as a single compact JSON line.
+
+    Creates the parent directory if necessary. Uses ``sort_keys=True``
+    so the stored records are deterministic — important for diffable
+    audit logs.
+    """
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    if len(sys.argv) < 6:
+        print(
+            "usage: bypass_labels.py <label> <pr_slug> <pr_number> "
+            "<head_sha> <actor> <audit_dir>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    _label, _slug, _pr_num, _sha, _actor, _audit_dir = sys.argv[1:7]
+    _body = sys.stdin.read()
+    if _label == BREAK_GLASS_LABEL:
+        _decision = evaluate_break_glass(_body, _slug, int(_pr_num), _sha, _actor)
+        _filename = "break-glass.jsonl"
+    elif _label == SKIP_LABEL:
+        _decision = evaluate_skip(_body, _slug, int(_pr_num), _sha, _actor)
+        _filename = "skip.jsonl"
+    else:
+        print(f"unknown label: {_label}", file=sys.stderr)
+        raise SystemExit(2)
+    if _decision.audit_record is not None:
+        append_jsonl(Path(_audit_dir) / _filename, _decision.audit_record)
+    print(json.dumps({
+        "label": _decision.label,
+        "allowed": _decision.allowed,
+        "incident": _decision.incident,
+        "tracking_issue_title": _decision.tracking_issue_title,
+    }))

--- a/scripts/quality/render_codex_prompt.py
+++ b/scripts/quality/render_codex_prompt.py
@@ -18,6 +18,10 @@ from scripts.quality.control_plane import (
     load_inventory,
     load_repo_profile,
 )
+from scripts.quality.known_issues import load_known_issues, qrv2_prompt_entries
+
+
+_KNOWN_ISSUES_ROOT = Path(__file__).resolve().parents[2] / "known-issues"
 
 
 def _parse_args() -> argparse.Namespace:
@@ -82,6 +86,57 @@ def _required_contexts_lines(profile: dict, *, event_name: str) -> List[str]:
         "",
         *[f"- `{name}`" for name in contexts],
     ]
+
+
+def _render_known_issues_section(
+    registry_path: Path = _KNOWN_ISSUES_ROOT,
+) -> str:
+    """Render the known-issues registry as a Codex prompt section.
+
+    QRv2 reads this section so the remediation loop applies the
+    canonical fix for every recurring false positive instead of
+    re-deriving it per run. Only entries with ``feeds_qrv2: true`` +
+    a non-empty ``fix_snippet`` appear; the ``qrv2_prompt_entries``
+    filter enforces that.
+
+    Returns an empty string when the registry is empty — the caller
+    simply omits the section in that case so older profiles don't see
+    a dangling heading.
+    """
+    entries = qrv2_prompt_entries(load_known_issues(registry_path))
+    if not entries:
+        return ""
+    lines: List[str] = [
+        "## Known-issues registry",
+        "",
+        (
+            "The entries below are documented false positives / recurring "
+            "patterns with verified canonical fixes. When a CI failure "
+            "matches one of them, apply the fix_snippet verbatim rather "
+            "than inventing a new fix."
+        ),
+        "",
+    ]
+    for entry in entries:
+        lines.append(f"### {entry.get('id', '?')} — {entry.get('title', '')}")
+        lines.append("")
+        description = str(entry.get("description", "")).strip()
+        if description:
+            lines.append(description)
+            lines.append("")
+        affects = entry.get("affects") or []
+        if affects:
+            lines.append(f"Affects: {', '.join(str(a) for a in affects)}")
+            lines.append("")
+        fix_snippet = str(entry.get("fix_snippet", "")).rstrip()
+        if fix_snippet:
+            lines.append("Canonical fix:")
+            lines.append("")
+            lines.append("```")
+            lines.append(fix_snippet)
+            lines.append("```")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def _render_canonical_findings_section(findings: List[Dict[str, Any]]) -> str:
@@ -190,7 +245,11 @@ def _render_prompt(*args: object, **kwargs: object) -> str:
         "",
         _artifact_lines(artifacts),
     ]
-    return "\n".join(sections) + "\n"
+    rendered = "\n".join(sections) + "\n"
+    known_issues_section = _render_known_issues_section()
+    if known_issues_section:
+        rendered = rendered.rstrip("\n") + "\n\n" + known_issues_section
+    return rendered
 
 
 def main() -> int:

--- a/tests/test_bypass_labels.py
+++ b/tests/test_bypass_labels.py
@@ -1,0 +1,216 @@
+"""Tests for ``scripts.quality.bypass_labels`` — Phase 4 §5.2 handlers."""
+
+from __future__ import absolute_import
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.quality import bypass_labels as bl
+
+
+class ExtractIncidentTests(unittest.TestCase):
+    """``extract_incident_id`` parses the ``Incident: <id>`` line."""
+
+    def test_typical_incident_line_is_matched(self) -> None:
+        """Standard INC-1234 format is recognised."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident: INC-1234"),
+            "INC-1234",
+        )
+
+    def test_match_is_case_insensitive(self) -> None:
+        """``incident:`` and ``INCIDENT:`` are both accepted."""
+        self.assertEqual(
+            bl.extract_incident_id("incident: pd-42"),
+            "pd-42",
+        )
+
+    def test_whitespace_tolerated(self) -> None:
+        """Extra spaces before/after the colon don't break the match."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident :  INC-9"),
+            "INC-9",
+        )
+
+    def test_namespaced_incident_id_allowed(self) -> None:
+        """Slash-delimited providers like ``pagerduty/INC-1234`` work."""
+        self.assertEqual(
+            bl.extract_incident_id("Incident: pagerduty/INC-1234"),
+            "pagerduty/INC-1234",
+        )
+
+    def test_multi_line_body_picks_first(self) -> None:
+        """Two incident lines → the first one wins."""
+        body = "Context line\nIncident: INC-1\nOther: junk\nIncident: INC-2\n"
+        self.assertEqual(bl.extract_incident_id(body), "INC-1")
+
+    def test_no_incident_line_returns_none(self) -> None:
+        """Body without an incident line returns ``None``."""
+        self.assertIsNone(bl.extract_incident_id("No incident here."))
+
+    def test_non_string_body_returns_none(self) -> None:
+        """Defensive: non-string input still returns ``None``."""
+        self.assertIsNone(bl.extract_incident_id(None))  # type: ignore[arg-type]
+        self.assertIsNone(bl.extract_incident_id(42))  # type: ignore[arg-type]
+
+
+class EvaluateBreakGlassTests(unittest.TestCase):
+    """``evaluate_break_glass`` enforces the Incident-id requirement."""
+
+    def test_missing_incident_raises(self) -> None:
+        """Break-glass without Incident: raises BypassError."""
+        with self.assertRaises(bl.BypassError):
+            bl.evaluate_break_glass(
+                pr_body="forgot the incident id",
+                pr_slug="owner/repo",
+                pr_number=42,
+                head_sha="abc123",
+                actor="alice",
+            )
+
+    def test_valid_incident_returns_decision(self) -> None:
+        """With an Incident line the handler returns an allowed decision."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Reason: urgent fix\nIncident: INC-1234",
+            pr_slug="owner/repo",
+            pr_number=42,
+            head_sha="a" * 40,
+            actor="alice",
+        )
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.incident, "INC-1234")
+        self.assertIsNotNone(decision.audit_record)
+        self.assertEqual(
+            decision.audit_record["pr"]["slug"], "owner/repo"
+        )
+        self.assertEqual(decision.audit_record["actor"], "alice")
+        self.assertEqual(decision.label, bl.BREAK_GLASS_LABEL)
+
+    def test_audit_record_contains_timestamp(self) -> None:
+        """Each audit record is timestamped in ISO UTC."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Incident: INC-1",
+            pr_slug="x/y",
+            pr_number=1,
+            head_sha="s",
+            actor="a",
+        )
+        ts = decision.audit_record["timestamp_utc"]
+        self.assertTrue(ts.endswith("Z"))
+        # Parseable back into a datetime.
+        from datetime import datetime
+
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    def test_tracking_issue_body_references_pr_and_actor(self) -> None:
+        """Tracking issue body names the PR, the actor, and the incident."""
+        decision = bl.evaluate_break_glass(
+            pr_body="Incident: INC-99",
+            pr_slug="Prekzursil/event-link",
+            pr_number=77,
+            head_sha="s",
+            actor="bob",
+        )
+        title = decision.tracking_issue_title
+        body = decision.tracking_issue_body
+        self.assertIn("Prekzursil/event-link", title)
+        self.assertIn("#77", title)
+        self.assertIn("INC-99", title)
+        self.assertIn("@bob", body)
+        self.assertIn("Post-merge remediation", body)
+
+
+class EvaluateSkipTests(unittest.TestCase):
+    """``evaluate_skip`` always allows but still audits."""
+
+    def test_skip_always_allowed_without_incident(self) -> None:
+        """No Incident line is needed for the skip label."""
+        decision = bl.evaluate_skip(
+            pr_body="",  # no incident
+            pr_slug="x/y",
+            pr_number=5,
+            head_sha="s",
+            actor="alice",
+        )
+        self.assertTrue(decision.allowed)
+        self.assertIsNone(decision.incident)
+        self.assertIsNotNone(decision.audit_record)
+        self.assertEqual(decision.label, bl.SKIP_LABEL)
+
+    def test_skip_has_no_tracking_issue(self) -> None:
+        """Skip label doesn't require the post-merge follow-up issue."""
+        decision = bl.evaluate_skip(
+            pr_body="", pr_slug="x/y", pr_number=5, head_sha="s", actor="a",
+        )
+        self.assertIsNone(decision.tracking_issue_title)
+        self.assertIsNone(decision.tracking_issue_body)
+
+    def test_skip_audit_record_excludes_incident_key(self) -> None:
+        """Skip records don't include an incident field at all."""
+        decision = bl.evaluate_skip(
+            pr_body="Incident: INC-x",  # ignored
+            pr_slug="x/y", pr_number=5, head_sha="s", actor="a",
+        )
+        self.assertNotIn("incident", decision.audit_record)
+
+
+class AppendJsonlTests(unittest.TestCase):
+    """``append_jsonl`` writes one compact line per record."""
+
+    def test_creates_parent_dir_and_appends_line(self) -> None:
+        """First call creates the directory + file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "nested" / "audit.jsonl"
+            bl.append_jsonl(target, {"a": 1})
+            bl.append_jsonl(target, {"b": 2})
+            lines = target.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[0]), {"a": 1})
+        self.assertEqual(json.loads(lines[1]), {"b": 2})
+
+    def test_records_are_sorted_keys(self) -> None:
+        """``sort_keys=True`` makes the jsonl diff-friendly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "audit.jsonl"
+            bl.append_jsonl(target, {"z": 1, "a": 2})
+            line = target.read_text(encoding="utf-8").strip()
+        self.assertEqual(line, '{"a":2,"z":1}')
+
+
+class IntegrationFlowTests(unittest.TestCase):
+    """End-to-end: evaluate + append → file on disk has the expected line."""
+
+    def test_break_glass_flow_writes_audit_line(self) -> None:
+        """Break-glass happy path ends in one audit line on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            audit = Path(tmp) / "audit" / "break-glass.jsonl"
+            decision = bl.evaluate_break_glass(
+                pr_body="Incident: INC-42",
+                pr_slug="x/y", pr_number=1, head_sha="s", actor="a",
+            )
+            bl.append_jsonl(audit, decision.audit_record)
+            line = audit.read_text(encoding="utf-8").strip()
+        parsed = json.loads(line)
+        self.assertEqual(parsed["incident"], "INC-42")
+        self.assertEqual(parsed["label"], bl.BREAK_GLASS_LABEL)
+        self.assertEqual(parsed["pr"]["number"], 1)
+
+    def test_skip_flow_writes_audit_line(self) -> None:
+        """Skip happy path ends in one audit line on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            audit = Path(tmp) / "audit" / "skip.jsonl"
+            decision = bl.evaluate_skip(
+                pr_body="", pr_slug="x/y",
+                pr_number=2, head_sha="s", actor="a",
+            )
+            bl.append_jsonl(audit, decision.audit_record)
+            line = audit.read_text(encoding="utf-8").strip()
+        parsed = json.loads(line)
+        self.assertEqual(parsed["label"], bl.SKIP_LABEL)
+        self.assertNotIn("incident", parsed)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_render_codex_prompt_known_issues.py
+++ b/tests/test_render_codex_prompt_known_issues.py
@@ -1,0 +1,140 @@
+"""Tests for the known-issues section in ``render_codex_prompt``.
+
+Phase 4 of ``docs/QZP-V2-DESIGN.md`` §6 requires QRv2 to read the
+``known-issues/`` registry into its Codex prompt so the remediation
+loop applies the canonical fix for each documented false positive.
+These tests pin that contract.
+"""
+
+from __future__ import absolute_import
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.quality import render_codex_prompt as rcp
+
+
+class KnownIssuesSectionTests(unittest.TestCase):
+    """``_render_known_issues_section`` emits a prompt block from the registry."""
+
+    def _write_registry(self, files: dict) -> Path:
+        """Create a temp registry dir seeded with ``files``."""
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: None)  # TemporaryDirectory not used on purpose
+        for name, body in files.items():
+            (root / name).write_text(body, encoding="utf-8")
+        return root
+
+    def test_empty_registry_returns_empty_string(self) -> None:
+        """Missing / empty registry means no section emitted — no dangling heading."""
+        empty = self._write_registry({})
+        self.assertEqual(rcp._render_known_issues_section(empty), "")
+
+    def test_registry_without_qrv2_feeding_entries_is_empty(self) -> None:
+        """Entries with ``feeds_qrv2: false`` don't populate the section."""
+        reg = self._write_registry({
+            "QZ-FP-OFF.yml": (
+                "id: QZ-FP-OFF\ntitle: off\ndescription: off\n"
+                "affects: [x]\nfeeds_qrv2: false\nverified_at: '2026-04-23'\n"
+            ),
+        })
+        self.assertEqual(rcp._render_known_issues_section(reg), "")
+
+    def test_shipped_registry_produces_section(self) -> None:
+        """The real ``known-issues/`` registry renders all 4 entries."""
+        section = rcp._render_known_issues_section()
+        self.assertIn("## Known-issues registry", section)
+        self.assertIn("QZ-FP-001", section)
+        self.assertIn("QZ-FP-002", section)
+        self.assertIn("QZ-FP-003", section)
+        self.assertIn("QZ-CV-001", section)
+
+    def test_canonical_fix_rendered_in_code_fence(self) -> None:
+        """Each entry's ``fix_snippet`` lands inside a fenced block."""
+        reg = self._write_registry({
+            "QZ-OK-1.yml": (
+                "id: QZ-OK-1\ntitle: title\ndescription: why\n"
+                "affects: [codeql]\nfeeds_qrv2: true\n"
+                "fix_snippet: 'pass # fix'\nverified_at: '2026-04-23'\n"
+            ),
+        })
+        section = rcp._render_known_issues_section(reg)
+        self.assertIn("Canonical fix:", section)
+        self.assertIn("```\npass # fix\n```", section)
+
+    def test_affects_list_formatted(self) -> None:
+        """``affects`` renders as a comma-joined list."""
+        reg = self._write_registry({
+            "QZ-OK-2.yml": (
+                "id: QZ-OK-2\ntitle: t\ndescription: d\n"
+                "affects: [codeql, sonarcloud]\nfeeds_qrv2: true\n"
+                "fix_snippet: 'pass'\nverified_at: '2026-04-23'\n"
+            ),
+        })
+        section = rcp._render_known_issues_section(reg)
+        self.assertIn("Affects: codeql, sonarcloud", section)
+
+
+class PromptIntegrationTests(unittest.TestCase):
+    """``_render_prompt`` splices the known-issues section onto the prompt."""
+
+    _MIN_PROFILE = {
+        "slug": "Prekzursil/example",
+        "verify_command": "bash scripts/verify",
+        "default_branch": "main",
+        "profile_id": "example",
+        "stack": "python-only",
+        "github_mutation_lane": "default",
+        "codex_auth_lane": "default",
+        "provider_ui_mode": "default",
+        "codex_environment": {
+            "auth_file": "~/.codex/auth.json",
+            "runner_labels": ["self-hosted"],
+        },
+        "required_contexts": {
+            "always": ["codeql / CodeQL"],
+            "pull_request_only": [],
+            "required_now": ["codeql / CodeQL"],
+            "target": ["codeql / CodeQL"],
+        },
+        "required_secrets": [],
+        "conditional_secrets": [],
+        "required_vars": [],
+        "issue_policy": {"mode": "ratchet"},
+        "enabled_scanners": {},
+        "coverage": {},
+        "vendors": {},
+        "preserve_public_check_names": True,
+    }
+
+    def test_known_issues_section_appended_when_entries_exist(self) -> None:
+        """The shipped registry populates the section on every render."""
+        prompt = rcp._render_prompt(
+            self._MIN_PROFILE,
+            lane="remediation",
+            event_name="pull_request",
+            failure_context="",
+            artifacts=[],
+        )
+        self.assertIn("## Known-issues registry", prompt)
+        self.assertIn("QZ-FP-001", prompt)
+
+    def test_known_issues_section_omitted_when_registry_empty(self) -> None:
+        """Empty registry → prompt has no dangling heading."""
+        with patch.object(
+            rcp, "_render_known_issues_section", return_value=""
+        ):
+            prompt = rcp._render_prompt(
+                self._MIN_PROFILE,
+                lane="remediation",
+                event_name="pull_request",
+                failure_context="",
+                artifacts=[],
+            )
+        self.assertNotIn("## Known-issues registry", prompt)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Fourth Phase 4 deliverable per `docs/QZP-V2-DESIGN.md` §6. Extends `render_codex_prompt.py` so every QRv2 prompt now includes a `## Known-issues registry` section populated by `known_issues.qrv2_prompt_entries`. The remediation loop applies the canonical fix for each recurring false positive instead of re-deriving it per run.

## Section format

Each QRv2-feeding entry renders as:
- Heading: `### <id> — <title>`
- Body: the `description` prose
- `Affects: <scanner1>, <scanner2>, ...`
- `Canonical fix:` followed by the `fix_snippet` in a fenced code block

Empty registry (or no entries with `feeds_qrv2: true`) → section omitted, no dangling heading.

## Test plan

- [x] 7 new tests across 2 classes (KnownIssuesSection + PromptIntegration)
- [x] Real shipped registry surfaces all 4 entries (QZ-FP-001/002/003 + QZ-CV-001) in the rendered prompt
- [x] Full suite: 1196 tests + 17 subtests pass
- [ ] CI on this PR green

## Phase 4 scorecard after merge

- ✅ known-issues registry (PR #100)
- ✅ severity-aware rollup helper (PR #101)
- ✅ break-glass + skip handlers (PR #102)
- ✅ QRv2 reads known-issues (this PR)
- ❌ Wire severity-classifier into existing `build_quality_rollup.py`
- ❌ GitHub Action workflow wrapping the bypass handlers
- ❌ Security-class QRv2 always-PR verification with synthetic Dependabot finding

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a “Known-issues registry” to every QRv2 Codex prompt so remediation applies canonical fixes, and adds handlers for `quality-zero:break-glass` and `quality-zero:skip` with audit logging and follow‑up.

- **New Features**
  - Codex prompt: `scripts/quality/render_codex_prompt.py` appends a “Known-issues registry” section from `known_issues.qrv2_prompt_entries`; omitted if empty.
  - Section format: `### <id> — <title>`, description, `Affects: <scanner1>, <scanner2>`, and “Canonical fix:” with the `fix_snippet` in a fenced block.
  - Bypass labels: new `scripts/quality/bypass_labels.py` validates `quality-zero:break-glass` requires an `Incident: <id>` line, writes JSONL to `audit/break-glass.jsonl` or `audit/skip.jsonl`, and opens a post-merge tracking issue for break‑glass; never logs secrets.
  - Tests: coverage for section rendering and both label flows, including audit line formats and tracking issue content.

<sup>Written for commit a32a9c43095343dfda03e07fbdaa7203ad7d0b54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add break-glass and skip bypass handling, and include known fixes in QRv2 prompts**

### What Changed
- PRs using `quality-zero:break-glass` now require an `Incident: <id>` line before they can proceed, and the merge is recorded for follow-up review
- PRs using `quality-zero:skip` are allowed without an incident, but still create an audit record
- Both bypass paths write compact audit logs with PR details and a timestamp, while break-glass also opens a tracking issue for debriefing
- QRv2 Codex prompts now include a `Known-issues registry` section when matching entries exist, so recurring false positives can use the documented fix
- Added tests for incident parsing, bypass decisions, audit logging, and prompt rendering

### Impact
`✅ Clearer emergency bypass rules`
`✅ Fewer missed incident follow-ups`
`✅ More consistent QRv2 remediation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0bJ7ffL24lDXPq5xiwoFqRQOQbxdCRUroYEE6YOlOls&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
