### PR TITLE
chore(qzp-v2): self-governance — platform profile at phase:absolute + full severity map

### DIFF
--- a/profiles/repos/quality-zero-platform.yml
+++ b/profiles/repos/quality-zero-platform.yml
@@ -1,6 +1,6 @@
 slug: Prekzursil/quality-zero-platform
 version: 2
-stack: python-web
+stack: python-tooling
 mode:
   phase: absolute
 # The platform's OWN CI self-tests against the same zero-gate scanners it
@@ -14,8 +14,23 @@ mode:
 issue_policy:
   mode: audit
 scanners:
-  deepsource_visible:
-    severity: block
+  # Every scanner is severity: block on the platform per Phase 5
+  # self-governance contract. Only socket_project_report drops to info
+  # because it's a probabilistic SBOM report, not an actionable finding.
+  codeql: { severity: block }
+  dependabot: { severity: block }
+  sonarcloud: { severity: block }
+  codacy_issues: { severity: block }
+  codacy_complexity: { severity: block }
+  codacy_clones: { severity: block }
+  codacy_coverage: { severity: block }
+  deepscan: { severity: block }
+  deepsource_visible: { severity: block }
+  semgrep: { severity: block }
+  sentry: { severity: block }
+  socket_pr_alerts: { severity: block }
+  socket_project_report: { severity: info }
+  qlty_check: { severity: block }
 overrides: []
 verify_command: bash scripts/verify
 required_contexts_mode: replace

--- a/profiles/stacks/python-tooling.yml
+++ b/profiles/stacks/python-tooling.yml
@@ -1,0 +1,9 @@
+extends: quality-zero-phase1-common
+stack_family: python-tooling
+# Phase 5 self-governance stack. Used by the platform repo itself and
+# any consumer python CLI-heavy tooling (no Flask / Django / FastAPI
+# surface). Coverage still aggregates through coverage.xml — same shape
+# as python-web so downstream tooling doesn't branch on stack.
+coverage:
+  mode: coverage-xml
+  artifact_path: quality-artifacts/coverage/coverage.xml


### PR DESCRIPTION
## **User description**
## Summary

Aligns `profiles/repos/quality-zero-platform.yml` with the Phase 5 self-governance contract:

- `stack:` bumped from `python-web` → `python-tooling` (matches the Phase 3 stack scaffold the platform targets).
- `mode.phase:` stays `absolute` (already compliant).
- Every scanner gets an explicit `severity: block` entry, except `socket_project_report` which stays at `severity: info` (probabilistic SBOM report, not actionable).

Also adds `profiles/stacks/python-tooling.yml` (missing stack-common YAML), since switching the profile's stack requires the corresponding stack config to exist.

## Scanners now explicitly governed

14 total: codeql, dependabot, sonarcloud, codacy_{issues,complexity,clones,coverage}, deepscan, deepsource_visible, semgrep, sentry, socket_pr_alerts, socket_project_report (info), qlty_check.

## Design notes

- `issue_policy.mode: audit` stays — that's orthogonal to scanner severity. Issue-policy governs whether legacy issue COUNTS fail the gate; scanner severity governs LANE failures. Tightening scanner severity without tightening issue_policy is the deliberate self-hosted-case divergence the design doc calls out.
- The new `python-tooling.yml` stack config is a minimal extension of `quality-zero-phase1-common`, matching `python-web.yml`'s shape so downstream tooling doesn't branch on stack id.

## Test plan

- [x] `profile_shape.validate_profile_shape` → no issues
- [x] `normalize_scanners` → 14 scanners (13 block + 1 info)
- [x] Full control-plane test suite passes (previously failed after the stack rename until `python-tooling.yml` was added)
- [x] `verify_v2_deployment.py --all` → exit 0
- [x] `scripts/verify` pre-push hook passes

Part of QZP v2 Phase 5 self-governance (task 46).


___

## **CodeAnt-AI Description**
Align the platform profile with the Phase 5 self-governance setup

### What Changed
- The platform now uses the python-tooling stack instead of python-web
- Added the missing python-tooling stack profile so the platform can use that stack
- All scanners are now set to block the pipeline, except socket_project_report which remains informational

### Impact
`✅ Clearer platform policy enforcement`
`✅ Fewer stack mismatch failures`
`✅ Consistent scanner blocking across the platform`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=vnFZi21R1lbFMrTpgUPXzI1FjVS84ucz5_rDviQPmXo&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the platform profile with Phase 5 self-governance. Switches to the `python-tooling` stack and sets an explicit scanner severity map (block by default, `socket_project_report` stays info).

- **Refactors**
  - Switch profile stack to `python-tooling`; add `profiles/stacks/python-tooling.yml`.
  - Define explicit severities for 14 scanners: 13 set to block; `socket_project_report` set to info.
  - Keep `mode.phase: absolute` and `issue_policy.mode: audit`.

<sup>Written for commit 993d05bba16062785b8658ba71b93e1ade2ac993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

