### PR TITLE
feat(qzp-v2 phase 4 inc-7): security-class QRv2 guard — dependabot-class always PR

### DIFF
--- a/scripts/quality/security_class_guard.py
+++ b/scripts/quality/security_class_guard.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Security-class guard: force QRv2 fixes to PR, never auto-merge.
+
+Phase 4 of ``docs/QZP-V2-DESIGN.md`` §5.3 (last criterion): a QRv2
+remediation that touches a security-class finding MUST open a pull
+request for human review; auto-merge is prohibited even when the
+remediation is trivial.
+
+Security-class findings are recognised by any one of:
+
+* A canonical scanner name that is intrinsically security-focused
+  (Dependabot, Semgrep, CodeQL, DeepSource Secrets, Socket Security,
+  GitHub secret scanning).
+* An ``is_security`` flag on the finding payload.
+* A CWE reference (``CWE-<number>``) in the finding id, tags, or
+  message — CWE entries are, by definition, security weaknesses.
+* An OWASP / ``A0n:`` reference in the id or tags.
+
+``is_security_finding(finding)`` is the primitive; ``filter_auto_merge
+_candidates(findings)`` splits a list into ``(auto_merge_ok,
+must_open_pr)``. The QRv2 loop calls the splitter before deciding
+whether to commit-to-remediation-branch + label-for-auto-merge or
+open-pr-and-wait.
+
+``ensure_pr_only_for_security(findings)`` is the assertion the loop
+uses as a belt-and-suspenders guard: it raises
+``SecurityAutoMergeRefused`` if called with a mode ``auto_merge`` AND
+any finding is security-class.
+"""
+
+from __future__ import absolute_import
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Tuple
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+SECURITY_SCANNERS: Tuple[str, ...] = (
+    "dependabot",
+    "semgrep",
+    "codeql",
+    "socket",
+    "socket_security",
+    "deepsource_secrets",
+    "github_secret_scanning",
+    "gitleaks",
+    "trivy",
+    "bandit",
+)
+
+_CWE_RE = re.compile(r"\bCWE-\d+\b", re.IGNORECASE)
+_OWASP_RE = re.compile(r"\bA0\d:\d{4}\b", re.IGNORECASE)
+
+
+class SecurityAutoMergeRefused(RuntimeError):
+    """Raised when QRv2 tries to auto-merge a security-class remediation."""
+
+
+@dataclass(frozen=True)
+class ClassifiedFindings:
+    """Result of splitting findings into auto-merge-ok vs must-open-pr sets."""
+
+    auto_merge_ok: List[Mapping[str, Any]]
+    must_open_pr: List[Mapping[str, Any]]
+
+
+def _scanner_name(finding: Mapping[str, Any]) -> str:
+    """Extract a scanner identifier from a finding record."""
+    for key in ("scanner", "source", "tool", "analyzer"):
+        value = finding.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _has_security_tag(finding: Mapping[str, Any]) -> bool:
+    """Return True when any finding text references a CWE / OWASP entry."""
+    haystack_parts: List[str] = []
+    for key in ("id", "rule", "message", "category", "title"):
+        value = finding.get(key)
+        if isinstance(value, str):
+            haystack_parts.append(value)
+    tags = finding.get("tags")
+    if isinstance(tags, (list, tuple)):
+        haystack_parts.extend(str(t) for t in tags if isinstance(t, str))
+    haystack = " | ".join(haystack_parts)
+    if _CWE_RE.search(haystack):
+        return True
+    if _OWASP_RE.search(haystack):
+        return True
+    return False
+
+
+def is_security_finding(finding: Mapping[str, Any]) -> bool:
+    """Return True when ``finding`` is security-class per any recognised signal."""
+    if not isinstance(finding, Mapping):
+        return False
+    if bool(finding.get("is_security")):
+        return True
+    scanner = _scanner_name(finding)
+    if scanner in SECURITY_SCANNERS:
+        return True
+    category = str(finding.get("category", "")).strip().lower()
+    if category in {"security", "vulnerability", "secret"}:
+        return True
+    if _has_security_tag(finding):
+        return True
+    return False
+
+
+def filter_auto_merge_candidates(
+    findings: Iterable[Mapping[str, Any]],
+) -> ClassifiedFindings:
+    """Split ``findings`` into auto-merge-safe vs must-open-pr groups."""
+    ok: List[Mapping[str, Any]] = []
+    pr: List[Mapping[str, Any]] = []
+    for finding in findings:
+        if is_security_finding(finding):
+            pr.append(finding)
+        else:
+            ok.append(finding)
+    return ClassifiedFindings(auto_merge_ok=ok, must_open_pr=pr)
+
+
+def ensure_pr_only_for_security(
+    findings: Iterable[Mapping[str, Any]],
+    *,
+    intends_auto_merge: bool,
+) -> None:
+    """Belt-and-suspenders guard called by the QRv2 loop.
+
+    Raises :class:`SecurityAutoMergeRefused` when ``intends_auto_merge``
+    is true AND any finding in ``findings`` is security-class. Silent
+    when no auto-merge is intended or no security-class findings are
+    present.
+    """
+    if not intends_auto_merge:
+        return
+    classified = filter_auto_merge_candidates(findings)
+    if classified.must_open_pr:
+        ids = ", ".join(
+            str(f.get("id") or f.get("rule") or "<anonymous>")
+            for f in classified.must_open_pr
+        )
+        raise SecurityAutoMergeRefused(
+            f"QRv2 refused to auto-merge: security-class findings present "
+            f"({ids}). Security-class remediations must open a PR."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import json
+
+    _findings = json.loads(sys.stdin.read() or "[]")
+    _classified = filter_auto_merge_candidates(_findings)
+    print(json.dumps({
+        "auto_merge_ok": _classified.auto_merge_ok,
+        "must_open_pr": _classified.must_open_pr,
+    }, indent=2))

--- a/tests/test_security_class_guard.py
+++ b/tests/test_security_class_guard.py
@@ -1,0 +1,179 @@
+"""Tests for the Phase 4 §5.3 security-class QRv2 guard.
+
+Verifies that synthetic security-class findings (Dependabot-class,
+CWE-tagged, scanner-name heuristic, category flag, OWASP reference)
+are all pulled out of the auto-merge-eligible set. Also exercises the
+``SecurityAutoMergeRefused`` belt-and-suspenders error.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+from scripts.quality import security_class_guard as sg
+
+
+class IsSecurityFindingTests(unittest.TestCase):
+    """``is_security_finding`` detects every documented signal."""
+
+    def test_dependabot_source_is_security(self) -> None:
+        """A synthetic Dependabot finding is recognised by its scanner name."""
+        self.assertTrue(
+            sg.is_security_finding({"scanner": "dependabot", "id": "DEP-1"})
+        )
+
+    def test_case_insensitive_scanner_match(self) -> None:
+        """Scanner name matching is case-insensitive."""
+        self.assertTrue(
+            sg.is_security_finding({"scanner": "Semgrep", "id": "sem-1"})
+        )
+
+    def test_is_security_flag_overrides(self) -> None:
+        """Explicit ``is_security: True`` is enough to flag the finding."""
+        self.assertTrue(
+            sg.is_security_finding({"scanner": "custom", "is_security": True})
+        )
+
+    def test_category_security_flag(self) -> None:
+        """``category: security`` (and synonyms) flag the finding."""
+        for category in ("security", "Security", "vulnerability", "secret"):
+            with self.subTest(category=category):
+                self.assertTrue(
+                    sg.is_security_finding(
+                        {"scanner": "misc", "category": category}
+                    )
+                )
+
+    def test_cwe_reference_in_id(self) -> None:
+        """CWE-<n> in the finding id flags it as security-class."""
+        self.assertTrue(
+            sg.is_security_finding(
+                {"scanner": "custom", "id": "run-shell-injection CWE-78"}
+            )
+        )
+
+    def test_cwe_reference_in_tags(self) -> None:
+        """CWE references inside ``tags`` are also recognised."""
+        self.assertTrue(
+            sg.is_security_finding(
+                {"scanner": "custom", "tags": ["style", "CWE-79"]}
+            )
+        )
+
+    def test_owasp_reference_in_message(self) -> None:
+        """``A01:2021`` style OWASP refs flag the finding."""
+        self.assertTrue(
+            sg.is_security_finding(
+                {"scanner": "custom", "message": "maps to A03:2021 Injection"}
+            )
+        )
+
+    def test_non_security_finding_returns_false(self) -> None:
+        """Style/formatting findings with no security signal → False."""
+        self.assertFalse(
+            sg.is_security_finding(
+                {
+                    "scanner": "prettier",
+                    "id": "max-line-length",
+                    "category": "style",
+                }
+            )
+        )
+
+    def test_non_mapping_input_returns_false(self) -> None:
+        """Defensive: ``None`` / lists don't crash."""
+        self.assertFalse(sg.is_security_finding(None))  # type: ignore[arg-type]
+        self.assertFalse(sg.is_security_finding([]))  # type: ignore[arg-type]
+
+    def test_alternate_scanner_keys_recognised(self) -> None:
+        """``source`` / ``tool`` / ``analyzer`` all populate the scanner hint."""
+        for key in ("source", "tool", "analyzer"):
+            with self.subTest(key=key):
+                self.assertTrue(sg.is_security_finding({key: "codeql"}))
+
+    def test_no_scanner_hint_no_tags_returns_false(self) -> None:
+        """Finding without any scanner key or security signal is non-security."""
+        self.assertFalse(sg.is_security_finding({"id": "style-001"}))
+
+
+class FilterAutoMergeCandidatesTests(unittest.TestCase):
+    """``filter_auto_merge_candidates`` splits into two disjoint lists."""
+
+    def test_security_findings_go_to_pr_list(self) -> None:
+        """Dependabot + CWE entries land in ``must_open_pr``."""
+        findings = [
+            {"scanner": "dependabot", "id": "DEP-1"},
+            {"scanner": "eslint", "id": "no-unused-vars"},
+            {"scanner": "custom", "id": "CWE-78 path"},
+        ]
+        result = sg.filter_auto_merge_candidates(findings)
+        self.assertEqual(len(result.must_open_pr), 2)
+        self.assertEqual(len(result.auto_merge_ok), 1)
+        self.assertEqual(result.auto_merge_ok[0]["id"], "no-unused-vars")
+
+
+class EnsurePrOnlyGuardTests(unittest.TestCase):
+    """``ensure_pr_only_for_security`` refuses auto-merge for security findings."""
+
+    def test_no_auto_merge_intent_is_silent(self) -> None:
+        """When caller doesn't intend auto-merge, the guard never raises."""
+        sg.ensure_pr_only_for_security(
+            [{"scanner": "dependabot"}], intends_auto_merge=False,
+        )  # no exception expected
+
+    def test_auto_merge_with_security_raises(self) -> None:
+        """A Dependabot-class finding blocks auto-merge."""
+        with self.assertRaises(sg.SecurityAutoMergeRefused) as ctx:
+            sg.ensure_pr_only_for_security(
+                [{"scanner": "dependabot", "id": "DEP-42"}],
+                intends_auto_merge=True,
+            )
+        self.assertIn("DEP-42", str(ctx.exception))
+
+    def test_auto_merge_without_security_passes(self) -> None:
+        """Style-only findings don't trip the guard."""
+        sg.ensure_pr_only_for_security(
+            [
+                {"scanner": "eslint", "id": "no-unused-vars"},
+                {"scanner": "prettier", "id": "max-line-length"},
+            ],
+            intends_auto_merge=True,
+        )  # no exception expected
+
+    def test_refusal_message_names_every_security_finding(self) -> None:
+        """The error message lists each finding's id so logs stay actionable."""
+        with self.assertRaises(sg.SecurityAutoMergeRefused) as ctx:
+            sg.ensure_pr_only_for_security(
+                [
+                    {"scanner": "codeql", "id": "py/injection"},
+                    {"scanner": "semgrep", "id": "xss.reflected"},
+                ],
+                intends_auto_merge=True,
+            )
+        msg = str(ctx.exception)
+        self.assertIn("py/injection", msg)
+        self.assertIn("xss.reflected", msg)
+
+    def test_dependabot_synthetic_finding_blocks_auto_merge(self) -> None:
+        """Phase 4 ABSOLUTE DONE contract: synthetic Dependabot finding forces PR.
+
+        This is the explicit acceptance check from the loop prompt
+        ("Security-class QRv2 fixes always open a PR — verified with
+        a synthetic Dependabot-class finding").
+        """
+        synthetic = {
+            "scanner": "dependabot",
+            "id": "GHSA-xxxx-yyyy-zzzz",
+            "category": "security",
+            "is_security": True,
+            "message": "Regular Expression Denial of Service (ReDoS) (CWE-1333)",
+        }
+        classified = sg.filter_auto_merge_candidates([synthetic])
+        self.assertEqual(len(classified.must_open_pr), 1)
+        self.assertEqual(classified.auto_merge_ok, [])
+        with self.assertRaises(sg.SecurityAutoMergeRefused):
+            sg.ensure_pr_only_for_security([synthetic], intends_auto_merge=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
**Closes the final Phase 4 ABSOLUTE DONE bullet:** Security-class QRv2 fixes always open a PR (never auto-merge) — verified with a synthetic Dependabot-class finding.

## Module surface

New `scripts/quality/security_class_guard.py`:

- `is_security_finding(finding)` — primitive recogniser
- `filter_auto_merge_candidates(findings)` → `ClassifiedFindings(auto_merge_ok, must_open_pr)`
- `ensure_pr_only_for_security(findings, intends_auto_merge=True)` — belt-and-suspenders guard that raises `SecurityAutoMergeRefused` when the QRv2 loop tries to auto-merge a security-class remediation

## Security-class signals (any one is enough)

- Canonical scanner name in `{dependabot, semgrep, codeql, socket, socket_security, deepsource_secrets, github_secret_scanning, gitleaks, trivy, bandit}` — case-insensitive; read from `scanner`/`source`/`tool`/`analyzer` keys
- Explicit `is_security: true` flag
- `category` in `{security, vulnerability, secret}`
- `CWE-<n>` reference in id / rule / message / tags
- OWASP `A0n:YYYY` reference in id / rule / message / tags

## Synthetic Dependabot acceptance test

`test_dependabot_synthetic_finding_blocks_auto_merge` is the explicit check from the loop's ABSOLUTE DONE:

```python
synthetic = {
    "scanner": "dependabot",
    "id": "GHSA-xxxx-yyyy-zzzz",
    "category": "security",
    "is_security": True,
    "message": "Regular Expression Denial of Service (ReDoS) (CWE-1333)",
}
classified = sg.filter_auto_merge_candidates([synthetic])
# Always pulled out of auto-merge bucket.
assert classified.must_open_pr == [synthetic]
assert classified.auto_merge_ok == []
# Guard raises when auto-merge intent meets security finding.
with raises(SecurityAutoMergeRefused):
    sg.ensure_pr_only_for_security([synthetic], intends_auto_merge=True)
```

## Test plan

- [x] 17 tests + 7 subtests across 3 classes
- [x] 100% branch+line coverage (67 stmts / 32 branches)
- [x] Full suite: 1226 tests pass
- [ ] CI green on this PR

## Phase 4 COMPLETE

With this PR, all six code-bearing Phase 4 ABSOLUTE DONE bullets are checked:
1. ✅ `build_quality_rollup.py` consumes `scanners.*.severity` (PR #105)
2. ✅ `quality-zero:break-glass` label handler (PR #102/#104)
3. ✅ `quality-zero:skip` label handler (PR #102/#104)
4. ✅ `known-issues/` seeded with QZ-FP-001..003 + QZ-CV-001 (PR #100)
5. ✅ QRv2 reads `known-issues/` into Codex prompt (PR #103)
6. ✅ Security-class always-PR verified with synthetic Dependabot (this PR)

Phase 5 (bootstrap, bumps, dashboard, 8 alerts, `verify_v2_deployment.py`) is the remaining code scope before the completion promise.


___

## **CodeAnt-AI Description**
Force security-related QRv2 fixes to open a PR instead of auto-merging

### What Changed
- Security-class findings are now kept out of the auto-merge path and must open a PR for review
- Security findings are recognized from common scanner names, explicit security flags, security/vulnerability/secret categories, and CWE or OWASP references in finding details
- Added checks that refuse auto-merge when a security finding is present and include the finding IDs in the error message
- Added tests covering Dependabot, Semgrep, CodeQL, category-based, CWE-based, and OWASP-based security findings, plus the PR-only refusal behavior

### Impact
`✅ Fewer security fixes auto-merged by mistake`
`✅ Clearer handling of Dependabot and scanner-reported vulnerabilities`
`✅ Safer QRv2 remediation flow for security findings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=YgkRUvOcr4dPyqKaxocHndd3b-rwgAgcTQS4sxo6Hpo&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
