### PR TITLE
feat(qzp-v2 phase 5 inc-5.5): alert dispatcher glue — triggers to gh issues

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -35,6 +35,7 @@ engines:
       - "scripts/quality/bumps.py"
       - "scripts/quality/admin_dashboard_pages.py"
       - "scripts/quality/alert_triggers.py"
+      - "scripts/quality/alert_dispatch.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/scripts/quality/alert_dispatch.py
+++ b/scripts/quality/alert_dispatch.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Phase 5 alert-dispatch glue — runs every detector over fleet state.
+
+``dispatch_detected_triggers`` is the thin adapter between the pure
+detectors in :mod:`alert_triggers` and the gh-backed opener in
+:mod:`alerts`. Each :class:`~alert_triggers.AlertTrigger` becomes one
+(or zero) open alert issue, deduped by title.
+
+``build_triggers_from_fleet_state`` composes every detector against
+an aggregated ``fleet_state`` dict (profiles + bypass issues + drift
+PRs + staging wave results). Callers populate ``fleet_state`` from
+whatever source of truth is cheapest (gh API, state-file JSON,
+scheduled workflow).
+
+Both functions are IO-free: the actual gh calls happen in ``alerts``
+which the caller injects via ``opener``. That keeps the module
+unit-testable without network / filesystem.
+"""
+
+from __future__ import absolute_import
+
+import datetime as dt
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping
+
+from scripts.quality import alert_triggers as at
+from scripts.quality import alerts
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+Opener = Callable[..., Mapping[str, Any]]
+
+
+def dispatch_detected_triggers(
+    *,
+    platform_slug: str,
+    triggers: Iterable[at.AlertTrigger],
+    opener: Opener = alerts.open_alert_issue,
+    dry_run: bool = False,
+) -> List[Dict[str, Any]]:
+    """Open one issue per trigger; return the list of opener results."""
+    results: List[Dict[str, Any]] = []
+    for trigger in triggers:
+        if dry_run:
+            results.append({
+                "number": 0,
+                "title": alerts.alert_issue_title(
+                    trigger.alert_type, trigger.subject,
+                ),
+                "created": False,
+            })
+            continue
+        result = opener(
+            platform_slug,
+            alert_type=trigger.alert_type,
+            subject=trigger.subject,
+            body=trigger.body,
+        )
+        results.append(dict(result))
+    return results
+
+
+def _profile_triggers(
+    profile_entry: Mapping[str, Any], *, today: dt.date,
+) -> List[at.AlertTrigger]:
+    """Run the per-profile detectors (regression, deadlines, flags)."""
+    slug = str(profile_entry.get("slug", ""))
+    profile = profile_entry.get("profile") or {}
+    baseline = float(profile_entry.get("baseline_coverage", 0.0))
+    current = float(profile_entry.get("current_coverage", 0.0))
+    declared = list(profile_entry.get("declared_flags") or [])
+    reported = list(profile_entry.get("reported_flags") or [])
+    triggers: List[at.AlertTrigger] = []
+    triggers.extend(at.detect_coverage_regression(
+        slug=slug, baseline_percent=baseline, current_percent=current,
+    ))
+    triggers.extend(at.detect_deadline_missed(
+        slug=slug, profile=profile, today=today,
+    ))
+    triggers.extend(at.detect_escalation(
+        slug=slug, profile=profile, today=today,
+    ))
+    triggers.extend(at.detect_flag_missing(
+        slug=slug, declared_flags=declared, reported_flags=reported,
+    ))
+    return triggers
+
+
+def _bypass_issue_triggers(
+    issues: Iterable[Mapping[str, Any]], *, now: dt.datetime,
+) -> List[at.AlertTrigger]:
+    """Run ``detect_bypass_stale`` over every tracking issue."""
+    triggers: List[at.AlertTrigger] = []
+    for issue in issues:
+        triggers.extend(at.detect_bypass_stale(
+            slug=str(issue.get("slug", "")),
+            issue_number=int(issue.get("issue_number", 0)),
+            opened_at=issue["opened_at"],
+            now=now,
+        ))
+    return triggers
+
+
+def _drift_pr_triggers(
+    prs: Iterable[Mapping[str, Any]], *, now: dt.datetime,
+) -> List[at.AlertTrigger]:
+    """Run ``detect_drift_stuck`` over every open drift-sync PR."""
+    triggers: List[at.AlertTrigger] = []
+    for pr in prs:
+        triggers.extend(at.detect_drift_stuck(
+            slug=str(pr.get("slug", "")),
+            pr_number=int(pr.get("pr_number", 0)),
+            opened_at=pr["opened_at"],
+            now=now,
+        ))
+    return triggers
+
+
+def build_triggers_from_fleet_state(
+    state: Mapping[str, Any],
+) -> List[at.AlertTrigger]:
+    """Run every detector over the aggregated fleet state."""
+    today: dt.date = state.get("today", dt.date.today())
+    now: dt.datetime = state.get("now", dt.datetime.now(dt.timezone.utc))
+
+    triggers: List[at.AlertTrigger] = []
+    for profile_entry in state.get("profiles", []):
+        triggers.extend(_profile_triggers(profile_entry, today=today))
+    triggers.extend(_bypass_issue_triggers(
+        state.get("bypass_issues", []), now=now,
+    ))
+    triggers.extend(_drift_pr_triggers(
+        state.get("drift_prs", []), now=now,
+    ))
+
+    recipe_name = str(state.get("recipe_name", ""))
+    staging = list(state.get("staging_results", []))
+    if recipe_name and staging:
+        triggers.extend(at.detect_fleet_bump_fail(
+            recipe_name=recipe_name, staging_results=staging,
+        ))
+    return triggers
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import json
+
+    print(json.dumps({
+        "module": "alert_dispatch",
+        "detectors": 7,
+        "public_api": [
+            "dispatch_detected_triggers",
+            "build_triggers_from_fleet_state",
+        ],
+    }, indent=2, sort_keys=True))

--- a/tests/test_alert_dispatch.py
+++ b/tests/test_alert_dispatch.py
@@ -1,0 +1,207 @@
+"""Tests for ``scripts.quality.alert_dispatch``.
+
+The dispatcher iterates every detector in ``alert_triggers`` over the
+appropriate inputs and calls ``alerts.open_alert_issue`` for each
+trigger that fires. This is the last wiring step of Phase 5 inc-5.
+"""
+
+from __future__ import absolute_import
+
+import datetime as dt
+import unittest
+from unittest.mock import MagicMock
+
+from scripts.quality import alert_dispatch
+from scripts.quality import alert_triggers as at
+from scripts.quality import alerts
+
+
+class DispatchDetectedTriggersTests(unittest.TestCase):
+    """``dispatch_detected_triggers`` hands each trigger to the opener."""
+
+    def test_each_trigger_opens_one_issue(self) -> None:
+        """Two triggers → two calls to ``open_alert_issue``."""
+        triggers = [
+            at.AlertTrigger(
+                alert_type=alerts.AlertType.REGRESSION,
+                subject="org/repo", body="body-a",
+            ),
+            at.AlertTrigger(
+                alert_type=alerts.AlertType.FLAG_MISSING,
+                subject="org/repo:ui", body="body-b",
+            ),
+        ]
+        opener = MagicMock(side_effect=[
+            {"number": 1, "title": "x", "created": True},
+            {"number": 2, "title": "y", "created": True},
+        ])
+        results = alert_dispatch.dispatch_detected_triggers(
+            platform_slug="Prekzursil/quality-zero-platform",
+            triggers=triggers,
+            opener=opener,
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(opener.call_count, 2)
+        first_call = opener.call_args_list[0]
+        self.assertEqual(first_call.kwargs["alert_type"], alerts.AlertType.REGRESSION)
+        self.assertEqual(first_call.kwargs["subject"], "org/repo")
+        self.assertEqual(first_call.kwargs["body"], "body-a")
+
+    def test_dry_run_does_not_invoke_opener(self) -> None:
+        """``dry_run=True`` yields stub records and never calls the opener."""
+        trigger = at.AlertTrigger(
+            alert_type=alerts.AlertType.REGRESSION,
+            subject="org/repo", body="body",
+        )
+        opener = MagicMock()
+        results = alert_dispatch.dispatch_detected_triggers(
+            platform_slug="Prekzursil/quality-zero-platform",
+            triggers=[trigger],
+            opener=opener,
+            dry_run=True,
+        )
+        opener.assert_not_called()
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0]["created"])
+        self.assertEqual(results[0]["title"], "[alert:regression] org/repo")
+
+    def test_no_triggers_no_opener_calls(self) -> None:
+        """Empty triggers list → no opener calls, empty results list."""
+        opener = MagicMock()
+        results = alert_dispatch.dispatch_detected_triggers(
+            platform_slug="Prekzursil/quality-zero-platform",
+            triggers=[],
+            opener=opener,
+        )
+        self.assertEqual(results, [])
+        opener.assert_not_called()
+
+
+class BuildTriggersFromFleetStateTests(unittest.TestCase):
+    """``build_triggers_from_fleet_state`` aggregates every detector's output."""
+
+    def test_all_detectors_run_and_concatenated(self) -> None:
+        """Coverage regression + deadline missed + flag missing all fire."""
+        state = {
+            "today": dt.date(2026, 4, 23),
+            "now": dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+            "profiles": [
+                {
+                    "slug": "org/cov-drop",
+                    "profile": {"mode": {"phase": "absolute"}},
+                    "baseline_coverage": 100.0,
+                    "current_coverage": 98.0,
+                    "declared_flags": ["backend", "ui"],
+                    "reported_flags": ["backend"],
+                },
+                {
+                    "slug": "org/deadline-past",
+                    "profile": {
+                        "mode": {
+                            "phase": "ratchet",
+                            "ratchet": {"target_date": "2026-01-01"},
+                        },
+                    },
+                    "baseline_coverage": 100.0,
+                    "current_coverage": 100.0,
+                    "declared_flags": [],
+                    "reported_flags": [],
+                },
+            ],
+            "bypass_issues": [
+                {
+                    "slug": "org/stale",
+                    "issue_number": 7,
+                    "opened_at": dt.datetime(2026, 4, 10, tzinfo=dt.timezone.utc),
+                },
+            ],
+            "drift_prs": [],
+            "staging_results": [],
+            "recipe_name": "",
+        }
+        triggers = alert_dispatch.build_triggers_from_fleet_state(state)
+        kinds = {t.alert_type for t in triggers}
+        self.assertIn(alerts.AlertType.REGRESSION, kinds)
+        self.assertIn(alerts.AlertType.DEADLINE_MISSED, kinds)
+        self.assertIn(alerts.AlertType.FLAG_MISSING, kinds)
+        self.assertIn(alerts.AlertType.BYPASS_STALE, kinds)
+
+    def test_empty_state_yields_no_triggers(self) -> None:
+        """All-empty inputs → zero triggers."""
+        state = {
+            "today": dt.date(2026, 4, 23),
+            "now": dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+            "profiles": [],
+            "bypass_issues": [],
+            "drift_prs": [],
+            "staging_results": [],
+            "recipe_name": "",
+        }
+        triggers = alert_dispatch.build_triggers_from_fleet_state(state)
+        self.assertEqual(triggers, [])
+
+    def test_fleet_bump_only_fires_when_recipe_and_staging_present(self) -> None:
+        """Empty staging_results → no fleet-bump alert (no wave happened)."""
+        state = {
+            "today": dt.date(2026, 4, 23),
+            "now": dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+            "profiles": [],
+            "bypass_issues": [],
+            "drift_prs": [],
+            "staging_results": [],
+            "recipe_name": "Node 20 -> 24",
+        }
+        triggers = alert_dispatch.build_triggers_from_fleet_state(state)
+        self.assertEqual(
+            [t for t in triggers if t.alert_type == alerts.AlertType.FLEET_BUMP_FAIL],
+            [],
+        )
+
+    def test_drift_stuck_fires_from_state(self) -> None:
+        """Drift PR open > 3 days in state → drift-stuck trigger."""
+        state = {
+            "today": dt.date(2026, 4, 23),
+            "now": dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+            "profiles": [],
+            "bypass_issues": [],
+            "drift_prs": [
+                {
+                    "slug": "org/slow-repo",
+                    "pr_number": 77,
+                    "opened_at": dt.datetime(2026, 4, 18, tzinfo=dt.timezone.utc),
+                },
+            ],
+            "staging_results": [],
+            "recipe_name": "",
+        }
+        triggers = alert_dispatch.build_triggers_from_fleet_state(state)
+        drift_triggers = [
+            t for t in triggers
+            if t.alert_type == alerts.AlertType.DRIFT_STUCK
+        ]
+        self.assertEqual(len(drift_triggers), 1)
+        self.assertEqual(drift_triggers[0].subject, "org/slow-repo#77")
+
+    def test_fleet_bump_fires_when_staging_failure(self) -> None:
+        """Staging failures + recipe name → bump alert fires."""
+        state = {
+            "today": dt.date(2026, 4, 23),
+            "now": dt.datetime(2026, 4, 23, tzinfo=dt.timezone.utc),
+            "profiles": [],
+            "bypass_issues": [],
+            "drift_prs": [],
+            "staging_results": [
+                {"slug": "org/staging-a", "conclusion": "failure"},
+            ],
+            "recipe_name": "Node 20 -> 24",
+        }
+        triggers = alert_dispatch.build_triggers_from_fleet_state(state)
+        bump = [
+            t for t in triggers
+            if t.alert_type == alerts.AlertType.FLEET_BUMP_FAIL
+        ]
+        self.assertEqual(len(bump), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Closes the Phase 5 alert contract end-to-end by adding `alert_dispatch.py` — the glue between the pure detectors in `alert_triggers.py` and the gh-backed opener in `alerts.py`.

## Public API

- `dispatch_detected_triggers(platform_slug, triggers, opener, dry_run)` — opens one issue per trigger; `dry_run=True` yields stub records without invoking the opener.
- `build_triggers_from_fleet_state(state)` — runs every detector against an aggregated fleet-state dict (profiles + bypass issues + drift PRs + staging wave results). Skips fleet-bump detection when no wave has happened.

## The full Phase 5 alert pipeline

```
             ┌────────────────────────────┐
fleet state ─│ build_triggers_from_state  │─► AlertTrigger[] ─► dispatch_detected_triggers ─► gh issues
             └────────────────────────────┘                                  │
                    alert_triggers.py                                        └─► alerts.open_alert_issue (dedupe by title)
```

Each stage is IO-free at its boundaries:
- Detectors = pure functions over state dicts
- Dispatcher = pure function + injected opener
- Opener = runs gh through injected `ProcessRunner`

That means every stage is trivially unit-testable, and CI never races gh / the Codecov API.

## Test plan

- [x] 8 tests covering dispatch (dry-run, normal, empty), fleet-state composition, drift-stuck from state, bump failure detection
- [x] Coverage: 100% on `alert_dispatch.py` (58 stmts / 12 branches)
- [x] Full suite: 1341 passed + 39 subtests
- [x] Lizard: max function CCN 2.8 (gate = 15)
- [x] Semgrep: clean
- [x] Codacy metric-engine exclude added

## Follow-up

Wiring the dispatcher into a scheduled workflow (`cron: "0 */6 * * *"` or similar) is operational, not code. Task 45 tracks it.

Part of QZP v2 Phase 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an alert dispatch system for detecting and reporting quality issues across fleet states, including coverage regressions, missed deadlines, missing flags, and stale bypass tracking.

* **Tests**
  * Added comprehensive test coverage for alert detection and dispatch functionality, including dry-run mode validation.

* **Chores**
  * Updated quality analysis configuration to exclude new quality scripts from metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add alert dispatching from fleet state to GitHub issues**

### What Changed
- Added a dispatcher that turns detected alerts into one GitHub issue per trigger, with a dry-run mode that returns stub results instead of creating issues
- Added fleet-state scanning that gathers alerts from repo profiles, stale bypass issues, stuck drift PRs, and failed staging waves
- Fleet-bump alerts are only checked when both a recipe name and staging results are present, so no alert is raised before a wave has happened
- Added tests covering normal dispatch, dry-run behavior, empty inputs, and each fleet-state alert path

### Impact
`✅ One issue per detected alert`
`✅ No accidental alert creation during dry runs`
`✅ Fewer missed stale or stuck fleet alerts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4DtW_r4d12UypfGcMqRreUsKJBH30HGQm3MqS1njUfc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `alert_dispatch.py` to turn detected triggers into GitHub issues via `alerts.open_alert_issue`, completing the Phase 5 alert pipeline. Also adds `build_triggers_from_fleet_state` to run all detectors over fleet state, with dry-run support.

- **New Features**
  - `dispatch_detected_triggers(platform_slug, triggers, opener, dry_run)` opens one issue per trigger; `dry_run=True` returns stub records and skips the opener.
  - `build_triggers_from_fleet_state(state)` runs all detectors across profiles, bypass issues, drift PRs, and staging results; skips fleet-bump when no staging wave is present.

<sup>Written for commit 725b65c45f8b4e0ba976cc8830980d77c11aaf88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

