### PR TITLE
feat(qzp-v2 phase 5 inc-1): alerts.py module — per-event issue dispatcher

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -30,6 +30,7 @@ engines:
       - "scripts/quality/template_render.py"
       - "scripts/quality/drift_sync.py"
       - "scripts/quality/apply_drift_pr.py"
+      - "scripts/quality/alerts.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/scripts/quality/alerts.py
+++ b/scripts/quality/alerts.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Phase 5 alert issue dispatcher — per-event, no digests.
+
+Opens and closes GitHub issues on the platform repo in response to
+alert events defined in ``docs/QZP-V2-DESIGN.md`` §8. Every alert
+type is identified by a stable ``alert:<slug>`` GitHub label; each
+occurrence (one repo, one event) gets its own issue (deduped via
+canonical title ``[alert:<slug>] <subject>``). No weekly digest is
+generated — the admin dashboard's audit feed is the only aggregated
+view per the Phase 5 acceptance contract.
+
+Alert types (8 total — kept in lock-step with §8 of the design doc):
+
+* ``REGRESSION`` — main-branch coverage dropped > 0.5%.
+* ``DEADLINE_MISSED`` — ratchet ``target_date`` passed without reaching
+  the absolute phase.
+* ``ESCALATION`` — ratchet ``escalation_date`` passed.
+* ``BYPASS_STALE`` — break-glass tracking issue open > 7 days.
+* ``DRIFT_STUCK`` — drift-sync PR open > 3 days.
+* ``FLEET_BUMP_FAIL`` — staging wave of a fleet bump failed CI.
+* ``REPO_NOT_PROFILED`` — inventory found a repo without a profile.
+* ``FLAG_MISSING`` — Codecov validator detected a declared flag with
+  no report.
+
+Public API:
+
+* ``AlertType`` — enum with ``.label`` (e.g. ``alert:drift-stuck``).
+* ``alert_issue_title(alert_type, subject)`` — canonical dedupable
+  title ``[<label>] <subject>``.
+* ``find_existing_alert_issue(platform_slug, *, alert_type, subject,
+  runner)`` — ``gh issue list`` wrapper that looks up the dedupe
+  target by title.
+* ``open_alert_issue(platform_slug, *, alert_type, subject, body,
+  runner, dry_run)`` — idempotent issue opener. Returns
+  ``{"number": int, "title": str, "created": bool}``.
+* ``close_alert_issue(platform_slug, *, alert_type, subject, runner,
+  dry_run, close_comment)`` — idempotent issue closer. Returns
+  ``{"number": int, "closed": bool}``.
+* ``resolve_alert_type(name_or_label)`` — string-to-enum helper for
+  CLI entry points.
+"""
+
+from __future__ import absolute_import
+
+import enum
+import json
+import subprocess  # nosec B404 # noqa: S404 — gh CLI wrapper; args are controlled
+import sys
+from pathlib import Path
+from typing import Any, Callable, List, Mapping, Optional
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+ProcessRunner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+class AlertType(enum.Enum):
+    """The 8 platform alert types from ``docs/QZP-V2-DESIGN.md`` §8."""
+
+    REGRESSION = "alert:regression"
+    DEADLINE_MISSED = "alert:deadline-missed"
+    ESCALATION = "alert:escalation"
+    BYPASS_STALE = "alert:bypass-stale"
+    DRIFT_STUCK = "alert:drift-stuck"
+    FLEET_BUMP_FAIL = "alert:fleet-bump-fail"
+    REPO_NOT_PROFILED = "alert:repo-not-profiled"
+    FLAG_MISSING = "alert:flag-missing"
+
+    @property
+    def label(self) -> str:
+        """Return the GitHub issue label string (e.g. ``alert:regression``)."""
+        return str(self.value)
+
+
+def alert_issue_title(alert_type: AlertType, subject: str) -> str:
+    """Canonical dedupable issue title: ``[<label>] <subject>``."""
+    return f"[{alert_type.label}] {subject}"
+
+
+def resolve_alert_type(name_or_label: str) -> AlertType:
+    """Parse ``alert:<slug>`` or bare ``<slug>`` into an ``AlertType``."""
+    normalised = name_or_label.strip()
+    if not normalised.startswith("alert:"):
+        normalised = f"alert:{normalised}"
+    for member in AlertType:
+        if member.label == normalised:
+            return member
+    raise ValueError(f"unknown alert label: {name_or_label!r}")
+
+
+def _run_gh(
+    args: List[str], *, runner: ProcessRunner,
+) -> "subprocess.CompletedProcess[str]":
+    """Invoke ``gh`` with shared defaults (capture, text, check=False)."""
+    return runner(
+        ["gh", *args], capture_output=True, text=True, check=False,
+    )  # nosec B603 — gh args are controlled by call site
+
+
+def find_existing_alert_issue(
+    platform_slug: str,
+    *,
+    alert_type: AlertType,
+    subject: str,
+    runner: ProcessRunner = subprocess.run,
+) -> Optional[Mapping[str, Any]]:
+    """Return a matching open alert issue for ``(alert_type, subject)``."""
+    args = [
+        "issue", "list",
+        "--repo", platform_slug,
+        "--label", alert_type.label,
+        "--state", "open",
+        "--search", subject,
+        "--json", "number,title,state",
+        "--limit", "100",
+    ]
+    completed = _run_gh(args, runner=runner)
+    payload = json.loads(completed.stdout) if completed.stdout else []
+    if not isinstance(payload, list):
+        return None
+    expected_title = alert_issue_title(alert_type, subject)
+    for issue in payload:
+        if isinstance(issue, Mapping) and issue.get("title") == expected_title:
+            return issue
+    return None
+
+
+def _issue_number_from_create_output(stdout: str) -> int:
+    """Parse ``gh issue create`` URL output (trailing ``/<n>``) to int."""
+    if not stdout:
+        return 0
+    tail = stdout.rstrip().rsplit("/", 1)[-1]
+    try:
+        return int(tail)
+    except ValueError:
+        return 0
+
+
+def _create_alert_issue(
+    platform_slug: str,
+    *,
+    alert_type: AlertType,
+    subject: str,
+    body: str,
+    runner: ProcessRunner,
+) -> Mapping[str, Any]:
+    """Create the issue on ``platform_slug`` and return the record."""
+    title = alert_issue_title(alert_type, subject)
+    args = [
+        "issue", "create",
+        "--repo", platform_slug,
+        "--title", title,
+        "--label", alert_type.label,
+        "--body", body,
+    ]
+    completed = _run_gh(args, runner=runner)
+    return {
+        "number": _issue_number_from_create_output(completed.stdout),
+        "title": title,
+        "created": True,
+    }
+
+
+def open_alert_issue(
+    platform_slug: str,
+    *,
+    alert_type: AlertType,
+    subject: str,
+    body: str,
+    runner: ProcessRunner = subprocess.run,
+    dry_run: bool = False,
+) -> Mapping[str, Any]:
+    """Open a new alert issue, or reuse an existing one if already open."""
+    title = alert_issue_title(alert_type, subject)
+    if dry_run:
+        return {"number": 0, "title": title, "created": False}
+    existing = find_existing_alert_issue(
+        platform_slug,
+        alert_type=alert_type,
+        subject=subject,
+        runner=runner,
+    )
+    if existing is not None:
+        return {
+            "number": int(existing.get("number", 0)),
+            "title": str(existing.get("title", title)),
+            "created": False,
+        }
+    return _create_alert_issue(
+        platform_slug,
+        alert_type=alert_type,
+        subject=subject,
+        body=body,
+        runner=runner,
+    )
+
+
+def close_alert_issue(
+    platform_slug: str,
+    *,
+    alert_type: AlertType,
+    subject: str,
+    runner: ProcessRunner = subprocess.run,
+    dry_run: bool = False,
+    close_comment: str = "",
+) -> Mapping[str, Any]:
+    """Close a matching open alert issue, if one exists."""
+    if dry_run:
+        return {"number": 0, "closed": False}
+    existing = find_existing_alert_issue(
+        platform_slug,
+        alert_type=alert_type,
+        subject=subject,
+        runner=runner,
+    )
+    if existing is None:
+        return {"number": 0, "closed": False}
+    issue_number = int(existing.get("number", 0))
+    args: List[str] = [
+        "issue", "close", str(issue_number),
+        "--repo", platform_slug,
+    ]
+    if close_comment:
+        args.extend(["--comment", close_comment])
+    _run_gh(args, runner=runner)
+    return {"number": issue_number, "closed": True}
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform-slug", required=True)
+    parser.add_argument("--alert", required=True, help="alert label or suffix")
+    parser.add_argument("--subject", required=True)
+    parser.add_argument("--body", default="", help="Issue body for open")
+    parser.add_argument("--close", action="store_true", help="Close instead of open")
+    parser.add_argument("--dry-run", action="store_true")
+    _args = parser.parse_args()
+
+    _alert_type = resolve_alert_type(_args.alert)
+    if _args.close:
+        _result = close_alert_issue(
+            _args.platform_slug,
+            alert_type=_alert_type,
+            subject=_args.subject,
+            dry_run=_args.dry_run,
+        )
+    else:
+        _result = open_alert_issue(
+            _args.platform_slug,
+            alert_type=_alert_type,
+            subject=_args.subject,
+            body=_args.body,
+            dry_run=_args.dry_run,
+        )
+    print(json.dumps(_result, indent=2, sort_keys=True))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,318 @@
+"""Tests for the Phase 5 ``scripts.quality.alerts`` module.
+
+Covers the 8 alert types from ``docs/QZP-V2-DESIGN.md`` §8:
+``regression``, ``deadline-missed``, ``escalation``, ``bypass-stale``,
+``drift-stuck``, ``fleet-bump-fail``, ``repo-not-profiled``,
+``flag-missing``. Every event opens (or dedupes) a dedicated
+GitHub issue — no digest, per the design.
+"""
+
+from __future__ import absolute_import
+
+import json
+import subprocess
+import unittest
+from typing import List
+from unittest.mock import MagicMock
+
+from scripts.quality import alerts
+
+
+def _fake_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Build a lightweight ``CompletedProcess`` for runner doubles."""
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+class AlertTypeRegistryTests(unittest.TestCase):
+    """The design spec's 8 alert types are all registered with labels."""
+
+    def test_every_documented_alert_type_has_a_label(self) -> None:
+        """All 8 alert:* labels from §8 are exposed as ``AlertType`` members."""
+        expected_labels = {
+            "alert:regression",
+            "alert:deadline-missed",
+            "alert:escalation",
+            "alert:bypass-stale",
+            "alert:drift-stuck",
+            "alert:fleet-bump-fail",
+            "alert:repo-not-profiled",
+            "alert:flag-missing",
+        }
+        actual_labels = {member.label for member in alerts.AlertType}
+        self.assertEqual(actual_labels, expected_labels)
+
+    def test_label_is_stable_string(self) -> None:
+        """``AlertType.label`` is the enum's canonical GitHub label string."""
+        self.assertEqual(
+            alerts.AlertType.REGRESSION.label, "alert:regression",
+        )
+        self.assertEqual(
+            alerts.AlertType.FLAG_MISSING.label, "alert:flag-missing",
+        )
+
+
+class AlertTitleTests(unittest.TestCase):
+    """``alert_issue_title`` produces dedupable ``[label] subject`` strings."""
+
+    def test_title_format_is_bracket_label_space_subject(self) -> None:
+        """``[alert:drift-stuck] org/repo`` canonical format."""
+        title = alerts.alert_issue_title(
+            alerts.AlertType.DRIFT_STUCK, "org/repo",
+        )
+        self.assertEqual(title, "[alert:drift-stuck] org/repo")
+
+    def test_title_preserves_subject_punctuation_for_flag_alerts(self) -> None:
+        """``alert:flag-missing`` carries ``slug:flag`` subjects literally."""
+        title = alerts.alert_issue_title(
+            alerts.AlertType.FLAG_MISSING, "Prekzursil/event-link:frontend",
+        )
+        self.assertEqual(
+            title, "[alert:flag-missing] Prekzursil/event-link:frontend",
+        )
+
+
+class FindExistingAlertIssueTests(unittest.TestCase):
+    """``find_existing_alert_issue`` is dedupe-by-title over gh issue list."""
+
+    def test_match_found_returns_the_issue_mapping(self) -> None:
+        """When gh returns an issue with matching title, it is returned."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"number": 42, "title": "[alert:drift-stuck] org/repo", "state": "open"},
+            {"number": 99, "title": "other-thing", "state": "open"},
+        ])))
+        issue = alerts.find_existing_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.DRIFT_STUCK,
+            subject="org/repo",
+            runner=runner,
+        )
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue["number"], 42)
+
+    def test_no_match_returns_none(self) -> None:
+        """When no matching title in gh output, return None."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"number": 99, "title": "unrelated", "state": "open"},
+        ])))
+        issue = alerts.find_existing_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.DRIFT_STUCK,
+            subject="org/repo",
+            runner=runner,
+        )
+        self.assertIsNone(issue)
+
+    def test_empty_stdout_returns_none(self) -> None:
+        """gh returning empty output is treated as no matches."""
+        runner = MagicMock(return_value=_fake_completed(""))
+        issue = alerts.find_existing_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo",
+            runner=runner,
+        )
+        self.assertIsNone(issue)
+
+    def test_non_list_stdout_returns_none(self) -> None:
+        """Defensive: if gh returns a non-list JSON, never crash."""
+        runner = MagicMock(return_value=_fake_completed('{"error": "boom"}'))
+        issue = alerts.find_existing_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo",
+            runner=runner,
+        )
+        self.assertIsNone(issue)
+
+
+class OpenAlertIssueTests(unittest.TestCase):
+    """``open_alert_issue`` opens a new issue or reuses an existing one."""
+
+    def test_dry_run_returns_stub_without_calling_gh(self) -> None:
+        """Dry run returns a stub record and never invokes the runner."""
+        runner = MagicMock()
+        result = alerts.open_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo",
+            body="Body text",
+            runner=runner,
+            dry_run=True,
+        )
+        self.assertFalse(result["created"])
+        self.assertEqual(result["number"], 0)
+        runner.assert_not_called()
+
+    def test_existing_open_issue_is_reused(self) -> None:
+        """When a matching open issue exists, ``created`` is False."""
+        list_result = _fake_completed(json.dumps([
+            {"number": 7, "title": "[alert:regression] org/repo", "state": "open"},
+        ]))
+        runner = MagicMock(return_value=list_result)
+        result = alerts.open_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo",
+            body="Cov dropped by 0.7%.",
+            runner=runner,
+        )
+        self.assertEqual(result["number"], 7)
+        self.assertFalse(result["created"])
+        # Only the list call should happen — never the create call.
+        self.assertEqual(runner.call_count, 1)
+
+    def test_create_new_issue_when_none_exists(self) -> None:
+        """Happy path: one list call + one create call; parses issue number."""
+        responses: List[subprocess.CompletedProcess] = [
+            _fake_completed(json.dumps([])),
+            _fake_completed(
+                "https://github.com/Prekzursil/quality-zero-platform/issues/314\n",
+            ),
+        ]
+        runner = MagicMock(side_effect=responses)
+        result = alerts.open_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo",
+            body="Coverage regression detected on main.",
+            runner=runner,
+        )
+        self.assertEqual(result["number"], 314)
+        self.assertTrue(result["created"])
+        self.assertEqual(runner.call_count, 2)
+
+    def test_create_without_url_tail_returns_zero(self) -> None:
+        """Defensive: a non-URL stdout yields number=0 but created=True."""
+        responses: List[subprocess.CompletedProcess] = [
+            _fake_completed(json.dumps([])),
+            _fake_completed("some random gh stdout\n"),
+        ]
+        runner = MagicMock(side_effect=responses)
+        result = alerts.open_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.FLAG_MISSING,
+            subject="org/repo:frontend",
+            body="Flag 'frontend' declared but no Codecov report.",
+            runner=runner,
+        )
+        self.assertEqual(result["number"], 0)
+        self.assertTrue(result["created"])
+
+    def test_create_with_empty_stdout_returns_zero(self) -> None:
+        """``gh issue create`` with no stdout gives number=0 but created=True."""
+        responses: List[subprocess.CompletedProcess] = [
+            _fake_completed(json.dumps([])),
+            _fake_completed(""),
+        ]
+        runner = MagicMock(side_effect=responses)
+        result = alerts.open_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.BYPASS_STALE,
+            subject="org/repo",
+            body="bypass open > 7 days",
+            runner=runner,
+        )
+        self.assertEqual(result["number"], 0)
+        self.assertTrue(result["created"])
+
+
+class CloseAlertIssueTests(unittest.TestCase):
+    """``close_alert_issue`` closes a matching open issue, if any."""
+
+    def test_dry_run_returns_stub_without_calling_gh(self) -> None:
+        """Dry run never invokes the runner."""
+        runner = MagicMock()
+        result = alerts.close_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.DRIFT_STUCK,
+            subject="org/repo",
+            runner=runner,
+            dry_run=True,
+        )
+        self.assertFalse(result["closed"])
+        self.assertEqual(result["number"], 0)
+        runner.assert_not_called()
+
+    def test_no_matching_issue_returns_unclosed_stub(self) -> None:
+        """When list returns no match, closed=False, number=0."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([])))
+        result = alerts.close_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.DRIFT_STUCK,
+            subject="org/repo",
+            runner=runner,
+        )
+        self.assertFalse(result["closed"])
+
+    def test_closes_matching_open_issue(self) -> None:
+        """When a matching issue exists, ``gh issue close`` is called."""
+        responses: List[subprocess.CompletedProcess] = [
+            _fake_completed(json.dumps([
+                {"number": 11, "title": "[alert:drift-stuck] org/repo", "state": "open"},
+            ])),
+            _fake_completed(""),  # gh close is silent on success.
+        ]
+        runner = MagicMock(side_effect=responses)
+        result = alerts.close_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.DRIFT_STUCK,
+            subject="org/repo",
+            runner=runner,
+            close_comment="sync PR merged — clearing",
+        )
+        self.assertTrue(result["closed"])
+        self.assertEqual(result["number"], 11)
+        self.assertEqual(runner.call_count, 2)
+        # Truthy close_comment branch → --comment present in close args.
+        close_args = runner.call_args_list[1].args[0]
+        self.assertIn("--comment", close_args)
+
+    def test_close_without_comment_skips_comment_flag(self) -> None:
+        """Empty ``close_comment`` → ``gh issue close`` is called without --comment."""
+        responses: List[subprocess.CompletedProcess] = [
+            _fake_completed(json.dumps([
+                {"number": 22, "title": "[alert:flag-missing] org/repo:frontend", "state": "open"},
+            ])),
+            _fake_completed(""),
+        ]
+        runner = MagicMock(side_effect=responses)
+        result = alerts.close_alert_issue(
+            "Prekzursil/quality-zero-platform",
+            alert_type=alerts.AlertType.FLAG_MISSING,
+            subject="org/repo:frontend",
+            runner=runner,
+        )
+        self.assertTrue(result["closed"])
+        self.assertEqual(result["number"], 22)
+        # Falsy close_comment branch → --comment NOT added.
+        close_args = runner.call_args_list[1].args[0]
+        self.assertNotIn("--comment", close_args)
+
+
+class ResolveAlertTypeTests(unittest.TestCase):
+    """``resolve_alert_type`` parses label strings back to enum members."""
+
+    def test_known_label_returns_enum(self) -> None:
+        """``alert:regression`` → ``AlertType.REGRESSION``."""
+        self.assertEqual(
+            alerts.resolve_alert_type("alert:regression"),
+            alerts.AlertType.REGRESSION,
+        )
+
+    def test_bare_suffix_also_resolves(self) -> None:
+        """``regression`` (no prefix) also resolves for CLI ergonomics."""
+        self.assertEqual(
+            alerts.resolve_alert_type("regression"),
+            alerts.AlertType.REGRESSION,
+        )
+
+    def test_unknown_label_raises(self) -> None:
+        """``alert:nonexistent`` raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            alerts.resolve_alert_type("alert:nope-does-not-exist")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Phase 5 increment 1: adds `scripts/quality/alerts.py`, the per-event alert issue dispatcher for the 8 alert types defined in `docs/QZP-V2-DESIGN.md` §8.

This module is the foundation the rest of Phase 5 (bootstrap, bumps, dashboard) will call into when synthetic triggers fire. It does NOT wire the triggers themselves yet — those arrive in follow-up increments (tracked as tasks 38-42).

## Design notes

- **One-shot per-event, no digest** — every event gets its own issue (deduped by canonical title `[<label>] <subject>`). Per the design doc: _"Per-event issues only — no digest at all"_.
- **`AlertType` enum** carries `.label` attribute: `AlertType.REGRESSION.label == "alert:regression"`.
- **`ProcessRunner` dependency injection** — every `gh` call goes through `_run_gh(args, runner=...)`, so the module is fully testable with `MagicMock`.
- **Dry-run support** on both `open_alert_issue` and `close_alert_issue` so synthetic triggers can safely round-trip without actually opening issues.
- **Complexity**: max function CCN = 9 (under Lizard's 15 threshold).

## Alert types covered

| AlertType | Label |
|---|---|
| `REGRESSION` | `alert:regression` |
| `DEADLINE_MISSED` | `alert:deadline-missed` |
| `ESCALATION` | `alert:escalation` |
| `BYPASS_STALE` | `alert:bypass-stale` |
| `DRIFT_STUCK` | `alert:drift-stuck` |
| `FLEET_BUMP_FAIL` | `alert:fleet-bump-fail` |
| `REPO_NOT_PROFILED` | `alert:repo-not-profiled` |
| `FLAG_MISSING` | `alert:flag-missing` |

`fleet_inventory.py` already has its own `alert:repo-not-profiled` opener — that survives unchanged for now; the new module is the generalized replacement that future callers will use (refactor to unify comes in a later increment to keep this PR small).

## Test plan

- [x] `tests/test_alerts.py` — 20 tests covering enum registry, title format, dedupe lookup, open (dry-run / existing / new / URL parse / empty stdout), close (dry-run / no match / with comment / without comment), label resolution
- [x] Coverage: 100% (81 stmts / 24 branches)
- [x] Full suite: 1247 passed, 1 skipped, 29 subtests
- [x] Lizard: max CCN 9, under the 15 gate
- [x] Semgrep: clean
- [x] Codacy metric-engine exclude added (matches pattern from prior net-new CLI modules)

Part of QZP v2 Phase 5 (see `docs/QZP-V2-DESIGN.md` §4, §8). Follow-up increments tracked in tasks 38-42.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-event alert issue dispatcher for QZP v2 Phase 5 that opens/closes GitHub issues for 8 alert types and dedupes by a canonical title.

- **New Features**
  - Added `scripts/quality/alerts.py` implementing per-event issues for 8 alert types with `[<label>] <subject>` dedupe.
  - Public API: `AlertType`, `alert_issue_title`, `find_existing_alert_issue`, `open_alert_issue`, `close_alert_issue`, `resolve_alert_type`.
  - Idempotent open/close with dry-run support and `ProcessRunner` injection for testability.
  - Tests added; `.codacy.yaml` updated to exclude the new module. Triggers will call this in follow-up increments.

<sup>Written for commit 550c2d960dec20c79503e094dfc48a2b3c9df55c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Add per-event alert issue handling for the Phase 5 quality workflow

### What Changed
- Adds support for all 8 alert types with stable `alert:<slug>` labels and a standard `[label] subject` issue title for deduping repeated events
- Opens alert issues only when no matching open issue already exists, and closes matching issues without changing anything when none are found
- Supports dry-run mode for both opening and closing, so alerts can be checked without creating changes
- Accepts either full alert labels or bare alert names when resolving an alert type from the command line
- Adds tests covering label mapping, deduping, dry-run behavior, issue creation, issue closing, and invalid alert names

### Impact
`✅ Fewer duplicate alert issues`
`✅ Safer alert checks in dry-run mode`
`✅ Clearer issue titles for each alert event`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=MxsJhMw0xoWaLtP1SyEudJ00KDDyGftqZmXtaf_ufjg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
