### PR TITLE
feat(qzp-v2 phase 5 inc-5): 7 alert-trigger detectors

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -34,6 +34,7 @@ engines:
       - "scripts/quality/bootstrap_repo.py"
       - "scripts/quality/bumps.py"
       - "scripts/quality/admin_dashboard_pages.py"
+      - "scripts/quality/alert_triggers.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/scripts/quality/alert_triggers.py
+++ b/scripts/quality/alert_triggers.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Phase 5 alert-trigger detectors.
+
+Each detector here is the *synthetic trigger* for one of the 8 alert
+types in ``docs/QZP-V2-DESIGN.md`` §8 (``repo-not-profiled`` already
+ships in ``fleet_inventory.py``). A detector is a pure function over
+its inputs that returns a list of :class:`AlertTrigger` records.
+
+Each :class:`AlertTrigger` is a dataclass with ``alert_type``,
+``subject`` (deduper for the issue title), and a pre-formatted
+``body`` explaining the trigger in human terms.
+
+The caller dispatches the triggers via ``scripts.quality.alerts``:
+
+.. code-block:: python
+
+    for trigger in detect_coverage_regression(...):
+        alerts.open_alert_issue(
+            platform_slug,
+            alert_type=trigger.alert_type,
+            subject=trigger.subject,
+            body=trigger.body,
+            runner=subprocess.run,
+        )
+
+The pure-function shape means every detector is unit-testable
+without hitting GitHub or Codecov; the integration happens at the
+call site.
+"""
+
+from __future__ import absolute_import
+
+import datetime as dt
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Sequence
+
+from scripts.quality import alerts
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+COVERAGE_REGRESSION_THRESHOLD_POINTS = 0.5  # percentage-point drop
+BYPASS_STALE_THRESHOLD_DAYS = 7
+DRIFT_STUCK_THRESHOLD_DAYS = 3
+
+
+@dataclass(frozen=True)
+class AlertTrigger:
+    """One alert-eligible event; callers hand this to ``alerts.open_alert_issue``."""
+
+    alert_type: alerts.AlertType
+    subject: str
+    body: str
+
+
+def detect_coverage_regression(
+    *,
+    slug: str,
+    baseline_percent: float,
+    current_percent: float,
+) -> List[AlertTrigger]:
+    """Fire when coverage drops by strictly more than 0.5 percentage points."""
+    drop = baseline_percent - current_percent
+    if drop <= COVERAGE_REGRESSION_THRESHOLD_POINTS:
+        return []
+    body = (
+        f"Main-branch coverage dropped by **{drop:.2f}** percentage points "
+        f"on `{slug}`: baseline was `{baseline_percent:.2f}%`, current is "
+        f"`{current_percent:.2f}%`."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.REGRESSION, subject=slug, body=body,
+    )]
+
+
+def _iso_date(value: Any) -> dt.date:
+    """Parse ``YYYY-MM-DD`` or return a low sentinel so comparisons fail closed."""
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return dt.date.min
+
+
+def _ratchet_block(profile: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the ``mode.ratchet`` sub-block, defaulting to empty."""
+    mode = profile.get("mode") if isinstance(profile, Mapping) else None
+    if not isinstance(mode, Mapping):
+        return {}
+    ratchet = mode.get("ratchet")
+    return ratchet if isinstance(ratchet, Mapping) else {}
+
+
+def _phase(profile: Mapping[str, Any]) -> str:
+    """Return ``mode.phase`` or empty string."""
+    mode = profile.get("mode") if isinstance(profile, Mapping) else None
+    if not isinstance(mode, Mapping):
+        return ""
+    return str(mode.get("phase", ""))
+
+
+def detect_deadline_missed(
+    *, slug: str, profile: Mapping[str, Any], today: dt.date,
+) -> List[AlertTrigger]:
+    """Fire when ``ratchet.target_date`` passed and phase is not absolute."""
+    if _phase(profile) == "absolute":
+        return []
+    ratchet = _ratchet_block(profile)
+    if "target_date" not in ratchet:
+        return []
+    target = _iso_date(ratchet["target_date"])
+    if target >= today:
+        return []
+    body = (
+        f"Ratchet target date **{target.isoformat()}** has passed without "
+        f"`{slug}` reaching `mode.phase: absolute`. Current phase: "
+        f"`{_phase(profile) or '<unset>'}`."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.DEADLINE_MISSED, subject=slug, body=body,
+    )]
+
+
+def detect_escalation(
+    *, slug: str, profile: Mapping[str, Any], today: dt.date,
+) -> List[AlertTrigger]:
+    """Fire when ``ratchet.escalation_date`` passed and phase is not absolute."""
+    if _phase(profile) == "absolute":
+        return []
+    ratchet = _ratchet_block(profile)
+    if "escalation_date" not in ratchet:
+        return []
+    escalation = _iso_date(ratchet["escalation_date"])
+    if escalation >= today:
+        return []
+    body = (
+        f"Ratchet escalation date **{escalation.isoformat()}** has passed. "
+        f"`{slug}` must flip to `mode.phase: absolute` now."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.ESCALATION, subject=slug, body=body,
+    )]
+
+
+def detect_bypass_stale(
+    *,
+    slug: str, issue_number: int,
+    opened_at: dt.datetime, now: dt.datetime,
+    threshold_days: int = BYPASS_STALE_THRESHOLD_DAYS,
+) -> List[AlertTrigger]:
+    """Fire when a break-glass tracking issue has been open > ``threshold_days``."""
+    age = now - opened_at
+    if age.days <= threshold_days:
+        return []
+    subject = f"{slug}#{issue_number}"
+    body = (
+        f"Break-glass tracking issue {subject} has been open for "
+        f"**{age.days} days** — past the {threshold_days}-day remediation "
+        f"SLA. Close the underlying quality regression and this issue."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.BYPASS_STALE, subject=subject, body=body,
+    )]
+
+
+def detect_drift_stuck(
+    *,
+    slug: str, pr_number: int,
+    opened_at: dt.datetime, now: dt.datetime,
+    threshold_days: int = DRIFT_STUCK_THRESHOLD_DAYS,
+) -> List[AlertTrigger]:
+    """Fire when a drift-sync PR has been open > ``threshold_days``."""
+    age = now - opened_at
+    if age.days <= threshold_days:
+        return []
+    subject = f"{slug}#{pr_number}"
+    body = (
+        f"Drift-sync PR {subject} has been open for **{age.days} days** — "
+        f"past the {threshold_days}-day sync SLA. Merge or close the PR to "
+        f"keep the fleet aligned."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.DRIFT_STUCK, subject=subject, body=body,
+    )]
+
+
+def detect_fleet_bump_fail(
+    *,
+    recipe_name: str,
+    staging_results: Sequence[Mapping[str, Any]],
+) -> List[AlertTrigger]:
+    """Fire if any staging-wave result in ``staging_results`` failed CI."""
+    failed = [
+        str(entry.get("slug", "<unknown>"))
+        for entry in staging_results
+        if str(entry.get("conclusion", "")) != "success"
+    ]
+    if not failed:
+        return []
+    body = (
+        f"Bump recipe **{recipe_name}** failed CI on the staging wave. "
+        f"Failing staging repos: {', '.join(failed)}. Revert the recipe "
+        f"commit and investigate before rolling out to the rest of the fleet."
+    )
+    return [AlertTrigger(
+        alert_type=alerts.AlertType.FLEET_BUMP_FAIL,
+        subject=recipe_name, body=body,
+    )]
+
+
+def detect_flag_missing(
+    *, slug: str,
+    declared_flags: Iterable[str],
+    reported_flags: Iterable[str],
+) -> List[AlertTrigger]:
+    """One alert per declared flag without a matching Codecov report."""
+    reported_set = {str(f).strip() for f in reported_flags if str(f).strip()}
+    missing = [
+        str(flag).strip()
+        for flag in declared_flags
+        if str(flag).strip() and str(flag).strip() not in reported_set
+    ]
+    triggers: List[AlertTrigger] = []
+    for flag in missing:
+        subject = f"{slug}:{flag}"
+        body = (
+            f"Codecov flag **{flag}** is declared in `{slug}`'s profile "
+            f"coverage inputs but did not appear in the latest commit's "
+            f"Codecov totals. Check the upload step of the `{flag}` lane."
+        )
+        triggers.append(AlertTrigger(
+            alert_type=alerts.AlertType.FLAG_MISSING,
+            subject=subject, body=body,
+        ))
+    return triggers
+
+
+if __name__ == "__main__":  # pragma: no cover — no ad-hoc CLI yet
+    import json
+    print(json.dumps({"detectors": [
+        "coverage_regression", "deadline_missed", "escalation",
+        "bypass_stale", "drift_stuck", "fleet_bump_fail", "flag_missing",
+    ]}))

--- a/tests/test_alert_triggers.py
+++ b/tests/test_alert_triggers.py
@@ -1,0 +1,329 @@
+"""Tests for Phase 5 ``scripts.quality.alert_triggers`` detectors.
+
+Each detector is the synthetic-trigger surface for one of the 8
+alert types from ``docs/QZP-V2-DESIGN.md`` §8 (``repo-not-profiled``
+is already covered by fleet_inventory.py). Every detector returns a
+list of ``AlertTrigger`` records the caller can feed straight into
+``alerts.open_alert_issue``.
+"""
+
+from __future__ import absolute_import
+
+import datetime as dt
+import unittest
+
+from scripts.quality import alert_triggers as at
+from scripts.quality import alerts
+
+
+class DetectCoverageRegressionTests(unittest.TestCase):
+    """``detect_coverage_regression`` fires when cov drops > 0.5%."""
+
+    def test_drop_over_threshold_fires(self) -> None:
+        """Baseline 100 → current 99.2 (Δ=0.8) → regression alert."""
+        triggers = at.detect_coverage_regression(
+            slug="org/repo",
+            baseline_percent=100.0,
+            current_percent=99.2,
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.REGRESSION)
+        self.assertEqual(triggers[0].subject, "org/repo")
+        self.assertIn("0.8", triggers[0].body)
+
+    def test_drop_at_exact_threshold_fires(self) -> None:
+        """Baseline 100 → 99.5 (Δ=0.5) → exactly at threshold, fires."""
+        triggers = at.detect_coverage_regression(
+            slug="org/repo",
+            baseline_percent=100.0,
+            current_percent=99.5,
+        )
+        # The design doc says "drops > 0.5%" — use strict greater-than;
+        # exactly 0.5% does not fire.
+        self.assertEqual(triggers, [])
+
+    def test_drop_just_over_threshold_fires(self) -> None:
+        """Baseline 100 → 99.49 (Δ=0.51) → fires."""
+        triggers = at.detect_coverage_regression(
+            slug="org/repo",
+            baseline_percent=100.0,
+            current_percent=99.49,
+        )
+        self.assertEqual(len(triggers), 1)
+
+    def test_coverage_recovery_does_not_fire(self) -> None:
+        """Current > baseline → no alert."""
+        triggers = at.detect_coverage_regression(
+            slug="org/repo",
+            baseline_percent=99.0,
+            current_percent=100.0,
+        )
+        self.assertEqual(triggers, [])
+
+
+class DetectDeadlineMissedTests(unittest.TestCase):
+    """``detect_deadline_missed`` fires when target_date < today and not absolute."""
+
+    def test_target_date_past_and_not_absolute_fires(self) -> None:
+        """``target_date: 2026-01-01``, today 2026-04-23, phase ratchet → fires."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"target_date": "2026-01-01"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.DEADLINE_MISSED)
+        self.assertIn("2026-01-01", triggers[0].body)
+
+    def test_target_date_future_does_not_fire(self) -> None:
+        """Target 2026-12-31, today 2026-04-23 → no alert."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"target_date": "2026-12-31"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+    def test_already_absolute_never_fires(self) -> None:
+        """Even with past target_date, absolute phase suppresses alert."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "absolute",
+                              "ratchet": {"target_date": "2026-01-01"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+    def test_no_ratchet_block_does_not_fire(self) -> None:
+        """Profile without ratchet → no alert."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "shadow"}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+
+class DetectEscalationTests(unittest.TestCase):
+    """``detect_escalation`` fires when escalation_date < today and not absolute."""
+
+    def test_escalation_date_past_fires(self) -> None:
+        """Escalation passed + not absolute → alert fires."""
+        triggers = at.detect_escalation(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"escalation_date": "2025-12-31"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.ESCALATION)
+
+    def test_escalation_date_future_does_not_fire(self) -> None:
+        """Future escalation → no alert."""
+        triggers = at.detect_escalation(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"escalation_date": "2026-12-31"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+    def test_absolute_phase_never_escalates(self) -> None:
+        """Once absolute, escalation is moot."""
+        triggers = at.detect_escalation(
+            slug="org/repo",
+            profile={"mode": {"phase": "absolute",
+                              "ratchet": {"escalation_date": "2025-12-31"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+    def test_no_escalation_date_does_not_fire(self) -> None:
+        """Ratchet block without escalation_date → no alert."""
+        triggers = at.detect_escalation(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"target_date": "2026-06-30"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+
+class DefensiveProfileShapeTests(unittest.TestCase):
+    """Detectors never crash on malformed profile shapes."""
+
+    def test_mode_not_mapping_returns_empty(self) -> None:
+        """``mode:`` as a scalar → no alert, no exception."""
+        for detector in (at.detect_deadline_missed, at.detect_escalation):
+            with self.subTest(detector=detector.__name__):
+                triggers = detector(
+                    slug="org/repo",
+                    profile={"mode": "not-a-mapping"},
+                    today=dt.date(2026, 4, 23),
+                )
+                self.assertEqual(triggers, [])
+
+    def test_mode_missing_returns_empty(self) -> None:
+        """Profile without ``mode:`` key → no alert."""
+        for detector in (at.detect_deadline_missed, at.detect_escalation):
+            with self.subTest(detector=detector.__name__):
+                triggers = detector(
+                    slug="org/repo",
+                    profile={},
+                    today=dt.date(2026, 4, 23),
+                )
+                self.assertEqual(triggers, [])
+
+    def test_ratchet_not_mapping_returns_empty(self) -> None:
+        """``mode.ratchet:`` as a list → no alert, no exception."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet", "ratchet": ["a", "b"]}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(triggers, [])
+
+    def test_date_value_is_already_a_date_object(self) -> None:
+        """Profile with `target_date: date(..)` object (not str) also works."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"target_date": dt.date(2025, 1, 1)}}},
+            today=dt.date(2026, 4, 23),
+        )
+        self.assertEqual(len(triggers), 1)
+
+    def test_unparseable_date_returns_no_alert(self) -> None:
+        """Garbage date string → parses to date.min, fails-closed."""
+        triggers = at.detect_deadline_missed(
+            slug="org/repo",
+            profile={"mode": {"phase": "ratchet",
+                              "ratchet": {"target_date": "not-a-date"}}},
+            today=dt.date(2026, 4, 23),
+        )
+        # date.min < today → fires the alert (that's the "fail-closed"
+        # contract: unparseable dates still trigger the alert so the
+        # operator notices them).
+        self.assertEqual(len(triggers), 1)
+
+
+class DetectBypassStaleTests(unittest.TestCase):
+    """``detect_bypass_stale`` fires when break-glass tracking issue > 7 days."""
+
+    def test_stale_issue_fires(self) -> None:
+        """Opened 8 days ago, still open → alert fires."""
+        triggers = at.detect_bypass_stale(
+            slug="org/repo",
+            issue_number=42,
+            opened_at=dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc),
+            now=dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.BYPASS_STALE)
+        self.assertEqual(triggers[0].subject, "org/repo#42")
+
+    def test_fresh_issue_does_not_fire(self) -> None:
+        """Opened 3 days ago → no alert (under 7-day threshold)."""
+        triggers = at.detect_bypass_stale(
+            slug="org/repo",
+            issue_number=42,
+            opened_at=dt.datetime(2026, 4, 20, tzinfo=dt.timezone.utc),
+            now=dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+        )
+        self.assertEqual(triggers, [])
+
+
+class DetectDriftStuckTests(unittest.TestCase):
+    """``detect_drift_stuck`` fires when a drift-sync PR has been open > 3 days."""
+
+    def test_old_pr_fires(self) -> None:
+        """PR open 4 days → alert fires."""
+        triggers = at.detect_drift_stuck(
+            slug="org/repo",
+            pr_number=99,
+            opened_at=dt.datetime(2026, 4, 19, tzinfo=dt.timezone.utc),
+            now=dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.DRIFT_STUCK)
+        self.assertEqual(triggers[0].subject, "org/repo#99")
+
+    def test_fresh_pr_does_not_fire(self) -> None:
+        """PR open 1 day → no alert."""
+        triggers = at.detect_drift_stuck(
+            slug="org/repo",
+            pr_number=99,
+            opened_at=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+            now=dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+        )
+        self.assertEqual(triggers, [])
+
+
+class DetectFleetBumpFailTests(unittest.TestCase):
+    """``detect_fleet_bump_fail`` fires when staging wave CI failed."""
+
+    def test_any_staging_failure_fires(self) -> None:
+        """One failing staging PR → alert fires with recipe name as subject."""
+        triggers = at.detect_fleet_bump_fail(
+            recipe_name="Node 20 -> 24",
+            staging_results=[
+                {"slug": "org/staging-a", "conclusion": "success"},
+                {"slug": "org/staging-b", "conclusion": "failure"},
+            ],
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.FLEET_BUMP_FAIL)
+        self.assertIn("org/staging-b", triggers[0].body)
+        self.assertIn("Node 20 -> 24", triggers[0].subject)
+
+    def test_all_green_staging_does_not_fire(self) -> None:
+        """Every staging PR green → no alert."""
+        triggers = at.detect_fleet_bump_fail(
+            recipe_name="Node 20 -> 24",
+            staging_results=[
+                {"slug": "org/staging-a", "conclusion": "success"},
+                {"slug": "org/staging-b", "conclusion": "success"},
+            ],
+        )
+        self.assertEqual(triggers, [])
+
+
+class DetectFlagMissingTests(unittest.TestCase):
+    """``detect_flag_missing`` fires when a declared flag has no Codecov report."""
+
+    def test_missing_flag_fires_one_alert_per_flag(self) -> None:
+        """Declared [backend, ui], reported [backend] → 1 alert for ui."""
+        triggers = at.detect_flag_missing(
+            slug="org/repo",
+            declared_flags=["backend", "ui"],
+            reported_flags=["backend"],
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.FLAG_MISSING)
+        self.assertEqual(triggers[0].subject, "org/repo:ui")
+
+    def test_multiple_missing_flags_each_open_separate_alert(self) -> None:
+        """Declared [a, b, c], reported [a] → 2 separate alerts."""
+        triggers = at.detect_flag_missing(
+            slug="org/repo",
+            declared_flags=["a", "b", "c"],
+            reported_flags=["a"],
+        )
+        self.assertEqual(len(triggers), 2)
+        subjects = sorted(t.subject for t in triggers)
+        self.assertEqual(subjects, ["org/repo:b", "org/repo:c"])
+
+    def test_all_flags_present_does_not_fire(self) -> None:
+        """Declared == reported → no alert."""
+        triggers = at.detect_flag_missing(
+            slug="org/repo",
+            declared_flags=["backend", "ui"],
+            reported_flags=["ui", "backend"],
+        )
+        self.assertEqual(triggers, [])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Phase 5 increment 5: adds `scripts/quality/alert_triggers.py` — one pure-function detector per alert type from §8 of the design doc, completing coverage for all 8 alert types when combined with `fleet_inventory.py`'s existing `alert:repo-not-profiled` opener.

## Detectors (all with synthetic-trigger unit tests)

| Detector | Alert type | Fires when |
|---|---|---|
| `detect_coverage_regression` | `alert:regression` | baseline − current > 0.5 pp |
| `detect_deadline_missed` | `alert:deadline-missed` | `target_date` < today AND phase ≠ `absolute` |
| `detect_escalation` | `alert:escalation` | `escalation_date` < today AND phase ≠ `absolute` |
| `detect_bypass_stale` | `alert:bypass-stale` | break-glass tracking issue open > 7 days |
| `detect_drift_stuck` | `alert:drift-stuck` | drift-sync PR open > 3 days |
| `detect_fleet_bump_fail` | `alert:fleet-bump-fail` | any staging-wave CI result != success |
| `detect_flag_missing` | `alert:flag-missing` | declared flag absent from Codecov totals (one alert per missing flag) |

## Design notes

- **Pure functions** — no gh / HTTP / disk IO; trivially unit-testable.
- **Defensive** — malformed profile shapes (mode:"scalar", mode missing, ratchet as list) return `[]` instead of raising.
- **Fail-closed on unparseable dates** — a garbage `target_date` parses to `date.min`, which triggers the alert, so operators notice the data problem instead of having it silently suppress the detector.
- **`AlertTrigger` dataclass** — pre-packaged `alert_type` / `subject` / `body` triplet the caller feeds straight into `alerts.open_alert_issue`.

## Test plan

- [x] 26 tests + 4 subtests, one happy path + one no-fire case per detector, plus defensive shape tests
- [x] Coverage: 100% on `alert_triggers.py` (92 stmts / 28 branches)
- [x] Full suite: 1333 passed + 39 subtests
- [x] Lizard: max function CCN 3.4 (gate = 15)
- [x] Semgrep: clean
- [x] Codacy metric-engine exclude added

## Follow-up

Phase 5 inc-5.5 will wire each detector into a scheduled workflow (or cron) that actually calls `alerts.open_alert_issue` when detection returns triggers. This PR ships the primitives + the synthetic-trigger verification each §8 row requires.

Part of QZP v2 Phase 5 (tasks 40, 43, 44).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seven pure-function alert detectors to complete §8 alert coverage (with the existing `alert:repo-not-profiled`). This enables downstream jobs to open precise alert issues for regressions, timelines, drift, fleet bumps, and Codecov flags.

- **New Features**
  - Coverage regression: fires when baseline − current > 0.5 pp.
  - Deadline missed: `target_date` < today and phase ≠ `absolute`.
  - Escalation: `escalation_date` < today and phase ≠ `absolute`.
  - Bypass stale: break-glass issue open > 7 days.
  - Drift stuck: drift-sync PR open > 3 days.
  - Fleet bump fail: any staging-wave CI result != success.
  - Flag missing: one alert per declared flag absent from Codecov totals.
  - Returns `AlertTrigger` records for `alerts.open_alert_issue`; pure functions with defensive parsing and fail-closed dates.

<sup>Written for commit b03485de293ec1f93ac1c197c73d711179f08253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Add alert triggers for coverage drops, overdue deadlines, failed fleet bumps, and missing Codecov flags

### What Changed
- Added alert checks for coverage regressions, missed ratchet deadlines, overdue escalation dates, stale break-glass issues, stuck drift-sync PRs, failed staging-wave bumps, and missing coverage flags
- Each check now returns a ready-to-send alert message with a clear subject and body, and handles malformed or missing profile data without crashing
- Added test coverage for trigger and no-trigger cases for each alert path, including edge cases for bad dates and unexpected profile shapes

### Impact
`✅ Earlier coverage regression alerts`
`✅ Fewer missed ratchet deadlines`
`✅ Faster detection of stuck fleet sync work`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bYt27uaxdUSW-TMlOZghmhN_u7k95D082nz79V282DY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
