### PR TITLE
feat(qzp-v2 phase 5 inc-3): bump recipe loader + Node 20→24 canary

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -32,6 +32,7 @@ engines:
       - "scripts/quality/apply_drift_pr.py"
       - "scripts/quality/alerts.py"
       - "scripts/quality/bootstrap_repo.py"
+      - "scripts/quality/bumps.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/profiles/bumps/2026-04-23-node-24.yml
+++ b/profiles/bumps/2026-04-23-node-24.yml
@@ -1,0 +1,21 @@
+name: Node 20 -> 24
+# Canonical Phase 5 canary recipe — flips every actions/setup-node step's
+# node-version from '20' to '24' across the fullstack-web fleet. Used both
+# as the reference example in docs/QZP-V2-DESIGN.md §5.5 and as a live test
+# fixture for the bump-recipe validator.
+
+target:
+  - file_glob: "**/.github/workflows/*.yml"
+    yaml_path: "jobs.*.steps[?.uses contains 'setup-node'].with.node-version"
+    value: '24'
+
+affects_stacks:
+  - fullstack-web
+  - react-vite-vitest
+
+staging_repos:
+  - Prekzursil/env-inspector
+  - Prekzursil/webcoder
+
+full_rollout_after_staging: true
+rollback_on_failure: true

--- a/profiles/bumps/README.md
+++ b/profiles/bumps/README.md
@@ -1,0 +1,29 @@
+# Bump recipes
+
+Bump recipes describe fleet-wide nudges (e.g. `Node 20 -> 24`, `ubuntu-latest -> ubuntu-24.04`). They are consumed by `.github/workflows/reusable-bumps.yml` in a staged-rollout pattern.
+
+## File naming
+
+`profiles/bumps/<YYYY-MM-DD>-<slug>.yml` — the date keeps history sortable, the slug describes the change.
+
+## Schema
+
+| Field | Type | Required | Default | Meaning |
+|---|---|---|---|---|
+| `name` | string | yes | — | Human-readable label (e.g. `Node 20 -> 24`). |
+| `target` | list | yes | — | Non-empty list of target entries. |
+| `target[].file_glob` | string | yes | — | `pathlib.Path.glob` pattern (rel. to repo root). |
+| `target[].yaml_path` | string | yes | — | YAML selector applied within each matched file. |
+| `target[].value` | string | yes | — | New value to write. |
+| `affects_stacks` | list\[string\] | yes | — | Stack ids this bump applies to. |
+| `staging_repos` | list\[owner/name\] | yes | — | Wave-1 canary repos. |
+| `full_rollout_after_staging` | bool | no | `true` | Auto-roll to all affected after staging is green. |
+| `rollback_on_failure` | bool | no | `true` | Revert the recipe commit + open `alert:fleet-bump-fail` on staging failure. |
+
+## Validation
+
+All recipes go through `scripts/quality/bumps.py::load_bump_recipe`, which enforces the above schema and raises `BumpRecipeError` on any violation. CI runs the validator as part of the quality rollup.
+
+## Example
+
+See [`2026-04-23-node-24.yml`](./2026-04-23-node-24.yml) for the canonical Phase 5 canary.

--- a/scripts/quality/bumps.py
+++ b/scripts/quality/bumps.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Phase 5 bump recipe primitives.
+
+Bumps are platform-owned recipes that describe a fleet-wide nudge
+(e.g. ``Node 20 → 24``, ``ubuntu-latest → ubuntu-24.04``). They live
+in ``profiles/bumps/<date>-<name>.yml`` and are consumed by
+``reusable-bumps.yml`` in a staged-rollout workflow:
+
+1. Open PRs against ``staging_repos`` first. Wait for all CI green.
+2. If all green → open PRs against the remainder of the affected
+   fleet (every repo whose ``stack`` is in ``affects_stacks``).
+3. If any staging PR fails CI → revert the bump recipe commit and
+   open ``alert:fleet-bump-fail`` on the platform repo.
+
+This module ships the **schema validator + file-resolver primitives**
+only. The actual PR-opening + rollout orchestration is wired by the
+workflow and a follow-up increment (Phase 5 inc-3.5).
+
+Recipe schema (per ``docs/QZP-V2-DESIGN.md`` §5.5):
+
+```yaml
+name: Node 20 -> 24             # required — human-readable label
+target:                         # required — non-empty list
+  - file_glob: "**/ci.yml"      # required per entry — glob relative to repo
+    yaml_path: "jobs.*.steps..."  # required per entry — YAML selector (applier spec)
+    value: '24'                 # required per entry — new value
+affects_stacks:                 # required — non-empty list of stack ids
+  - fullstack-web
+staging_repos:                  # required — non-empty list of owner/name
+  - Prekzursil/env-inspector
+full_rollout_after_staging: true   # optional, defaults to True
+rollback_on_failure: true          # optional, defaults to True
+```
+"""
+
+from __future__ import absolute_import
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+import yaml  # type: ignore[import-untyped]
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+REQUIRED_TOP_FIELDS = (
+    "name", "target", "affects_stacks", "staging_repos",
+)
+REQUIRED_TARGET_FIELDS = ("file_glob", "yaml_path", "value")
+
+
+class BumpRecipeError(ValueError):
+    """Raised when a bump recipe fails schema validation."""
+
+
+def _validate_top_fields(recipe: Mapping[str, Any], path: Path) -> None:
+    """Assert every required top-level field is present + non-empty."""
+    for field in REQUIRED_TOP_FIELDS:
+        if field not in recipe:
+            raise BumpRecipeError(
+                f"bump recipe {path} missing required field: {field!r}",
+            )
+    for list_field in ("target", "affects_stacks", "staging_repos"):
+        value = recipe.get(list_field)
+        if not isinstance(value, list) or not value:
+            raise BumpRecipeError(
+                f"bump recipe {path} field {list_field!r} must be a "
+                f"non-empty list (got {type(value).__name__})",
+            )
+
+
+def _validate_target_entries(recipe: Mapping[str, Any], path: Path) -> None:
+    """Assert every target entry has file_glob/yaml_path/value."""
+    for index, entry in enumerate(recipe["target"]):
+        if not isinstance(entry, Mapping):
+            raise BumpRecipeError(
+                f"bump recipe {path} target[{index}] must be a mapping",
+            )
+        for field in REQUIRED_TARGET_FIELDS:
+            if field not in entry:
+                raise BumpRecipeError(
+                    f"bump recipe {path} target[{index}] missing {field!r}",
+                )
+
+
+def _validate_staging_repo_slugs(recipe: Mapping[str, Any], path: Path) -> None:
+    """Assert each staging repo is an ``owner/name`` slug."""
+    for slug in recipe["staging_repos"]:
+        if not isinstance(slug, str) or "/" not in slug:
+            raise BumpRecipeError(
+                f"bump recipe {path} staging repo {slug!r} must be "
+                f"'owner/name' format",
+            )
+
+
+def load_bump_recipe(path: Path) -> Dict[str, Any]:
+    """Load, validate, and normalise a bump recipe YAML at ``path``.
+
+    Returns a dict with all fields set (defaults applied). Raises
+    ``BumpRecipeError`` on any schema violation.
+    """
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise BumpRecipeError(
+            f"bump recipe {path} must be a YAML mapping at top level",
+        )
+    _validate_top_fields(raw, path)
+    _validate_target_entries(raw, path)
+    _validate_staging_repo_slugs(raw, path)
+    recipe: Dict[str, Any] = dict(raw)
+    recipe.setdefault("full_rollout_after_staging", True)
+    recipe.setdefault("rollback_on_failure", True)
+    return recipe
+
+
+def resolve_target_files(
+    repo_root: Path, targets: Iterable[Mapping[str, Any]],
+) -> List[Path]:
+    """Expand every ``target[].file_glob`` against ``repo_root``.
+
+    Returns the deduplicated, sorted list of files that match at
+    least one target's glob. The glob syntax is ``pathlib.Path.glob``
+    (``**`` recurses, ``*`` matches one path segment).
+    """
+    seen: Dict[str, Path] = {}
+    for target in targets:
+        glob = str(target["file_glob"])
+        for hit in repo_root.glob(glob):
+            if hit.is_file():
+                key = hit.relative_to(repo_root).as_posix()
+                seen.setdefault(key, hit)
+    return [seen[k] for k in sorted(seen)]
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", required=True, help="Path to bump recipe YAML")
+    parser.add_argument("--repo-root", default=".", help="Resolve target globs here")
+    _args = parser.parse_args()
+
+    _recipe = load_bump_recipe(Path(_args.recipe))
+    _files = resolve_target_files(
+        Path(_args.repo_root), _recipe["target"],
+    )
+    print(json.dumps({
+        "recipe_name": _recipe["name"],
+        "staging_repos": _recipe["staging_repos"],
+        "affects_stacks": _recipe["affects_stacks"],
+        "target_files": [p.as_posix() for p in _files],
+    }, indent=2, sort_keys=True))

--- a/tests/test_bumps.py
+++ b/tests/test_bumps.py
@@ -1,0 +1,232 @@
+"""Tests for Phase 5 ``scripts.quality.bumps`` — bump recipe primitives."""
+
+from __future__ import absolute_import
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts.quality import bumps
+
+
+def _write_recipe(dirpath: Path, body: str, name: str = "recipe.yml") -> Path:
+    """Helper: write ``body`` to ``dirpath/name`` and return the path."""
+    path = dirpath / name
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+class LoadBumpRecipeTests(unittest.TestCase):
+    """``load_bump_recipe`` parses + validates the recipe YAML."""
+
+    def test_valid_recipe_returns_normalised_dict(self) -> None:
+        """Canonical Node 20→24 recipe round-trips through the loader."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: Node 20 -> 24
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "jobs.*.steps[?.uses contains 'setup-node'].with.node-version"
+                    value: '24'
+                affects_stacks: [fullstack-web]
+                staging_repos:
+                  - Prekzursil/env-inspector
+                full_rollout_after_staging: true
+                rollback_on_failure: true
+            """)
+            recipe = bumps.load_bump_recipe(path)
+        self.assertEqual(recipe["name"], "Node 20 -> 24")
+        self.assertEqual(len(recipe["target"]), 1)
+        self.assertEqual(recipe["target"][0]["value"], "24")
+        self.assertIn("fullstack-web", recipe["affects_stacks"])
+        self.assertTrue(recipe["full_rollout_after_staging"])
+
+    def test_missing_required_field_raises(self) -> None:
+        """Recipe missing ``name`` is rejected with clear message."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "x.y"
+                    value: '24'
+                affects_stacks: [x]
+                staging_repos: [a/b]
+            """)
+            with self.assertRaises(bumps.BumpRecipeError) as ctx:
+                bumps.load_bump_recipe(path)
+            self.assertIn("name", str(ctx.exception))
+
+    def test_target_must_be_non_empty_list(self) -> None:
+        """Recipe with empty ``target`` is rejected."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: empty
+                target: []
+                affects_stacks: [x]
+                staging_repos: [a/b]
+            """)
+            with self.assertRaises(bumps.BumpRecipeError):
+                bumps.load_bump_recipe(path)
+
+    def test_target_entry_requires_file_glob_yaml_path_value(self) -> None:
+        """Each target entry must have all three required keys."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: partial
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "x.y"
+                    # missing: value
+                affects_stacks: [x]
+                staging_repos: [a/b]
+            """)
+            with self.assertRaises(bumps.BumpRecipeError):
+                bumps.load_bump_recipe(path)
+
+    def test_staging_repos_must_be_non_empty(self) -> None:
+        """Empty staging_repos blocks rollout — rejected."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: no-staging
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "x.y"
+                    value: '24'
+                affects_stacks: [x]
+                staging_repos: []
+            """)
+            with self.assertRaises(bumps.BumpRecipeError):
+                bumps.load_bump_recipe(path)
+
+    def test_staging_repo_slug_must_have_owner(self) -> None:
+        """Staging repos must be ``owner/name``, not bare ``name``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: bad-slug
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "x.y"
+                    value: '24'
+                affects_stacks: [x]
+                staging_repos: [just-a-name]
+            """)
+            with self.assertRaises(bumps.BumpRecipeError):
+                bumps.load_bump_recipe(path)
+
+    def test_defaults_applied_when_optional_fields_missing(self) -> None:
+        """``full_rollout_after_staging`` and ``rollback_on_failure`` default to True."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: minimal
+                target:
+                  - file_glob: "**/ci.yml"
+                    yaml_path: "x.y"
+                    value: '24'
+                affects_stacks: [x]
+                staging_repos: [a/b]
+            """)
+            recipe = bumps.load_bump_recipe(path)
+        self.assertTrue(recipe["full_rollout_after_staging"])
+        self.assertTrue(recipe["rollback_on_failure"])
+
+    def test_yaml_root_must_be_mapping(self) -> None:
+        """A top-level list or scalar is rejected with clear message."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "recipe.yml"
+            path.write_text("- not-a-mapping\n", encoding="utf-8")
+            with self.assertRaises(bumps.BumpRecipeError) as ctx:
+                bumps.load_bump_recipe(path)
+            self.assertIn("mapping", str(ctx.exception))
+
+    def test_target_entry_that_is_not_mapping_rejected(self) -> None:
+        """``target: [scalar]`` rejected — each entry must be a mapping."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_recipe(Path(tmp), """
+                name: bad-target
+                target:
+                  - just-a-string
+                affects_stacks: [x]
+                staging_repos: [a/b]
+            """)
+            with self.assertRaises(bumps.BumpRecipeError) as ctx:
+                bumps.load_bump_recipe(path)
+            self.assertIn("target[0]", str(ctx.exception))
+
+
+class ResolveTargetFilesTests(unittest.TestCase):
+    """``resolve_target_files`` expands file_globs against a repo root."""
+
+    def test_glob_matches_nested_ci_yml(self) -> None:
+        """Glob ``**/ci.yml`` finds files in top + nested dirs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            ci_a = root / ".github" / "workflows" / "ci.yml"
+            ci_a.write_text("name: a\n", encoding="utf-8")
+            (root / "sub" / ".github" / "workflows").mkdir(parents=True)
+            ci_b = root / "sub" / ".github" / "workflows" / "ci.yml"
+            ci_b.write_text("name: b\n", encoding="utf-8")
+            (root / "other.yml").write_text("name: other\n", encoding="utf-8")
+
+            targets = [{"file_glob": "**/ci.yml", "yaml_path": "x", "value": "y"}]
+            files = bumps.resolve_target_files(root, targets)
+        self.assertEqual(
+            sorted(p.relative_to(root).as_posix() for p in files),
+            [".github/workflows/ci.yml", "sub/.github/workflows/ci.yml"],
+        )
+
+    def test_no_matches_returns_empty_list(self) -> None:
+        """Unmatched glob returns ``[]`` — caller decides whether to warn."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "unrelated.txt").write_text("x", encoding="utf-8")
+            targets = [{"file_glob": "**/ci.yml", "yaml_path": "x", "value": "y"}]
+            files = bumps.resolve_target_files(root, targets)
+        self.assertEqual(files, [])
+
+    def test_multiple_targets_deduped(self) -> None:
+        """If 2 targets match the same file, it's only returned once."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "ci.yml").write_text("name: a\n", encoding="utf-8")
+            targets = [
+                {"file_glob": "**/ci.yml", "yaml_path": "x", "value": "y"},
+                {"file_glob": "ci.yml", "yaml_path": "x", "value": "y"},
+            ]
+            files = bumps.resolve_target_files(root, targets)
+        self.assertEqual(len(files), 1)
+
+    def test_directory_matches_are_skipped(self) -> None:
+        """Glob matches that are directories (not files) are excluded."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "ci.yml").mkdir()  # a directory NAMED ci.yml
+            (root / "sub" / "ci.yml").parent.mkdir(parents=True)
+            (root / "sub" / "ci.yml").write_text("x", encoding="utf-8")
+            targets = [{"file_glob": "**/ci.yml", "yaml_path": "x", "value": "y"}]
+            files = bumps.resolve_target_files(root, targets)
+        # Only the real file under sub/ci.yml; the directory ci.yml is skipped.
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0].name, "ci.yml")
+        self.assertEqual(files[0].parent.name, "sub")
+
+
+class SampleNodeRecipeIsValidTests(unittest.TestCase):
+    """The shipped sample recipe under ``profiles/bumps/`` loads cleanly."""
+
+    def test_sample_recipe_loads_and_has_node_24(self) -> None:
+        """The canonical Node 20→24 recipe survives the loader round-trip."""
+        sample_path = (
+            Path(__file__).resolve().parents[1]
+            / "profiles" / "bumps" / "2026-04-23-node-24.yml"
+        )
+        recipe = bumps.load_bump_recipe(sample_path)
+        self.assertIn("node", recipe["name"].lower())
+        # Last target (or any) should have 24 in its value.
+        values = [t["value"] for t in recipe["target"]]
+        self.assertIn("24", values)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Phase 5 increment 3: adds `scripts/quality/bumps.py` (the schema validator + target-file resolver for fleet-wide bump recipes) and ships the canonical Node 20→24 canary recipe that the design doc references in §5.5.

This lands the recipe+loader **before** the rollout orchestration workflow so the rest of Phase 5 can cite a validated recipe rather than an aspirational one.

## New files

- `scripts/quality/bumps.py` (52 stmts, 100% cov, 14 tests)
  - `BumpRecipeError` — schema-validation exception
  - `load_bump_recipe(path)` — validates required fields, target entry shape, staging repo slugs; applies defaults
  - `resolve_target_files(repo_root, targets)` — `Path.glob` expansion with dedupe + directory-exclusion
- `profiles/bumps/2026-04-23-node-24.yml` — canonical canary, flips `actions/setup-node` to `node-version: '24'` across `fullstack-web` + `react-vite-vitest` stacks
- `profiles/bumps/README.md` — schema reference + filename convention docs

## Design notes

- **Schema is enforced at load time** — loader returns a fully-defaulted dict; no downstream caller needs to re-check required fields.
- **A live test verifies the shipped canary recipe loads cleanly**, so any future schema tightening that breaks the recipe fails CI immediately.
- **Rollout orchestration deliberately deferred** — the workflow + PR-opening logic arrive in Phase 5 inc-3.5 to keep this PR small and reviewable.

## Test plan

- [x] 14 tests (8 loader + 3 resolver + 1 canary-validates + 2 defensive) all pass
- [x] Coverage: 100% on `bumps.py` (52 stmts / 28 branches)
- [x] Full suite: 1294 passed + 35 subtests
- [x] Lizard: max function CCN 4 (gate = 15)
- [x] Semgrep: clean
- [x] Codacy metric-engine exclude added (matches prior net-new CLI pattern)

Part of QZP v2 Phase 5 (tasks 40-42).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a schema-validated bump recipe loader and the Node 20→24 canary recipe to prepare Phase 5 rollouts. This lands the validated recipe and primitives before the rollout workflow.

- **New Features**
  - `scripts/quality/bumps.py`: `load_bump_recipe(path)` validates required fields and applies defaults; `resolve_target_files(repo_root, targets)` expands `file_glob` with dedupe and skips directories.
  - `profiles/bumps/2026-04-23-node-24.yml`: flips `actions/setup-node` to `node-version: '24'` for `fullstack-web` and `react-vite-vitest`; stages on `Prekzursil/env-inspector` and `Prekzursil/webcoder`.
  - `profiles/bumps/README.md`: schema and naming guide.
  - Tests cover loader, resolver, and sample recipe; `.codacy.yaml` updated to exclude the new CLI script.

<sup>Written for commit bb9e871dcfceb10666315020d4b41f956359e4b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Add validated bump recipes for staged fleet-wide version updates

### What Changed
- Adds a bump recipe loader that checks required fields, rejects invalid recipes, and fills in default rollout settings
- Adds target file resolution so matching files are found once, while skipping duplicates and directories
- Ships the canonical Node 20 → 24 bump recipe for the fullstack-web and react-vite-vitest stacks
- Documents the recipe file naming and schema rules for future bump recipes
- Adds tests that cover valid recipes, schema failures, file matching, and the shipped sample recipe

### Impact
`✅ Fewer invalid rollout recipes`
`✅ Safer staged fleet updates`
`✅ Clearer bump recipe validation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=1ddTk0YdHLBfntoVfkOJ6k2kfFcLY_93TwCQm8zIL7c&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
