### PR TITLE
feat(qzp-v2 phase 5 inc-3.5): reusable-bumps.yml workflow + rollout planner

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -36,6 +36,7 @@ engines:
       - "scripts/quality/admin_dashboard_pages.py"
       - "scripts/quality/alert_triggers.py"
       - "scripts/quality/alert_dispatch.py"
+      - "scripts/quality/bump_rollout.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/.github/workflows/reusable-bumps.yml
+++ b/.github/workflows/reusable-bumps.yml
@@ -1,0 +1,120 @@
+name: Reusable Bumps
+
+# QZP v2 Phase 5 §5.5 — fleet-wide bump recipe rollout.
+# ``workflow_dispatch`` entry point that loads a recipe from
+# ``profiles/bumps/<date>-<name>.yml``, validates it against the
+# bump-recipe schema, plans the staging + rollout waves, and
+# (in a future increment) opens the per-repo PRs. Today this
+# workflow ships the PLAN step so the recipe schema is reachable
+# from CI. The per-repo PR-opening + staging-CI wait + rollback
+# land in a follow-up increment.
+#
+# Waves, per the design doc:
+#  1. Stage 1: open PRs against ``staging_repos``. Wait for CI
+#     green on all.
+#  2. Stage 2 (auto when ``full_rollout_after_staging: true``):
+#     open PRs against the rest of the affected fleet.
+#  3. Rollback: if stage 1 CI fails on >= 1 repo, revert the
+#     bump recipe commit + open ``alert:fleet-bump-fail``.
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      recipe_path:
+        type: string
+        required: true
+        description: "Path to the bump recipe YAML (e.g. ``profiles/bumps/2026-04-23-node-24.yml``)."
+      fleet_path:
+        type: string
+        required: false
+        default: inventory/repos.yml
+        description: "Path to fleet inventory; used to compute the rollout wave."
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, print the plan but do not open PRs or touch alerts."
+
+concurrency:
+  group: bumps-${{ inputs.recipe_path }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      staging: ${{ steps.plan.outputs.staging }}
+      rollout: ${{ steps.plan.outputs.rollout }}
+      recipe_name: ${{ steps.plan.outputs.recipe_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Plan rollout waves
+        id: plan
+        env:
+          BUMP_RECIPE_PATH: ${{ inputs.recipe_path }}
+          BUMP_FLEET_PATH: ${{ inputs.fleet_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          import yaml
+          from scripts.quality import bumps, bump_rollout
+
+          recipe_path = Path(os.environ["BUMP_RECIPE_PATH"].strip())
+          fleet_path_raw = os.environ.get("BUMP_FLEET_PATH", "").strip()
+
+          recipe = bumps.load_bump_recipe(recipe_path)
+          fleet: list = []
+          if fleet_path_raw and Path(fleet_path_raw).is_file():
+              raw = yaml.safe_load(Path(fleet_path_raw).read_text(encoding="utf-8")) or {}
+              fleet = list(raw.get("repos", []))
+
+          plan = bump_rollout.plan_rollout(recipe=recipe, fleet=fleet)
+
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"recipe_name={recipe['name']}\n")
+                  fh.write(f"staging={json.dumps(plan['staging'])}\n")
+                  fh.write(f"rollout={json.dumps(plan['rollout'])}\n")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write(f"## Bump Rollout Plan — {recipe['name']}\n\n")
+                  fh.write(f"- Recipe: `{recipe_path}`\n")
+                  fh.write(f"- Affects stacks: `{', '.join(recipe['affects_stacks'])}`\n")
+                  fh.write(f"- Staging ({len(plan['staging'])}): ")
+                  fh.write(", ".join(f"`{s}`" for s in plan['staging']) + "\n")
+                  fh.write(f"- Rollout ({len(plan['rollout'])}): ")
+                  fh.write(", ".join(f"`{s}`" for s in plan['rollout']) + "\n")
+                  fh.write("- Per-repo PR opening arrives in a follow-up "
+                           "increment (Phase 5 inc-3.6).\n")
+          PY
+
+  notify-dry-run:
+    needs: plan
+    if: ${{ inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Record dry-run
+        env:
+          BUMP_RECIPE_NAME: ${{ needs.plan.outputs.recipe_name }}
+          BUMP_STAGING: ${{ needs.plan.outputs.staging }}
+          BUMP_ROLLOUT: ${{ needs.plan.outputs.rollout }}
+        run: |
+          echo "Dry-run — no PRs opened for $BUMP_RECIPE_NAME."
+          echo "Staging: $BUMP_STAGING"
+          echo "Rollout: $BUMP_ROLLOUT"

--- a/scripts/quality/bump_rollout.py
+++ b/scripts/quality/bump_rollout.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Phase 5 bump rollout planner.
+
+Pure-logic primitives the ``reusable-bumps.yml`` workflow uses to turn
+a validated bump recipe (see :mod:`bumps`) into a concrete rollout
+plan:
+
+* ``plan_rollout(recipe, fleet)`` — returns
+  ``{"staging": [...], "rollout": [...]}`` split by wave.
+* ``classify_staging_outcome(staging_results)`` — returns
+  ``{"proceed_to_rollout", "rollback_required", "failed_repos"}``.
+
+Both functions are IO-free so they are trivially unit-testable
+without gh / disk / network. The workflow does the side-effecting
+work (opening PRs, reverting, opening ``alert:fleet-bump-fail``).
+"""
+
+from __future__ import absolute_import
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+def _dedupe_preserving_order(values: Iterable[str]) -> List[str]:
+    """Return ``values`` deduped + stripped, preserving first-seen order."""
+    seen: Dict[str, None] = {}
+    for raw in values:
+        cleaned = str(raw).strip()
+        if cleaned and cleaned not in seen:
+            seen[cleaned] = None
+    return list(seen.keys())
+
+
+def plan_rollout(
+    *,
+    recipe: Mapping[str, Any],
+    fleet: Sequence[Mapping[str, Any]],
+) -> Dict[str, List[str]]:
+    """Split ``fleet`` into staging vs full-rollout lists for ``recipe``."""
+    affected_stacks = {str(s).strip() for s in recipe.get("affects_stacks", [])}
+    staging_slugs = set(
+        _dedupe_preserving_order(recipe.get("staging_repos", [])),
+    )
+    staging_order = _dedupe_preserving_order(recipe.get("staging_repos", []))
+
+    rollout: List[str] = []
+    for entry in fleet:
+        slug = str(entry.get("slug", "")).strip()
+        stack = str(entry.get("stack", "")).strip()
+        if not slug or stack not in affected_stacks:
+            continue
+        if slug in staging_slugs:
+            continue
+        rollout.append(slug)
+
+    if not recipe.get("full_rollout_after_staging", True):
+        rollout = []
+
+    return {"staging": staging_order, "rollout": rollout}
+
+
+def classify_staging_outcome(
+    *, staging_results: Sequence[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Decide rollout/rollback/wait from staging CI conclusions."""
+    if not staging_results:
+        return {
+            "proceed_to_rollout": False,
+            "rollback_required": False,
+            "failed_repos": [],
+        }
+    failed = [
+        str(entry.get("slug", "<unknown>"))
+        for entry in staging_results
+        if str(entry.get("conclusion", "")) != "success"
+    ]
+    return {
+        "proceed_to_rollout": not failed,
+        "rollback_required": bool(failed),
+        "failed_repos": failed,
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import argparse
+    import json
+
+    from scripts.quality import bumps
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", required=True)
+    parser.add_argument("--fleet", default="")
+    _args = parser.parse_args()
+
+    _recipe = bumps.load_bump_recipe(Path(_args.recipe))
+    _fleet: List[Dict[str, Any]] = []
+    if _args.fleet:
+        _fleet = json.loads(Path(_args.fleet).read_text(encoding="utf-8"))
+    _plan = plan_rollout(recipe=_recipe, fleet=_fleet)
+    print(json.dumps({
+        "recipe_name": _recipe["name"],
+        "staging": _plan["staging"],
+        "rollout": _plan["rollout"],
+    }, indent=2, sort_keys=True))

--- a/tests/test_bump_rollout.py
+++ b/tests/test_bump_rollout.py
@@ -1,0 +1,116 @@
+"""Tests for Phase 5 ``scripts.quality.bump_rollout`` — rollout planner."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from scripts.quality import bump_rollout
+
+
+def _recipe(
+    staging=("Prekzursil/staging-a",),
+    stacks=("fullstack-web",),
+    full_rollout_after_staging=True,
+) -> dict:
+    """Helper: build a minimal valid recipe for planner tests."""
+    return {
+        "name": "Node 20 -> 24",
+        "target": [
+            {"file_glob": "**/ci.yml", "yaml_path": "x.y", "value": "24"},
+        ],
+        "affects_stacks": list(stacks),
+        "staging_repos": list(staging),
+        "full_rollout_after_staging": full_rollout_after_staging,
+        "rollback_on_failure": True,
+    }
+
+
+class PlanRolloutTests(unittest.TestCase):
+    """``plan_rollout`` splits affected fleet into staging + rollout waves."""
+
+    def test_staging_repos_excluded_from_rollout(self) -> None:
+        """A staging repo never appears in the full-rollout wave."""
+        recipe = _recipe(
+            staging=("Prekzursil/staging-a",),
+            stacks=("fullstack-web",),
+        )
+        fleet = [
+            {"slug": "Prekzursil/staging-a", "stack": "fullstack-web"},
+            {"slug": "Prekzursil/repo-b", "stack": "fullstack-web"},
+            {"slug": "Prekzursil/repo-c", "stack": "go"},
+        ]
+        plan = bump_rollout.plan_rollout(recipe=recipe, fleet=fleet)
+        self.assertEqual(plan["staging"], ["Prekzursil/staging-a"])
+        self.assertEqual(plan["rollout"], ["Prekzursil/repo-b"])
+
+    def test_rollout_filters_by_affected_stacks(self) -> None:
+        """Fleet repos outside affects_stacks never enter the rollout wave."""
+        recipe = _recipe(stacks=("fullstack-web",), staging=())
+        fleet = [
+            {"slug": "Prekzursil/go-repo", "stack": "go"},
+            {"slug": "Prekzursil/rust-repo", "stack": "rust"},
+        ]
+        plan = bump_rollout.plan_rollout(recipe=recipe, fleet=fleet)
+        self.assertEqual(plan["rollout"], [])
+
+    def test_rollout_suppressed_when_flag_false(self) -> None:
+        """``full_rollout_after_staging: false`` → empty rollout wave."""
+        recipe = _recipe(full_rollout_after_staging=False)
+        fleet = [
+            {"slug": "Prekzursil/staging-a", "stack": "fullstack-web"},
+            {"slug": "Prekzursil/repo-b", "stack": "fullstack-web"},
+        ]
+        plan = bump_rollout.plan_rollout(recipe=recipe, fleet=fleet)
+        self.assertEqual(plan["staging"], ["Prekzursil/staging-a"])
+        self.assertEqual(plan["rollout"], [])
+
+    def test_duplicate_staging_dedup_preserves_order(self) -> None:
+        """``staging_repos`` with dupes/whitespace are cleaned + deduped."""
+        recipe = _recipe(staging=("Prekzursil/a", "Prekzursil/a"))
+        plan = bump_rollout.plan_rollout(recipe=recipe, fleet=[])
+        self.assertEqual(plan["staging"], ["Prekzursil/a"])
+
+    def test_multiple_affected_stacks(self) -> None:
+        """Repos in any of the affected stacks are included in rollout."""
+        recipe = _recipe(stacks=("fullstack-web", "react-vite-vitest"))
+        fleet = [
+            {"slug": "Prekzursil/a", "stack": "fullstack-web"},
+            {"slug": "Prekzursil/b", "stack": "react-vite-vitest"},
+            {"slug": "Prekzursil/c", "stack": "go"},
+        ]
+        plan = bump_rollout.plan_rollout(recipe=recipe, fleet=fleet)
+        self.assertEqual(plan["rollout"], ["Prekzursil/a", "Prekzursil/b"])
+
+
+class ClassifyStagingOutcomeTests(unittest.TestCase):
+    """``classify_staging_outcome`` decides rollout vs rollback."""
+
+    def test_all_staging_green_means_rollout(self) -> None:
+        """100% staging success → ``proceed_to_rollout=True``."""
+        outcome = bump_rollout.classify_staging_outcome(staging_results=[
+            {"slug": "a/b", "conclusion": "success"},
+            {"slug": "c/d", "conclusion": "success"},
+        ])
+        self.assertTrue(outcome["proceed_to_rollout"])
+        self.assertFalse(outcome["rollback_required"])
+        self.assertEqual(outcome["failed_repos"], [])
+
+    def test_any_staging_failure_means_rollback(self) -> None:
+        """Any non-success conclusion → rollback path."""
+        outcome = bump_rollout.classify_staging_outcome(staging_results=[
+            {"slug": "a/b", "conclusion": "success"},
+            {"slug": "c/d", "conclusion": "failure"},
+        ])
+        self.assertFalse(outcome["proceed_to_rollout"])
+        self.assertTrue(outcome["rollback_required"])
+        self.assertEqual(outcome["failed_repos"], ["c/d"])
+
+    def test_empty_staging_results_is_neither_rollout_nor_rollback(self) -> None:
+        """No results yet → wait state (both False)."""
+        outcome = bump_rollout.classify_staging_outcome(staging_results=[])
+        self.assertFalse(outcome["proceed_to_rollout"])
+        self.assertFalse(outcome["rollback_required"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_reusable_bumps.py
+++ b/tests/test_reusable_bumps.py
@@ -1,0 +1,79 @@
+"""Contract tests for ``reusable-bumps.yml``.
+
+Phase 5 §5.5 workflow that plans the staging + rollout waves for a
+bump recipe. Pins the inputs, env-var indirection, and dry_run gate
+so future edits can't silently drop the safety net.
+"""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "reusable-bumps.yml"
+)
+
+
+class ReusableBumpsWorkflowTests(unittest.TestCase):
+    """Invariants on the reusable-bumps workflow."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_is_workflow_dispatch(self) -> None:
+        """Entry is manual dispatch from the platform repo."""
+        # ``on:`` parses as YAML boolean True — access via that key.
+        self.assertIn("workflow_dispatch", self.doc[True])
+
+    def test_required_recipe_path_input(self) -> None:
+        """``recipe_path`` is mandatory."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        self.assertIn("recipe_path", inputs)
+        self.assertTrue(inputs["recipe_path"].get("required"))
+
+    def test_dry_run_defaults_to_true(self) -> None:
+        """Safety net: dry-run is the default."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        self.assertIn("dry_run", inputs)
+        self.assertTrue(inputs["dry_run"].get("default", False))
+
+    def test_env_var_indirection_inside_heredoc_body(self) -> None:
+        """No ``${{ github.* }}`` / ``${{ inputs.* }}`` inside PY heredoc."""
+        heredocs = re.findall(r"<<'PY'(.+?)PY", self.text, flags=re.DOTALL)
+        self.assertTrue(heredocs, "expected at least one python heredoc")
+        for body in heredocs:
+            with self.subTest(body_excerpt=body[:60]):
+                self.assertNotIn("${{ inputs.", body)
+                self.assertNotIn("${{ github.", body)
+
+    def test_concurrency_key_binds_to_recipe(self) -> None:
+        """Prevent two rollouts of the same recipe from racing."""
+        concurrency = self.doc.get("concurrency", {})
+        self.assertIn("${{ inputs.recipe_path }}", str(concurrency.get("group", "")))
+
+    def test_plan_outputs_declared(self) -> None:
+        """Downstream jobs need the plan's staging / rollout / recipe_name."""
+        plan_job = self.doc["jobs"]["plan"]
+        outputs = plan_job.get("outputs", {})
+        for key in ("staging", "rollout", "recipe_name"):
+            with self.subTest(output=key):
+                self.assertIn(key, outputs)
+
+    def test_permissions_are_narrow(self) -> None:
+        """Top-level permissions empty; plan job has read-only contents."""
+        self.assertEqual(self.doc.get("permissions"), {})
+        plan_perms = self.doc["jobs"]["plan"].get("permissions", {})
+        self.assertEqual(plan_perms.get("contents"), "read")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Adds the last remaining Phase 5 optional artifact — `.github/workflows/reusable-bumps.yml` — plus the pure-logic primitives it depends on (`scripts/quality/bump_rollout.py`). After merge, `verify_v2_deployment.py --all` reports **39 ok / 0 missing / 0 warnings**.

## New files

- `scripts/quality/bump_rollout.py` (37 stmts, 100% cov, 8 tests)
  - `plan_rollout(recipe, fleet)` — splits fleet into staging + rollout waves
  - `classify_staging_outcome(staging_results)` — proceed / rollback / wait predicate
- `.github/workflows/reusable-bumps.yml`
  - `workflow_dispatch` with `recipe_path` (required), `fleet_path` (default `inventory/repos.yml`), `dry_run` (default `true` — safety net)
  - Plan step validates recipe via `bumps.load_bump_recipe`, calls `bump_rollout.plan_rollout`, emits `staging` / `rollout` / `recipe_name` as job outputs
  - Env-var indirection for every `${{ ... }}` in heredocs (blocks CWE-78)
  - Concurrency group keyed to `recipe_path` to prevent racing rollouts
- `tests/test_reusable_bumps.py` — 7 contract tests pinning the shape

## Current scope

- PLAN step fully wired end-to-end (schema validation + wave split + summary rendering).
- Per-repo PR opening + staging-CI wait + rollback arrive in Phase 5 inc-3.6 as a follow-up (this keeps the surface area reviewable).

## Test plan

- [x] 15 tests + 4 subtests across `bump_rollout` + workflow contract
- [x] Coverage: 100% on `bump_rollout.py` (37 stmts / 14 branches)
- [x] Full suite: 1356 passed + 43 subtests
- [x] Lizard: max CCN 4.2 (gate = 15)
- [x] Semgrep: clean
- [x] `verify_v2_deployment.py --all` → exit 0, **39/39 artifacts ok, no warnings**
- [x] Codacy metric-engine exclude added

Closes the last code-only gap in Phase 5. Remaining work for `QZP_V2_FULLY_SHIPPED_AND_VERIFIED` is operational: first drift-sync wave, event-link per-flag Codecov verification, fleet-wide green rollup.


___

## **CodeAnt-AI Description**
**Add a reusable bump rollout planner and workflow**

### What Changed
- Added a reusable workflow that lets maintainers manually plan a bump recipe rollout, with a required recipe path, optional fleet path, and dry-run enabled by default.
- The workflow now shows the staging and rollout waves in the job summary and passes those results to later steps.
- Added rollout planning logic that splits affected repositories into staging and rollout groups, skips staging repos from the rollout wave, and stops rollout when staging is set not to continue.
- Added staging outcome checks so the plan can tell whether rollout should proceed, pause, or roll back based on CI results.
- Added contract tests to lock in the workflow inputs, safety defaults, permissions, and output shape, plus planner tests for staging, rollout filtering, deduping, and failure handling.

### Impact
`✅ Safer fleet-wide bump planning`
`✅ Fewer accidental rollouts`
`✅ Clearer bump rollout summaries`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=jQUeNWaKJcrOiyI2lIl9Rt0pnDb-KlvZWGDRLIQgBys&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
