### PR TITLE
feat(qzp-v2 phase 4 inc-6): build_quality_rollup consumes scanners.*.severity

### DIFF
--- a/scripts/quality/build_quality_rollup.py
+++ b/scripts/quality/build_quality_rollup.py
@@ -27,6 +27,10 @@ from scripts.quality.check_required_checks import (
     _evaluate_observed_context,
     _resolve_observed_context,
 )
+from scripts.quality.severity_rollup import (
+    classify_lanes,
+    failing_lanes_to_gate_output,
+)
 from scripts.security_helpers import load_json_https
 
 GITHUB_API_BASE = "https://api.github.com"
@@ -189,6 +193,24 @@ def _build_rollup_row(
     }
 
 
+def _lane_statuses_from_rows(
+    rows: List[Dict[str, str]],
+    reverse_map: Mapping[str, str],
+) -> Dict[str, str]:
+    """Return ``{lane_id: status}`` keyed off ``reverse_map`` for severity rollup.
+
+    Contexts that can't be mapped to a lane (e.g. ``SonarCloud Code
+    Analysis`` isn't in ``LANE_CONTEXTS``) pass through under their
+    context name so the severity map can still match by that key.
+    """
+    statuses: Dict[str, str] = {}
+    for row in rows:
+        context_name = row["context"]
+        lane_key = reverse_map.get(context_name, context_name)
+        statuses[lane_key] = row["status"]
+    return statuses
+
+
 def build_rollup(
     *,
     profile: Mapping[str, Any],
@@ -196,7 +218,15 @@ def build_rollup(
     contexts: Mapping[str, Dict[str, str]],
     sha: str,
 ) -> Dict[str, Any]:
-    """Build the aggregated strict-zero rollup payload."""
+    """Build the aggregated strict-zero rollup payload.
+
+    v2 profiles declare ``scanners.*.severity`` (block/warn/info);
+    :func:`scripts.quality.severity_rollup.classify_lanes` downgrades
+    ``warn``/``info`` lane failures from the overall verdict while
+    still tracking them in the ``severity`` sub-payload. Legacy v1
+    profiles that don't declare ``scanners`` default every lane to
+    ``block`` severity (same as the existing behaviour).
+    """
     required_contexts = sorted(profile.get("active_required_contexts", []))
     rows: List[Dict[str, str]] = []
     overall = "pass"
@@ -213,12 +243,27 @@ def build_rollup(
         elif row["status"] == "pending" and overall == "pass":
             overall = "pending"
         rows.append(row)
+
+    severity_verdict = classify_lanes(
+        profile, _lane_statuses_from_rows(rows, reverse_map)
+    )
+    severity_payload = failing_lanes_to_gate_output(severity_verdict)
+    # Severity-aware overall: if the zero-rollup says ``fail`` but every
+    # failure is only ``warn``/``info`` severity, soften to ``warn`` or
+    # keep ``pass``. Preserves the hard ``fail`` when blockers exist
+    # AND preserves ``pending`` (not-yet-reported) regardless.
+    if overall == "fail":
+        if severity_verdict.verdict == "warn":
+            overall = "warn"
+        elif severity_verdict.verdict == "pass":
+            overall = "pass"
     return {
         "repo": profile["slug"],
         "sha": sha,
         "status": overall,
         "generated_at": utc_timestamp(),
         "contexts": rows,
+        "severity": severity_payload,
     }
 
 

--- a/tests/test_build_rollup_severity.py
+++ b/tests/test_build_rollup_severity.py
@@ -1,0 +1,115 @@
+"""Tests for the Phase 4 severity integration in ``build_quality_rollup``."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from scripts.quality import build_quality_rollup as br
+
+
+class LaneStatusesFromRowsTests(unittest.TestCase):
+    """``_lane_statuses_from_rows`` prepares the input for ``classify_lanes``."""
+
+    def test_known_contexts_map_to_lane_ids(self) -> None:
+        """Standard LANE_CONTEXTS entries resolve to their lane id."""
+        reverse_map = {ctx: lane for lane, ctx in br.LANE_CONTEXTS.items()}
+        rows = [
+            {"context": "Codacy Zero", "status": "fail", "detail": ""},
+            {"context": "Coverage 100 Gate", "status": "pass", "detail": ""},
+        ]
+        statuses = br._lane_statuses_from_rows(rows, reverse_map)
+        self.assertEqual(statuses["codacy"], "fail")
+        self.assertEqual(statuses["coverage"], "pass")
+
+    def test_unknown_context_passes_through_under_context_name(self) -> None:
+        """Contexts not in LANE_CONTEXTS keep their full name as key."""
+        reverse_map = {ctx: lane for lane, ctx in br.LANE_CONTEXTS.items()}
+        rows = [
+            {"context": "SonarCloud Code Analysis", "status": "fail", "detail": ""},
+        ]
+        statuses = br._lane_statuses_from_rows(rows, reverse_map)
+        self.assertEqual(statuses["SonarCloud Code Analysis"], "fail")
+
+
+class BuildRollupSeverityTests(unittest.TestCase):
+    """``build_rollup`` emits a severity payload + honours profile severities."""
+
+    def _profile(self) -> dict:
+        """Minimal profile with one fail-lane of each severity."""
+        return {
+            "slug": "Prekzursil/example",
+            "active_required_contexts": [
+                "Codacy Zero",
+                "Coverage 100 Gate",
+                "Sentry Zero",
+            ],
+            "scanners": {
+                "codacy": {"severity": "block"},
+                "coverage": {"severity": "warn"},
+                "sentry": {"severity": "info"},
+            },
+        }
+
+    def test_warn_severity_fail_softens_overall(self) -> None:
+        """Only warn/info failures → overall softens to ``warn`` or ``pass``."""
+        profile = self._profile()
+        contexts = {
+            "Codacy Zero": {"source": "check_run", "state": "completed", "conclusion": "success"},
+            "Coverage 100 Gate": {"source": "check_run", "state": "completed", "conclusion": "failure"},
+            "Sentry Zero": {"source": "check_run", "state": "completed", "conclusion": "failure"},
+        }
+        # lane_payloads left empty → rows fall back to context statuses
+        payload = br.build_rollup(
+            profile=profile, lane_payloads={}, contexts=contexts, sha="abc",
+        )
+        # One warn-severity failure + one info-severity failure → overall warn
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(payload["severity"]["verdict"], "warn")
+        self.assertEqual(payload["severity"]["warnings"], ["coverage"])
+        self.assertEqual(payload["severity"]["infos"], ["sentry"])
+        self.assertEqual(payload["severity"]["blockers"], [])
+
+    def test_block_severity_fail_still_fails(self) -> None:
+        """One block-severity failure still yields overall=fail."""
+        profile = self._profile()
+        contexts = {
+            "Codacy Zero": {"source": "check_run", "state": "completed", "conclusion": "failure"},
+            "Coverage 100 Gate": {"source": "check_run", "state": "completed", "conclusion": "success"},
+            "Sentry Zero": {"source": "check_run", "state": "completed", "conclusion": "success"},
+        }
+        payload = br.build_rollup(
+            profile=profile, lane_payloads={}, contexts=contexts, sha="abc",
+        )
+        self.assertEqual(payload["status"], "fail")
+        self.assertEqual(payload["severity"]["verdict"], "fail")
+        self.assertEqual(payload["severity"]["blockers"], ["codacy"])
+
+    def test_info_only_failures_pass(self) -> None:
+        """Info-only failures → overall=pass (gate unchanged)."""
+        profile = self._profile()
+        contexts = {
+            "Codacy Zero": {"source": "check_run", "state": "completed", "conclusion": "success"},
+            "Coverage 100 Gate": {"source": "check_run", "state": "completed", "conclusion": "success"},
+            "Sentry Zero": {"source": "check_run", "state": "completed", "conclusion": "failure"},
+        }
+        payload = br.build_rollup(
+            profile=profile, lane_payloads={}, contexts=contexts, sha="abc",
+        )
+        self.assertEqual(payload["status"], "pass")
+        self.assertEqual(payload["severity"]["infos"], ["sentry"])
+
+    def test_payload_includes_severity_block(self) -> None:
+        """Every rollup has a ``severity`` sub-dict with the expected keys."""
+        payload = br.build_rollup(
+            profile={"slug": "x", "active_required_contexts": []},
+            lane_payloads={}, contexts={}, sha="s",
+        )
+        self.assertIn("severity", payload)
+        self.assertIn("verdict", payload["severity"])
+        self.assertIn("blockers", payload["severity"])
+        self.assertIn("warnings", payload["severity"])
+        self.assertIn("infos", payload["severity"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
Closes the **"`build_quality_rollup.py` consumes `scanners.*.severity`"** bullet from Phase 4's ABSOLUTE DONE. Wires the Phase 4 severity helper (`severity_rollup.classify_lanes`, PR #101) into the legacy rollup so the aggregate verdict honours the v2 profile's severity policy.

## Verdict rules

- `block` → failing lane keeps `status: fail` on the aggregate
- `warn` → failing lane softens aggregate to `status: warn` (new)
- `info` → failing lane never affects aggregate; recorded in `severity.infos` only

Legacy v1 profiles (no `scanners` declared) default every lane to `block` — existing behaviour preserved.

## Payload additions

New `severity` sub-dict with `verdict` / `blockers` / `warnings` / `infos` keys (JSON-safe for step-summary + dashboard consumption).

Overall `status` softening:
- `fail` → `warn` when every failure is warn-severity
- `fail` → `pass` when every failure is info-severity
- Hard `fail` preserved when any block-severity lane fails
- `pending` states pass through unchanged

## Test plan

- [x] 6 new tests in `test_build_rollup_severity.py` covering each verdict path + the `_lane_statuses_from_rows` mapping helper
- [x] Full suite: 1210 tests + 22 subtests pass
- [ ] CI on this PR green

## Phase 4 scorecard after merge

- ✅ `build_quality_rollup.py` consumes `scanners.*.severity` (this PR)
- ✅ known-issues registry + 4 seed entries (PR #100)
- ✅ severity-aware rollup helper (PR #101)
- ✅ break-glass + skip handlers (PR #102)
- ✅ QRv2 reads known-issues into Codex prompt (PR #103)
- ✅ Reusable bypass workflow (PR #104)
- ❌ Security-class QRv2 always-PR verification with synthetic Dependabot finding — last remaining Phase 4 criterion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build quality assessments now include severity-based classification, enabling more granular reporting of failures categorized as blockers, warnings, and informational issues.

* **Tests**
  * Added comprehensive test coverage for the new severity classification system in build quality assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Integrates v2 severity policy into `build_quality_rollup` so overall status honors `scanners.*.severity` and adds a `severity` payload. Completes Phase 4’s severity-aware rollup requirement.

- **New Features**
  - Uses `severity_rollup.classify_lanes` to apply `block`/`warn`/`info` rules.
  - Softens overall `fail` to `warn` if only warn-severity fails; to `pass` if only info-severity fails.
  - Preserves hard `fail` when any block-severity lane fails; `pending` unchanged.
  - Adds `_lane_statuses_from_rows` to map contexts to lane ids (or keep context name if unknown).
  - Emits `severity` sub-dict with `verdict`, `blockers`, `warnings`, `infos`.
  - Keeps v1 behavior when no `scanners` are declared (all lanes default to `block`).

<sup>Written for commit 1a613ad224fc100d58f14ec452e0b0a5ca16d6fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make quality rollups respect scanner severity levels**

### What Changed
- Rollup results now treat scanner failures differently based on severity: blocker failures keep the overall result as fail, warning failures soften it to warn, and info-only failures no longer fail the rollup.
- Every rollup now includes a severity summary showing blockers, warnings, and info-only failures.
- Existing profiles without scanner severity settings keep the same all-fail behavior as before.

### Impact
`✅ Fewer hard failures from non-blocking checks`
`✅ Clearer rollup results for warning-level issues`
`✅ Same behavior for legacy profiles`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tabNsNQo668K8PwkFpse1G739ehyRGHBP2FsAFE07SQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
