### PR TITLE
feat(qzp-v2 phase 5 inc-2): reusable-bootstrap-repo workflow + shadow→absolute promoter

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -31,6 +31,7 @@ engines:
       - "scripts/quality/drift_sync.py"
       - "scripts/quality/apply_drift_pr.py"
       - "scripts/quality/alerts.py"
+      - "scripts/quality/bootstrap_repo.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/.github/workflows/reusable-bootstrap-repo.yml
+++ b/.github/workflows/reusable-bootstrap-repo.yml
@@ -1,0 +1,147 @@
+name: Reusable Bootstrap Repo
+
+# QZP v2 Phase 5 §5.4 — bootstrap a new consumer repo through the
+# shadow-mode lifecycle. Today this workflow implements the
+# *promotion* half: poll ``gh run list`` on the target's default
+# branch, count 3 consecutive green shadow runs, then open a PR on
+# the platform repo that flips ``mode.phase: shadow`` →
+# ``mode.phase: absolute`` (or ``ratchet``). The initial onboarding
+# step (create profile from stack defaults, open consumer PR) is
+# tracked in Phase 5 inc-2.5 and will land as an extension to this
+# workflow.
+#
+# Callers dispatch this workflow from the platform repo via the UI
+# or ``gh workflow run`` once a repo has been onboarded in shadow
+# mode. Re-running it is idempotent — if not enough greens have
+# accumulated, the job exits clean without opening a promotion PR.
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_slug:
+        type: string
+        required: true
+        description: "Target consumer repo, ``owner/name``. Used to poll CI."
+      profile_path:
+        type: string
+        required: true
+        description: "Path to the profile in this repo, e.g. ``profiles/repos/event-link.yml``."
+      workflow_name:
+        type: string
+        required: false
+        default: quality-rollup.yml
+        description: "Workflow file name polled on the consumer repo."
+      branch:
+        type: string
+        required: false
+        default: main
+        description: "Target branch on the consumer repo whose runs we count."
+      target_phase:
+        type: choice
+        required: true
+        options: [ratchet, absolute]
+        description: "Mode to flip to once 3 greens land."
+      required_green:
+        type: string
+        required: false
+        default: "3"
+        description: "Minimum consecutive green runs before promoting."
+
+concurrency:
+  group: bootstrap-repo-${{ inputs.repo_slug }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Compute promotion plan
+        id: plan
+        env:
+          BOOTSTRAP_REPO_SLUG: ${{ inputs.repo_slug }}
+          BOOTSTRAP_PROFILE: ${{ inputs.profile_path }}
+          BOOTSTRAP_WORKFLOW: ${{ inputs.workflow_name }}
+          BOOTSTRAP_BRANCH: ${{ inputs.branch }}
+          BOOTSTRAP_TARGET_PHASE: ${{ inputs.target_phase }}
+          BOOTSTRAP_REQUIRED: ${{ inputs.required_green }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from scripts.quality import bootstrap_repo as br
+
+          slug = os.environ["BOOTSTRAP_REPO_SLUG"].strip()
+          profile_path = Path(os.environ["BOOTSTRAP_PROFILE"].strip())
+          workflow = os.environ["BOOTSTRAP_WORKFLOW"].strip()
+          branch = os.environ["BOOTSTRAP_BRANCH"].strip()
+          target_phase = os.environ["BOOTSTRAP_TARGET_PHASE"].strip()
+          required = int(os.environ.get("BOOTSTRAP_REQUIRED", "3"))
+
+          profile_text = profile_path.read_text(encoding="utf-8")
+          plan = br.compute_promotion_plan(
+              slug=slug,
+              workflow=workflow,
+              branch=branch,
+              profile_yaml=profile_text,
+              target_phase=target_phase,
+              required_green=required,
+          )
+
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"ready={'true' if plan['ready'] else 'false'}\n")
+                  fh.write(f"green_runs={plan['green_runs']}\n")
+
+          if plan["ready"]:
+              profile_path.write_text(plan["promoted_yaml"], encoding="utf-8")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write("## Bootstrap Repo — Promotion Plan\n\n")
+                  fh.write(f"- Target: `{slug}`\n")
+                  fh.write(f"- Profile: `{profile_path}`\n")
+                  fh.write(f"- Workflow polled: `{workflow}` on `{branch}`\n")
+                  fh.write(f"- Green runs: **{plan['green_runs']}** / required **{required}**\n")
+                  verdict = "READY — promotion PR opens next step" if plan["ready"] else "NOT READY — will re-run later"
+                  fh.write(f"- Verdict: **{verdict}**\n")
+          PY
+
+      - name: Open promotion PR on platform
+        if: ${{ steps.plan.outputs.ready == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BOOTSTRAP_REPO_SLUG: ${{ inputs.repo_slug }}
+          BOOTSTRAP_PROFILE: ${{ inputs.profile_path }}
+          BOOTSTRAP_TARGET_PHASE: ${{ inputs.target_phase }}
+        run: |
+          set -euo pipefail
+          slug_safe="${BOOTSTRAP_REPO_SLUG//\//-}"
+          branch_name="bootstrap/promote-${slug_safe}-${BOOTSTRAP_TARGET_PHASE}"
+          git config user.email "platform-bot@quality-zero.local"
+          git config user.name "quality-zero-platform bootstrap"
+          git checkout -b "$branch_name"
+          git add "$BOOTSTRAP_PROFILE"
+          git commit -m "feat(bootstrap): promote ${BOOTSTRAP_REPO_SLUG} mode.phase → ${BOOTSTRAP_TARGET_PHASE}"
+          git push -u origin "$branch_name"
+          gh pr create \
+            --title "feat(bootstrap): promote ${BOOTSTRAP_REPO_SLUG} → ${BOOTSTRAP_TARGET_PHASE}" \
+            --body "Automated promotion from \`reusable-bootstrap-repo.yml\`. 3 consecutive green shadow runs observed on \`${BOOTSTRAP_REPO_SLUG}\`. Promoting \`mode.phase\` to \`${BOOTSTRAP_TARGET_PHASE}\`." \
+            --label "quality-zero:bootstrap-promote" || true

--- a/scripts/quality/bootstrap_repo.py
+++ b/scripts/quality/bootstrap_repo.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Phase 5 shadow-mode bootstrap primitives.
+
+Powers ``reusable-bootstrap-repo.yml`` — the workflow that onboards a new
+consumer repo via 3-consecutive-green-shadow-runs before flipping the
+``mode.phase`` from ``shadow`` → ``absolute`` (or ``ratchet``).
+
+Primitives:
+
+* ``count_consecutive_green_shadow_runs(slug, workflow, branch, runner)``
+  — walks ``gh run list`` newest-first and counts contiguous
+  ``conclusion == "success"`` runs. ``in_progress`` runs are skipped
+  (neither counted nor a stopper). A non-success completed run is the
+  stopper.
+* ``should_promote(green_run_count, required=3)`` — trivial gate
+  predicate that keeps the 3-green threshold adjustable in tests +
+  future policy work.
+* ``promote_profile(profile_yaml, target_phase)`` — text-level rewriter
+  that flips ``mode.phase: shadow`` → ``mode.phase: <target_phase>`` and
+  rewrites ``shadow_until: <date>`` → ``shadow_until: null``. Byte-for-
+  byte preserves every other line so downstream diffs are minimal.
+* ``compute_promotion_plan(...)`` — convenience composition returning
+  ``{"ready", "green_runs", "promoted_yaml"}`` for the workflow step.
+
+The module is deliberately IO-free: callers pass ``ProcessRunner`` in to
+run gh, and pass ``profile_yaml`` in as text (not a file path). This
+keeps every function unit-testable without disk or network.
+"""
+
+from __future__ import absolute_import
+
+import json
+import re
+import subprocess  # nosec B404 # noqa: S404 — gh CLI wrapper; args are controlled
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+ProcessRunner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+ALLOWED_TARGET_PHASES = ("ratchet", "absolute")
+DEFAULT_GREEN_RUN_THRESHOLD = 3
+
+
+_PHASE_LINE_RE = re.compile(r"^(?P<indent>\s*)phase:\s*(?P<phase>\S+)\s*$")
+_SHADOW_UNTIL_LINE_RE = re.compile(r"^(?P<indent>\s*)shadow_until:\s*.+$")
+
+
+def _run_gh(
+    args: List[str], *, runner: ProcessRunner,
+) -> "subprocess.CompletedProcess[str]":
+    """Invoke ``gh`` with shared defaults (capture, text, check=False)."""
+    return runner(
+        ["gh", *args], capture_output=True, text=True, check=False,
+    )  # nosec B603 — gh args are controlled
+
+
+def count_consecutive_green_shadow_runs(
+    *,
+    slug: str,
+    workflow: str,
+    branch: str,
+    runner: ProcessRunner = subprocess.run,
+    limit: int = 25,
+) -> int:
+    """Count contiguous newest-first green runs of ``workflow`` on ``branch``."""
+    args = [
+        "run", "list",
+        "--repo", slug,
+        "--workflow", workflow,
+        "--branch", branch,
+        "--limit", str(limit),
+        "--json", "conclusion,status",
+    ]
+    completed = _run_gh(args, runner=runner)
+    payload = json.loads(completed.stdout) if completed.stdout else []
+    if not isinstance(payload, list):
+        return 0
+    consecutive = 0
+    for run in payload:
+        if not isinstance(run, dict):
+            break
+        status = str(run.get("status", ""))
+        if status != "completed":
+            # in_progress / queued runs neither count nor break the streak.
+            continue
+        if str(run.get("conclusion", "")) == "success":
+            consecutive += 1
+            continue
+        break
+    return consecutive
+
+
+def should_promote(
+    *, green_run_count: int, required: int = DEFAULT_GREEN_RUN_THRESHOLD,
+) -> bool:
+    """Return True iff ``green_run_count`` meets/exceeds ``required``."""
+    return green_run_count >= required
+
+
+def promote_profile(profile_yaml: str, *, target_phase: str) -> str:
+    """Rewrite ``mode.phase`` and clear ``shadow_until`` in ``profile_yaml``."""
+    if target_phase not in ALLOWED_TARGET_PHASES:
+        raise ValueError(
+            f"target_phase must be one of {ALLOWED_TARGET_PHASES}; "
+            f"got {target_phase!r}",
+        )
+    rewritten_lines: List[str] = []
+    found_shadow_phase = False
+    for line in profile_yaml.splitlines(keepends=True):
+        phase_match = _PHASE_LINE_RE.match(line.rstrip("\n").rstrip("\r"))
+        if phase_match and phase_match.group("phase") == "shadow":
+            found_shadow_phase = True
+            indent = phase_match.group("indent")
+            rewritten_lines.append(f"{indent}phase: {target_phase}\n")
+            continue
+        shadow_match = _SHADOW_UNTIL_LINE_RE.match(
+            line.rstrip("\n").rstrip("\r"),
+        )
+        if shadow_match:
+            indent = shadow_match.group("indent")
+            rewritten_lines.append(f"{indent}shadow_until: null\n")
+            continue
+        rewritten_lines.append(line)
+    if not found_shadow_phase:
+        raise ValueError(
+            "promote_profile requires an existing 'mode.phase: shadow' line; "
+            "profile is already past shadow phase.",
+        )
+    return "".join(rewritten_lines)
+
+
+def compute_promotion_plan(
+    *,
+    slug: str,
+    workflow: str,
+    branch: str,
+    profile_yaml: str,
+    target_phase: str,
+    runner: ProcessRunner = subprocess.run,
+    required_green: int = DEFAULT_GREEN_RUN_THRESHOLD,
+) -> Dict[str, Any]:
+    """Return ``{ready, green_runs, promoted_yaml}`` summary for the workflow."""
+    green_runs = count_consecutive_green_shadow_runs(
+        slug=slug, workflow=workflow, branch=branch, runner=runner,
+    )
+    ready = should_promote(
+        green_run_count=green_runs, required=required_green,
+    )
+    promoted_yaml = (
+        promote_profile(profile_yaml, target_phase=target_phase)
+        if ready else ""
+    )
+    return {
+        "ready": ready,
+        "green_runs": green_runs,
+        "promoted_yaml": promoted_yaml,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--profile", required=True, help="Path to profile YAML")
+    parser.add_argument("--target-phase", required=True, choices=list(ALLOWED_TARGET_PHASES))
+    parser.add_argument("--required", type=int, default=DEFAULT_GREEN_RUN_THRESHOLD)
+    parser.add_argument("--out", default="", help="Write promoted YAML here; stdout otherwise")
+    _args = parser.parse_args()
+
+    _profile_text = Path(_args.profile).read_text(encoding="utf-8")
+    _plan = compute_promotion_plan(
+        slug=_args.slug,
+        workflow=_args.workflow,
+        branch=_args.branch,
+        profile_yaml=_profile_text,
+        target_phase=_args.target_phase,
+        required_green=_args.required,
+    )
+    print(json.dumps(
+        {"ready": _plan["ready"], "green_runs": _plan["green_runs"]},
+        indent=2, sort_keys=True,
+    ))
+    if _plan["ready"]:
+        if _args.out:
+            Path(_args.out).write_text(_plan["promoted_yaml"], encoding="utf-8")
+        else:
+            print(_plan["promoted_yaml"])

--- a/tests/test_bootstrap_repo.py
+++ b/tests/test_bootstrap_repo.py
@@ -1,0 +1,262 @@
+"""Tests for Phase 5 ``scripts.quality.bootstrap_repo``.
+
+Exercises the two primitives the ``reusable-bootstrap-repo.yml``
+workflow relies on:
+
+* ``count_consecutive_green_shadow_runs`` — walks CI history on the
+  onboarding repo's default branch from newest to oldest and counts
+  how many consecutive runs had ``conclusion == "success"`` for the
+  named workflow. Stops at the first non-green or non-existent run.
+* ``promote_profile`` — applies the shadow→target mode flip to the
+  profile YAML text (preserves everything else, updates only the
+  ``mode.phase`` line and clears ``mode.shadow_until``).
+"""
+
+from __future__ import absolute_import
+
+import json
+import subprocess
+import unittest
+from unittest.mock import MagicMock
+
+from scripts.quality import bootstrap_repo as br
+
+
+def _fake_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Helper: lightweight ``CompletedProcess`` double for runner mocks."""
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+class CountConsecutiveGreenShadowRunsTests(unittest.TestCase):
+    """``count_consecutive_green_shadow_runs`` walks gh run list output."""
+
+    def test_all_green_returns_full_count(self) -> None:
+        """3/3 newest-first green runs → 3."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+        ])))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 3)
+
+    def test_stops_at_first_failure(self) -> None:
+        """Greens before a failure → up to the failure only."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "failure", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+        ])))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 2)
+
+    def test_in_progress_run_is_skipped_not_counted(self) -> None:
+        """An ``in_progress`` run is neither counted nor a stopper."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "", "status": "in_progress"},
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+        ])))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 2)
+
+    def test_empty_history_returns_zero(self) -> None:
+        """``gh run list`` returning ``[]`` → 0 green runs."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([])))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 0)
+
+    def test_empty_stdout_returns_zero(self) -> None:
+        """Defensive: empty gh stdout → 0."""
+        runner = MagicMock(return_value=_fake_completed(""))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 0)
+
+    def test_non_list_payload_returns_zero(self) -> None:
+        """Defensive: gh returns non-list JSON → 0."""
+        runner = MagicMock(return_value=_fake_completed('{"error": "nope"}'))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 0)
+
+    def test_non_dict_element_breaks_the_streak(self) -> None:
+        """Defensive: a non-mapping element interrupts counting."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "success", "status": "completed"},
+            "not-a-dict",
+            {"conclusion": "success", "status": "completed"},
+        ])))
+        count = br.count_consecutive_green_shadow_runs(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            runner=runner,
+        )
+        self.assertEqual(count, 1)
+
+
+class ShouldPromoteTests(unittest.TestCase):
+    """``should_promote`` is the 3-green-in-a-row gate predicate."""
+
+    def test_three_greens_default_threshold_promotes(self) -> None:
+        """3 ≥ default threshold of 3 → True."""
+        self.assertTrue(br.should_promote(green_run_count=3))
+
+    def test_more_than_threshold_promotes(self) -> None:
+        """Any excess over threshold still promotes."""
+        self.assertTrue(br.should_promote(green_run_count=10))
+
+    def test_below_default_threshold_does_not_promote(self) -> None:
+        """2/3 → False."""
+        self.assertFalse(br.should_promote(green_run_count=2))
+
+    def test_custom_threshold_honoured(self) -> None:
+        """Caller can relax/tighten the threshold."""
+        self.assertTrue(br.should_promote(green_run_count=5, required=5))
+        self.assertFalse(br.should_promote(green_run_count=4, required=5))
+
+
+class PromoteProfileTests(unittest.TestCase):
+    """``promote_profile`` flips the mode.phase + clears shadow_until."""
+
+    def test_shadow_to_absolute_flips_phase_and_clears_shadow_until(self) -> None:
+        """``phase: shadow`` + ``shadow_until`` → ``absolute`` + null."""
+        src = (
+            "slug: Prekzursil/event-link\n"
+            "mode:\n"
+            "  phase: shadow\n"
+            "  shadow_until: 2026-06-30\n"
+            "coverage:\n"
+            "  min_percent: 100.0\n"
+        )
+        out = br.promote_profile(src, target_phase="absolute")
+        self.assertIn("phase: absolute", out)
+        self.assertIn("shadow_until: null", out)
+        self.assertNotIn("phase: shadow\n", out)
+        self.assertIn("slug: Prekzursil/event-link", out)
+        self.assertIn("min_percent: 100.0", out)
+
+    def test_shadow_to_ratchet_also_clears_shadow_until(self) -> None:
+        """Target ``ratchet`` clears the shadow deadline field."""
+        src = (
+            "mode:\n"
+            "  phase: shadow\n"
+            "  shadow_until: 2026-06-30\n"
+        )
+        out = br.promote_profile(src, target_phase="ratchet")
+        self.assertIn("phase: ratchet", out)
+        self.assertIn("shadow_until: null", out)
+
+    def test_rejects_invalid_target_phase(self) -> None:
+        """Target phase must be ``ratchet`` or ``absolute``."""
+        with self.assertRaises(ValueError):
+            br.promote_profile("mode:\n  phase: shadow\n", target_phase="nothing")
+
+    def test_rejects_source_that_is_not_shadow(self) -> None:
+        """Promoting an already-absolute profile is a no-op signal → ValueError."""
+        with self.assertRaises(ValueError):
+            br.promote_profile(
+                "mode:\n  phase: absolute\n  shadow_until: null\n",
+                target_phase="absolute",
+            )
+
+    def test_preserves_lines_other_than_mode(self) -> None:
+        """Everything outside ``mode:`` is preserved byte-for-byte."""
+        src = (
+            "slug: org/repo\n"
+            "stack: go\n"
+            "mode:\n"
+            "  phase: shadow\n"
+            "  shadow_until: 2026-12-31\n"
+            "scanners:\n"
+            "  codeql: { enabled: true, severity: block }\n"
+        )
+        out = br.promote_profile(src, target_phase="absolute")
+        # Non-mode lines unchanged.
+        self.assertIn("slug: org/repo\n", out)
+        self.assertIn("stack: go\n", out)
+        self.assertIn(
+            "scanners:\n  codeql: { enabled: true, severity: block }\n", out,
+        )
+
+
+class ComputePromotionPlanTests(unittest.TestCase):
+    """``compute_promotion_plan`` combines the primitives into a decision."""
+
+    def test_plan_ready_when_enough_greens(self) -> None:
+        """3 greens + target → ``ready=True``, promoted YAML included."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "success", "status": "completed"},
+        ])))
+        plan = br.compute_promotion_plan(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            profile_yaml=(
+                "slug: Prekzursil/event-link\n"
+                "mode:\n"
+                "  phase: shadow\n"
+                "  shadow_until: 2026-06-30\n"
+            ),
+            target_phase="absolute",
+            runner=runner,
+        )
+        self.assertTrue(plan["ready"])
+        self.assertEqual(plan["green_runs"], 3)
+        self.assertIn("phase: absolute", plan["promoted_yaml"])
+
+    def test_plan_not_ready_when_insufficient_greens(self) -> None:
+        """< 3 greens → ``ready=False``, no promoted YAML."""
+        runner = MagicMock(return_value=_fake_completed(json.dumps([
+            {"conclusion": "success", "status": "completed"},
+            {"conclusion": "failure", "status": "completed"},
+        ])))
+        plan = br.compute_promotion_plan(
+            slug="Prekzursil/event-link",
+            workflow="quality-rollup.yml",
+            branch="main",
+            profile_yaml="mode:\n  phase: shadow\n  shadow_until: null\n",
+            target_phase="absolute",
+            runner=runner,
+        )
+        self.assertFalse(plan["ready"])
+        self.assertEqual(plan["green_runs"], 1)
+        self.assertEqual(plan["promoted_yaml"], "")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_reusable_bootstrap_repo.py
+++ b/tests/test_reusable_bootstrap_repo.py
@@ -1,0 +1,101 @@
+"""Contract tests for ``reusable-bootstrap-repo.yml``.
+
+Phase 5 §5.4 workflow that promotes a consumer repo from ``shadow``
+to ``absolute`` / ``ratchet`` once 3 consecutive green CI runs land.
+Pins the inputs, env-var indirection (blocks Semgrep CWE-78), and
+the conditional PR-creation step so future edits can't silently
+drop either guarantee.
+"""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "reusable-bootstrap-repo.yml"
+)
+
+
+class ReusableBootstrapRepoWorkflowTests(unittest.TestCase):
+    """Invariants on the reusable-bootstrap-repo workflow."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_is_workflow_dispatch(self) -> None:
+        """Onboarding is manually triggered from the platform repo."""
+        # ``on:`` parses as YAML boolean True — access via that key.
+        self.assertIn("workflow_dispatch", self.doc[True])
+
+    def test_required_inputs_are_declared(self) -> None:
+        """Every field the Python planner reads must be a declared input."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        for required in ("repo_slug", "profile_path", "target_phase"):
+            with self.subTest(input=required):
+                self.assertIn(required, inputs)
+                self.assertTrue(inputs[required].get("required"))
+
+    def test_target_phase_limited_to_ratchet_or_absolute(self) -> None:
+        """``shadow`` is the starting state — cannot promote back to it."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        options = inputs["target_phase"].get("options", [])
+        self.assertEqual(sorted(options), ["absolute", "ratchet"])
+
+    def test_env_var_indirection_for_inputs(self) -> None:
+        """``${{ inputs.* }}`` is routed through env vars, not shell args."""
+        # All ${{ inputs.X }} usage in the body must be inside an ``env:`` block,
+        # never interpolated directly into a ``run: |`` step (Semgrep CWE-78).
+        for needle in ("${{ inputs.repo_slug }}", "${{ inputs.profile_path }}"):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.text)
+        # None of those interpolations should sit inside a python heredoc body —
+        # they should only appear on ``env:`` lines or on top-level step fields
+        # (``if:``, ``run:`` shell lines that reference env vars, etc.).
+        heredoc_bodies = re.findall(
+            r"<<'PY'(.+?)PY", self.text, flags=re.DOTALL,
+        )
+        for body in heredoc_bodies:
+            with self.subTest(body_excerpt=body[:60]):
+                self.assertNotIn("${{ inputs.", body)
+                self.assertNotIn("${{ github.", body)
+
+    def test_promotion_pr_step_gated_on_ready_output(self) -> None:
+        """Only open a PR when ``steps.plan.outputs.ready == 'true'``."""
+        promote_job = self.doc["jobs"]["promote"]
+        steps = promote_job["steps"]
+        gated_steps = [
+            s for s in steps if "if" in s and "steps.plan.outputs.ready" in s["if"]
+        ]
+        self.assertTrue(
+            gated_steps,
+            "No promotion PR step gated on 'ready' — the workflow would "
+            "open a PR every run, even when fewer than 3 greens accumulated.",
+        )
+
+    def test_concurrency_key_binds_to_slug(self) -> None:
+        """Prevent racing promotions on the same repo."""
+        concurrency = self.doc.get("concurrency", {})
+        self.assertIn("${{ inputs.repo_slug }}", str(concurrency.get("group", "")))
+
+    def test_permissions_are_narrow(self) -> None:
+        """Top-level perms empty; job perms limited to contents + pull-requests."""
+        self.assertEqual(self.doc.get("permissions"), {})
+        promote_job = self.doc["jobs"]["promote"]
+        perms = promote_job.get("permissions", {})
+        self.assertEqual(perms.get("contents"), "write")
+        self.assertEqual(perms.get("pull-requests"), "write")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Phase 5 increment 2: implements the *promotion* half of `reusable-bootstrap-repo.yml` per §5.4 of `docs/QZP-V2-DESIGN.md`. Consumer repos that have been onboarded in `shadow` mode can be promoted to `absolute`/`ratchet` once they rack up **3 consecutive green CI runs** on the configured workflow.

Ties together the Phase 5 inc-1 alert dispatcher (for eventual `alert:fleet-bump-fail` wiring) with the Phase 1 profile schema v2 (`mode.phase` + `shadow_until`).

## New files

- `scripts/quality/bootstrap_repo.py` — IO-free promotion primitives (65 stmts, 100% cov, 18 tests)
  - `count_consecutive_green_shadow_runs` — newest-first gh run-list walker
  - `should_promote` — 3-greens predicate (adjustable threshold)
  - `promote_profile` — text-level mode.phase/shadow_until rewriter (byte-for-byte preserves non-mode lines)
  - `compute_promotion_plan` — convenience composition returning `{ready, green_runs, promoted_yaml}`
- `.github/workflows/reusable-bootstrap-repo.yml` — `workflow_dispatch` wrapper that dispatches the plan and opens a PR when ready
- `tests/test_reusable_bootstrap_repo.py` — 7 contract tests pinning inputs, env-var indirection, PR-creation gating, concurrency key, permissions

## Design notes

- **Idempotent** — re-dispatching the workflow before 3 greens accumulate is a no-op.
- **Race-safe** — `concurrency: group: bootstrap-repo-${{ inputs.repo_slug }}` prevents simultaneous promotions on the same repo.
- **CWE-78 safe** — every `${{ github.* }}` / `${{ inputs.* }}` use routes through an `env:` block before entering the shell or Python heredoc; the contract test verifies this.
- **Minimal diff promotion** — `promote_profile` only touches the two lines (phase + shadow_until); the rest of the profile YAML is unchanged byte-for-byte.

## Follow-ups

- Phase 5 inc-2.5: onboarding half (create profile from stack defaults, open consumer PR) — will extend this same workflow.
- Phase 5 inc-5: wire `alert:fleet-bump-fail` when promotion PR CI fails.

## Test plan

- [x] 25 tests (18 primitives + 7 workflow contract) all pass
- [x] Coverage: 100% on bootstrap_repo.py
- [x] Full suite: 1280 passed + 35 subtests
- [x] Lizard: max function CCN 3.3 (gate = 15)
- [x] Semgrep: clean
- [x] Codacy metric-engine exclude added (matches prior net-new CLI pattern)

Part of QZP v2 Phase 5 (tasks 38-42).


___

## **CodeAnt-AI Description**
**Add a reusable workflow that promotes shadowed repos after 3 green CI runs**

### What Changed
- Added a manually triggered workflow that checks a consumer repo’s recent CI history and opens a promotion PR only after 3 consecutive successful runs.
- The promotion step now updates the repo profile from `shadow` to `absolute` or `ratchet`, and clears the shadow deadline when promotion is ready.
- Re-running the workflow before enough green runs have accumulated does not open a PR.
- Added contract tests that verify the workflow inputs, promotion gate, concurrency protection, and limited permissions.

### Impact
`✅ Fewer premature promotions`
`✅ No duplicate promotion PRs for the same repo`
`✅ Clearer shadow-to-live repo onboarding`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=N2QUdWEO1OK8edNtCapTFRgiwjjRpgiu-wmZj1tnb74&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable workflow for automated repository profile promotion from shadow mode to production phases based on CI stability metrics
  * Workflow monitors consecutive successful CI runs and creates promotion pull requests when configured thresholds are met

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable GitHub Actions workflow to promote shadowed consumer repos to `absolute` or `ratchet` after 3 consecutive green CI runs and open a promotion PR. Implements Phase 5 §5.4 promotion logic with small, safe diffs to repo profiles.

- New Features
  - Added `.github/workflows/reusable-bootstrap-repo.yml` (manual trigger) that counts greens on `repo_slug`/`workflow_name`/`branch`, is idempotent, gates PR creation on readiness, uses per-repo concurrency, and limits permissions.
  - Introduced `scripts/quality/bootstrap_repo.py` with `count_consecutive_green_shadow_runs`, `should_promote`, `promote_profile`, and `compute_promotion_plan`; only updates `mode.phase` and `shadow_until`, and restricts targets to `absolute` or `ratchet`.
  - Routed `${{ inputs.* }}`/`${{ github.* }}` through `env:` blocks to avoid command injection, with contract tests enforcing inputs, gating, concurrency key, and permissions.

<sup>Written for commit 7b29699677b5454f73d92a3b386b27189e8af6ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

