### PR TITLE
feat(qzp-v2 phase 5 inc-5.6): alert:secret-missing alert type + detector

### DIFF
--- a/scripts/quality/alert_triggers.py
+++ b/scripts/quality/alert_triggers.py
@@ -247,9 +247,31 @@ def detect_flag_missing(
     return triggers
 
 
+def detect_secret_missing(
+    *, slug: str, missing_secrets: Iterable[str],
+) -> List[AlertTrigger]:
+    """One alert per severity:block scanner that lacks its configured secret."""
+    missing = [str(s).strip() for s in missing_secrets if str(s).strip()]
+    triggers: List[AlertTrigger] = []
+    for secret in missing:
+        subject = f"{slug}:{secret}"
+        body = (
+            f"Severity-block scanner on `{slug}` is missing its required "
+            f"secret **{secret}**. Add the secret to the repo's Actions "
+            f"secrets (or the org-level secret for shared scanners). Until "
+            f"the secret lands, the corresponding quality lane will fail."
+        )
+        triggers.append(AlertTrigger(
+            alert_type=alerts.AlertType.SECRET_MISSING,
+            subject=subject, body=body,
+        ))
+    return triggers
+
+
 if __name__ == "__main__":  # pragma: no cover — no ad-hoc CLI yet
     import json
     print(json.dumps({"detectors": [
         "coverage_regression", "deadline_missed", "escalation",
         "bypass_stale", "drift_stuck", "fleet_bump_fail", "flag_missing",
+        "secret_missing",
     ]}))

--- a/scripts/quality/alerts.py
+++ b/scripts/quality/alerts.py
@@ -65,7 +65,7 @@ ProcessRunner = Callable[..., "subprocess.CompletedProcess[str]"]
 
 
 class AlertType(enum.Enum):
-    """The 8 platform alert types from ``docs/QZP-V2-DESIGN.md`` §8."""
+    """The platform alert types from ``docs/QZP-V2-DESIGN.md`` §8 + §9 secrets-sync."""
 
     REGRESSION = "alert:regression"
     DEADLINE_MISSED = "alert:deadline-missed"
@@ -75,6 +75,7 @@ class AlertType(enum.Enum):
     FLEET_BUMP_FAIL = "alert:fleet-bump-fail"
     REPO_NOT_PROFILED = "alert:repo-not-profiled"
     FLAG_MISSING = "alert:flag-missing"
+    SECRET_MISSING = "alert:secret-missing"
 
     @property
     def label(self) -> str:

--- a/tests/test_alert_triggers.py
+++ b/tests/test_alert_triggers.py
@@ -290,6 +290,48 @@ class DetectFleetBumpFailTests(unittest.TestCase):
         self.assertEqual(triggers, [])
 
 
+class DetectSecretMissingTests(unittest.TestCase):
+    """``detect_secret_missing`` fires one alert per missing scanner secret."""
+
+    def test_single_missing_secret_fires_one_alert(self) -> None:
+        """One missing secret → exactly one alert with slug:secret subject."""
+        triggers = at.detect_secret_missing(
+            slug="org/repo",
+            missing_secrets=["CODACY_API_TOKEN"],
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].alert_type, alerts.AlertType.SECRET_MISSING)
+        self.assertEqual(triggers[0].subject, "org/repo:CODACY_API_TOKEN")
+
+    def test_multiple_missing_secrets_each_open_separate_alert(self) -> None:
+        """Two missing secrets → two separate alerts."""
+        triggers = at.detect_secret_missing(
+            slug="org/repo",
+            missing_secrets=["SONAR_TOKEN", "CODECOV_TOKEN"],
+        )
+        self.assertEqual(len(triggers), 2)
+        subjects = sorted(t.subject for t in triggers)
+        self.assertEqual(
+            subjects, ["org/repo:CODECOV_TOKEN", "org/repo:SONAR_TOKEN"],
+        )
+
+    def test_empty_missing_list_does_not_fire(self) -> None:
+        """No missing secrets → no alerts."""
+        triggers = at.detect_secret_missing(
+            slug="org/repo", missing_secrets=[],
+        )
+        self.assertEqual(triggers, [])
+
+    def test_blank_entries_ignored(self) -> None:
+        """Blank / whitespace-only entries in ``missing_secrets`` are skipped."""
+        triggers = at.detect_secret_missing(
+            slug="org/repo",
+            missing_secrets=["", "  ", "REAL_SECRET"],
+        )
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0].subject, "org/repo:REAL_SECRET")
+
+
 class DetectFlagMissingTests(unittest.TestCase):
     """``detect_flag_missing`` fires when a declared flag has no Codecov report."""
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -29,7 +29,7 @@ class AlertTypeRegistryTests(unittest.TestCase):
     """The design spec's 8 alert types are all registered with labels."""
 
     def test_every_documented_alert_type_has_a_label(self) -> None:
-        """All 8 alert:* labels from §8 are exposed as ``AlertType`` members."""
+        """All §8 + §9 alert:* labels are exposed as ``AlertType`` members."""
         expected_labels = {
             "alert:regression",
             "alert:deadline-missed",
@@ -39,6 +39,7 @@ class AlertTypeRegistryTests(unittest.TestCase):
             "alert:fleet-bump-fail",
             "alert:repo-not-profiled",
             "alert:flag-missing",
+            "alert:secret-missing",
         }
         actual_labels = {member.label for member in alerts.AlertType}
         self.assertEqual(actual_labels, expected_labels)


### PR DESCRIPTION
## **User description**
## Summary

Adds the 9th alert type required by the §9 secrets-sync criterion:

> `check_quality_secrets.py` fails when any severity:block scanner lacks its secret on the target repo; opens `alert:secret-missing`.

## Changes

- `alerts.AlertType` — adds `SECRET_MISSING = "alert:secret-missing"` member. The 8 existing members are unchanged, so all callers keep working.
- `alert_triggers.detect_secret_missing(slug, missing_secrets)` — fires one alert per missing scanner secret; blank / whitespace-only entries are skipped; subject is `slug:SECRET_NAME` for dedupe.
- Existing `AlertType` registry test updated to assert the 9-label set.
- 4 new detector tests (single / multiple / empty / blank entries).

## Test plan

- [x] Coverage: 100% on `alerts.py` (82 stmts) and `alert_triggers.py` (100 stmts / 30 branches)
- [x] Full suite: 1360 passed + 43 subtests
- [x] 50 tests across both alert modules, 4 subtests

## Follow-up

Wiring `check_quality_secrets.py` to actually CALL this detector + open the issue is Phase 5 inc-5.7. This PR ships the detector + alert type so the wiring step is a small edit rather than a large new surface.


___

## **CodeAnt-AI Description**
Add alerts for missing scanner secrets

### What Changed
- Adds a new alert when a required scanner secret is missing from a repo
- Sends one alert per missing secret, skips blank entries, and includes the repo plus secret name in the alert subject
- Includes the new `alert:secret-missing` label in the alert list so it can be recognized like the existing alert types
- Adds tests for one secret, multiple secrets, empty input, and blank entries

### Impact
`✅ Clearer missing-secret alerts`
`✅ One alert per missing scanner secret`
`✅ Fewer silent quality-scan failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=6ZxpUFCeUloG2uMo7-0FTh9fb0cRbyv-3pdRZ8Od8hI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
