### PR TITLE
feat(qzp-v2 phase 4 inc-5): reusable-quality-zero-bypass workflow

### DIFF
--- a/.github/workflows/reusable-quality-zero-bypass.yml
+++ b/.github/workflows/reusable-quality-zero-bypass.yml
@@ -1,0 +1,183 @@
+name: Reusable Quality Zero Bypass
+
+# QZP v2 Phase 4 §5.2 — record a ``quality-zero:break-glass`` or
+# ``quality-zero:skip`` label event and fail/succeed the downstream
+# merge gate accordingly. Consumer repos call this via ``workflow_call``
+# on their ``labeled`` PR event.
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        type: string
+        required: true
+        description: "Literal label that triggered the event (break-glass | skip)."
+      pr_slug:
+        type: string
+        required: true
+        description: "``owner/name`` of the repo hosting the PR."
+      pr_number:
+        type: number
+        required: true
+      head_sha:
+        type: string
+        required: true
+      actor:
+        type: string
+        required: true
+        description: "GitHub username that applied the label."
+      pr_body:
+        type: string
+        required: false
+        default: ""
+        description: "PR body — scanned for the ``Incident:`` line on break-glass."
+      audit_dir:
+        type: string
+        required: false
+        default: audit
+        description: "Relative path within the platform repo where the jsonl lands."
+      platform_repository:
+        type: string
+        required: false
+        default: Prekzursil/quality-zero-platform
+      platform_ref:
+        type: string
+        required: false
+        default: main
+    secrets:
+      BYPASS_AUDIT_PAT:
+        required: false
+        description: "Fine-grained PAT with ``contents:write`` on the platform repo for appending audit logs. Absent = dry-run."
+
+jobs:
+  bypass:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.platform_repository }}
+          ref: ${{ inputs.platform_ref }}
+          token: ${{ secrets.BYPASS_AUDIT_PAT || github.token }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Evaluate bypass
+        id: evaluate
+        env:
+          QZ_LABEL: ${{ inputs.label }}
+          QZ_PR_SLUG: ${{ inputs.pr_slug }}
+          QZ_PR_NUMBER: ${{ inputs.pr_number }}
+          QZ_HEAD_SHA: ${{ inputs.head_sha }}
+          QZ_ACTOR: ${{ inputs.actor }}
+          QZ_PR_BODY: ${{ inputs.pr_body }}
+          QZ_AUDIT_DIR: ${{ inputs.audit_dir }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+          from scripts.quality import bypass_labels as bl
+
+          label = os.environ["QZ_LABEL"].strip()
+          pr_body = os.environ.get("QZ_PR_BODY", "")
+          pr_slug = os.environ["QZ_PR_SLUG"].strip()
+          pr_number = int(os.environ["QZ_PR_NUMBER"])
+          head_sha = os.environ["QZ_HEAD_SHA"].strip()
+          actor = os.environ["QZ_ACTOR"].strip()
+          audit_dir = Path(os.environ.get("QZ_AUDIT_DIR", "audit"))
+
+          if label == bl.BREAK_GLASS_LABEL:
+            try:
+              decision = bl.evaluate_break_glass(
+                  pr_body=pr_body, pr_slug=pr_slug, pr_number=pr_number,
+                  head_sha=head_sha, actor=actor,
+              )
+            except bl.BypassError as exc:
+              print(f"::error::{exc}", flush=True)
+              sys.exit(1)
+            filename = "break-glass.jsonl"
+          elif label == bl.SKIP_LABEL:
+            decision = bl.evaluate_skip(
+                pr_body=pr_body, pr_slug=pr_slug, pr_number=pr_number,
+                head_sha=head_sha, actor=actor,
+            )
+            filename = "skip.jsonl"
+          else:
+            print(f"::error::Unknown bypass label: {label}", flush=True)
+            sys.exit(2)
+
+          audit_path = audit_dir / filename
+          bl.append_jsonl(audit_path, decision.audit_record)
+
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+            with open(output_path, "a", encoding="utf-8") as handle:
+              handle.write(f"allowed={'true' if decision.allowed else 'false'}\n")
+              handle.write(f"label={decision.label}\n")
+              handle.write(f"audit_path={audit_path}\n")
+              if decision.incident:
+                handle.write(f"incident={decision.incident}\n")
+              if decision.tracking_issue_title:
+                handle.write(
+                    f"tracking_issue_title={decision.tracking_issue_title}\n"
+                )
+          step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if step_summary:
+            with open(step_summary, "a", encoding="utf-8") as handle:
+              handle.write(f"## Quality Zero Bypass — {decision.label}\n\n")
+              handle.write(f"- PR: `{pr_slug}#{pr_number}`\n")
+              handle.write(f"- Actor: `@{actor}`\n")
+              if decision.incident:
+                handle.write(f"- Incident: `{decision.incident}`\n")
+              handle.write(f"- Audit log: `{audit_path}`\n")
+          PY
+
+      - name: Commit audit log
+        if: ${{ secrets.BYPASS_AUDIT_PAT != '' }}
+        env:
+          QZ_AUDIT_PATH: ${{ steps.evaluate.outputs.audit_path }}
+          QZ_LABEL: ${{ inputs.label }}
+          QZ_PR_SLUG: ${{ inputs.pr_slug }}
+          QZ_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          git config user.email "platform-bot@quality-zero.local"
+          git config user.name "quality-zero-platform bypass"
+          git add "$QZ_AUDIT_PATH"
+          git commit -m "chore(audit): record $QZ_LABEL for $QZ_PR_SLUG#$QZ_PR_NUMBER"
+          git push
+
+      - name: Open post-merge tracking issue
+        if: ${{ inputs.label == 'quality-zero:break-glass' && steps.evaluate.outputs.tracking_issue_title != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.BYPASS_AUDIT_PAT || github.token }}
+          QZ_ISSUE_TITLE: ${{ steps.evaluate.outputs.tracking_issue_title }}
+          QZ_PR_SLUG: ${{ inputs.pr_slug }}
+          QZ_PR_NUMBER: ${{ inputs.pr_number }}
+          QZ_ACTOR: ${{ inputs.actor }}
+          QZ_INCIDENT: ${{ steps.evaluate.outputs.incident }}
+          QZ_PLATFORM_REPO: ${{ inputs.platform_repository }}
+        run: |
+          gh issue create \
+            --repo "$QZ_PLATFORM_REPO" \
+            --title "$QZ_ISSUE_TITLE" \
+            --label "quality-zero:break-glass-followup" \
+            --body "Automated tracking issue from the reusable-quality-zero-bypass workflow.
+
+          - PR: $QZ_PR_SLUG#$QZ_PR_NUMBER
+          - Actor: @$QZ_ACTOR
+          - Incident: $QZ_INCIDENT
+
+          Post-merge remediation required: the PR merged past a red quality-zero gate using break-glass. Debrief the incident, resolve the underlying failure, and close this issue when the gate is green again on main."

--- a/tests/test_reusable_quality_zero_bypass.py
+++ b/tests/test_reusable_quality_zero_bypass.py
@@ -1,0 +1,94 @@
+"""Contract tests for ``reusable-quality-zero-bypass.yml``.
+
+Phase 4 §5.2 workflow that wraps the break-glass + skip label handlers.
+The tests pin the inputs/secrets/jobs shape so future edits can't
+silently drop the audit path or the env-var indirection that blocks
+Semgrep CWE-78.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "reusable-quality-zero-bypass.yml"
+)
+
+
+class ReusableBypassWorkflowTests(unittest.TestCase):
+    """Invariants on the reusable-quality-zero-bypass workflow."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_is_workflow_call(self) -> None:
+        """Other repos invoke it via ``uses: ...``."""
+        # ``on:`` parses as YAML boolean True — access via that key.
+        self.assertIn("workflow_call", self.doc[True])
+
+    def test_required_inputs_are_declared(self) -> None:
+        """Every field the Python evaluator reads must be a declared input."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        for required in (
+            "label", "pr_slug", "pr_number", "head_sha", "actor",
+        ):
+            with self.subTest(input=required):
+                self.assertIn(required, inputs)
+                self.assertTrue(inputs[required].get("required"))
+
+    def test_pr_body_input_default_empty(self) -> None:
+        """pr_body is optional + defaults to '' so skip-label works."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        self.assertIn("pr_body", inputs)
+        self.assertEqual(inputs["pr_body"].get("default", ""), "")
+
+    def test_bypass_audit_pat_secret_declared(self) -> None:
+        """Audit writes route through a fine-grained PAT."""
+        secrets = self.doc[True]["workflow_call"]["secrets"]
+        self.assertIn("BYPASS_AUDIT_PAT", secrets)
+
+    def test_env_var_indirection_for_github_context_values(self) -> None:
+        """Inputs reach the Python evaluator via env: not inline run: interpolation.
+
+        Blocks Semgrep CWE-78 run-shell-injection the same way the
+        Phase 2 / 3 workflows do.
+        """
+        self.assertIn("QZ_LABEL:", self.text)
+        self.assertIn("QZ_PR_SLUG:", self.text)
+        self.assertIn("QZ_PR_BODY:", self.text)
+        # Sanity: the evaluator actually reads from os.environ, not from
+        # an inline interpolation.
+        self.assertIn('os.environ["QZ_LABEL"]', self.text)
+        self.assertIn('os.environ["QZ_PR_SLUG"]', self.text)
+
+    def test_workflow_imports_bypass_labels_helper(self) -> None:
+        """The evaluator uses the Phase 4 ``bypass_labels`` module."""
+        self.assertIn("from scripts.quality import bypass_labels", self.text)
+
+    def test_commit_step_guarded_by_pat_presence(self) -> None:
+        """Audit log is committed only when ``BYPASS_AUDIT_PAT`` is set."""
+        self.assertIn(
+            "if: ${{ secrets.BYPASS_AUDIT_PAT != '' }}",
+            self.text,
+        )
+
+    def test_tracking_issue_step_runs_only_for_break_glass(self) -> None:
+        """Post-merge tracking issue is opened only for break-glass labels."""
+        self.assertIn(
+            "inputs.label == 'quality-zero:break-glass'",
+            self.text,
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Wraps the `scripts/quality/bypass_labels.py` helpers (from PR #102) into a reusable GitHub Actions workflow. Consumer repos invoke it via `workflow_call` on `pull_request: [labeled]` events for `quality-zero:break-glass` and `quality-zero:skip`.

## Workflow flow

1. Check out platform + install `requirements-dev.txt`
2. Invoke `evaluate_break_glass` / `evaluate_skip` via Python heredoc; all `inputs.*` routed through `env:` indirection (CWE-78 defence)
3. Append the audit record to `audit/break-glass.jsonl` or `audit/skip.jsonl`
4. When `BYPASS_AUDIT_PAT` is set, commit + push the audit log
5. For break-glass only: open the post-merge tracking issue via `gh issue create` with the `quality-zero:break-glass-followup` label

## Contract (8 tests)

- `workflow_call` trigger
- All 5 required inputs (`label`, `pr_slug`, `pr_number`, `head_sha`, `actor`) declared required
- `pr_body` optional with `''` default (skip-label works without it)
- `BYPASS_AUDIT_PAT` secret declared
- `github.*` / `inputs.*` fields route via `env:` + `os.environ[...]`, never inline interpolation
- Evaluator imports `scripts.quality.bypass_labels`
- Commit step guarded by secret presence
- Tracking-issue step runs only for break-glass

## Phase 4 scorecard after merge

- ✅ known-issues registry (PR #100)
- ✅ severity-aware rollup helper (PR #101)
- ✅ break-glass + skip Python handlers (PR #102)
- ✅ QRv2 reads known-issues into Codex prompt (PR #103)
- ✅ Reusable bypass workflow (this PR)
- ❌ Wire severity-classifier into existing `build_quality_rollup.py`
- ❌ Security-class QRv2 always-PR verification with synthetic Dependabot finding

## Test plan

- [x] 8 new tests + 5 subtests, full suite at 1204
- [x] YAML parses as valid `workflow_call`
- [x] Env-var indirection verified by inspecting file text
- [ ] CI on this PR green


___

## **CodeAnt-AI Description**
Reusable workflow for recording quality-zero bypass label events

### What Changed
- Adds a reusable workflow that consumer repos can call when a PR gets `quality-zero:break-glass` or `quality-zero:skip`
- Saves an audit record for each bypass, with an option to commit and push the log when a PAT is provided
- For break-glass cases, opens a follow-up tracking issue that includes the PR, actor, and incident details
- Adds contract tests to lock the workflow trigger, required inputs, optional PR body handling, audit secret, and break-glass-only issue creation

### Impact
`✅ Reusable bypass handling across repos`
`✅ Audited break-glass and skip events`
`✅ Clearer post-merge follow-up for break-glass cases`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=G8OcScGjxWH0Y8wPptS0Zjyp3cB0P_UJ6CwXGwLmE6g&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
