### PR TITLE
feat(qzp-v2 phase 5 inc-5.7): wire check_quality_secrets to alert:secret-missing

### DIFF
--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -5,13 +5,15 @@ from __future__ import absolute_import
 
 import argparse
 import os
+import subprocess  # nosec B404 # noqa: S404 — indirect gh CLI via alerts opener
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Mapping
+from typing import Any, Callable, Dict, Iterable, List, Mapping
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.quality import alert_triggers, alerts
 from scripts.quality.common import dedupe_strings, utc_timestamp, write_report
 
 NONE_BULLET = "- None"
@@ -48,6 +50,29 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--out-json", default="quality-secrets/secrets.json")
     parser.add_argument("--out-md", default="quality-secrets/secrets.md")
+    parser.add_argument(
+        "--open-alerts",
+        action="store_true",
+        help="Open alert:secret-missing issues on the platform repo for "
+        "every missing required secret.",
+    )
+    parser.add_argument(
+        "--dry-run-alerts",
+        action="store_true",
+        help="With --open-alerts, produce the would-be issues but do not "
+        "invoke gh (safety net for testing).",
+    )
+    parser.add_argument(
+        "--platform-slug",
+        default="Prekzursil/quality-zero-platform",
+        help="Platform repo to open alert issues on.",
+    )
+    parser.add_argument(
+        "--target-repo-slug",
+        default="",
+        help="Repo the secrets are missing on (subject of the alert). "
+        "Defaults to --platform-slug when empty.",
+    )
     return parser.parse_args()
 
 
@@ -115,6 +140,46 @@ def _build_payload(
     }
 
 
+def open_secret_missing_alerts(
+    *,
+    platform_slug: str,
+    target_repo_slug: str,
+    missing_secrets: Iterable[str],
+    runner: Callable[..., "subprocess.CompletedProcess[str]"] = subprocess.run,
+    dry_run: bool = False,
+) -> List[Dict[str, Any]]:
+    """Open one ``alert:secret-missing`` issue per missing scanner secret.
+
+    Thin composition of ``alert_triggers.detect_secret_missing`` and
+    ``alerts.open_alert_issue``: the detector filters blank entries +
+    builds pre-formatted bodies, the opener dedupes by canonical title
+    so re-running this on the same set is a no-op after the first call.
+    """
+    triggers = alert_triggers.detect_secret_missing(
+        slug=target_repo_slug, missing_secrets=missing_secrets,
+    )
+    results: List[Dict[str, Any]] = []
+    for trigger in triggers:
+        if dry_run:
+            results.append({
+                "number": 0,
+                "title": alerts.alert_issue_title(
+                    trigger.alert_type, trigger.subject,
+                ),
+                "created": False,
+            })
+            continue
+        record = alerts.open_alert_issue(
+            platform_slug,
+            alert_type=trigger.alert_type,
+            subject=trigger.subject,
+            body=trigger.body,
+            runner=runner,
+        )
+        results.append(dict(record))
+    return results
+
+
 def main() -> int:
     """Handle main."""
     args = _parse_args()
@@ -138,6 +203,13 @@ def main() -> int:
     )
     if return_code != 0:
         return return_code
+    if args.open_alerts and payload["missing_secrets"]:
+        open_secret_missing_alerts(
+            platform_slug=args.platform_slug,
+            target_repo_slug=args.target_repo_slug or args.platform_slug,
+            missing_secrets=payload["missing_secrets"],
+            dry_run=args.dry_run_alerts,
+        )
     return 0 if payload["status"] == "pass" else 1
 
 

--- a/tests/test_check_quality_secrets.py
+++ b/tests/test_check_quality_secrets.py
@@ -1,0 +1,97 @@
+"""Tests for the Phase 5 secret-missing wiring in ``check_quality_secrets``.
+
+This suite focuses on the new ``open_secret_missing_alerts`` helper added
+to close the §9 secrets-sync criterion:
+
+    ``check_quality_secrets.py`` fails when any severity:block scanner
+    lacks its secret on the target repo; opens ``alert:secret-missing``.
+"""
+
+from __future__ import absolute_import
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock
+
+from scripts.quality import check_quality_secrets as cqs
+
+
+def _fake_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Helper: ``CompletedProcess`` double for runner mocks."""
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+class OpenSecretMissingAlertsTests(unittest.TestCase):
+    """``open_secret_missing_alerts`` opens one issue per missing secret."""
+
+    def test_no_missing_secrets_opens_nothing(self) -> None:
+        """Empty ``missing_secrets`` → zero opener calls, zero results."""
+        runner = MagicMock()
+        results = cqs.open_secret_missing_alerts(
+            platform_slug="Prekzursil/quality-zero-platform",
+            target_repo_slug="Prekzursil/event-link",
+            missing_secrets=[],
+            runner=runner,
+        )
+        self.assertEqual(results, [])
+        runner.assert_not_called()
+
+    def test_dry_run_yields_stub_records_without_calling_gh(self) -> None:
+        """``dry_run=True`` never calls the runner."""
+        runner = MagicMock()
+        results = cqs.open_secret_missing_alerts(
+            platform_slug="Prekzursil/quality-zero-platform",
+            target_repo_slug="Prekzursil/event-link",
+            missing_secrets=["SONAR_TOKEN", "CODECOV_TOKEN"],
+            runner=runner,
+            dry_run=True,
+        )
+        runner.assert_not_called()
+        self.assertEqual(len(results), 2)
+        for record in results:
+            self.assertFalse(record["created"])
+
+    def test_real_call_fires_one_opener_per_missing_secret(self) -> None:
+        """Two missing secrets → ``gh issue list`` + create called for each."""
+        # 4 responses: (list, create) for secret #1 + (list, create) for #2
+        responses = [
+            _fake_completed("[]"),  # no existing issue
+            _fake_completed(
+                "https://github.com/Prekzursil/quality-zero-platform/issues/501\n",
+            ),
+            _fake_completed("[]"),
+            _fake_completed(
+                "https://github.com/Prekzursil/quality-zero-platform/issues/502\n",
+            ),
+        ]
+        runner = MagicMock(side_effect=responses)
+        results = cqs.open_secret_missing_alerts(
+            platform_slug="Prekzursil/quality-zero-platform",
+            target_repo_slug="Prekzursil/event-link",
+            missing_secrets=["SONAR_TOKEN", "CODECOV_TOKEN"],
+            runner=runner,
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(runner.call_count, 4)
+        created = sorted(r["title"] for r in results)
+        self.assertIn("[alert:secret-missing] Prekzursil/event-link:SONAR_TOKEN", created)
+        self.assertIn("[alert:secret-missing] Prekzursil/event-link:CODECOV_TOKEN", created)
+
+    def test_blank_secrets_filtered_out_by_detector(self) -> None:
+        """Blank entries in ``missing_secrets`` don't produce alerts."""
+        runner = MagicMock()
+        results = cqs.open_secret_missing_alerts(
+            platform_slug="Prekzursil/quality-zero-platform",
+            target_repo_slug="Prekzursil/event-link",
+            missing_secrets=["", "  ", ""],
+            runner=runner,
+            dry_run=True,
+        )
+        self.assertEqual(results, [])
+        runner.assert_not_called()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Closes the §9 secrets-sync criterion: `check_quality_secrets.py` now opens `alert:secret-missing` issues on the platform repo when any severity:block scanner lacks its required secret.

## Changes

- **New helper** `open_secret_missing_alerts(platform_slug, target_repo_slug, missing_secrets, runner, dry_run)` — thin composition of `alert_triggers.detect_secret_missing` + `alerts.open_alert_issue`. Dedupes by canonical title so re-runs on the same missing set are no-ops after the first.
- **New CLI flags**: `--open-alerts`, `--dry-run-alerts`, `--platform-slug`, `--target-repo-slug`. `main()` only invokes the opener when `--open-alerts` is set AND the payload has missing secrets, preserving backward compat for callers that don't opt in.
- **4 new tests** covering no-missing / dry-run / real-call / blank-entries paths.

## Design notes

- `check_quality_secrets.py` is legacy and not in the 100%-covered `source` list in `pyproject.toml`. My 4 tests cover the new helper; the existing CLI paths remain as-is.
- The module CCN stays well under the 15 gate (max 3.4 avg, unchanged from before the edit).
- Integrates via dependency injection: callers can pass a mock `runner` (already used in tests) or a custom `subprocess.run` variant; the default calls the real gh CLI.

## Test plan

- [x] 4 tests on the new helper
- [x] Full suite: 1364 passed + 43 subtests
- [x] `python check_quality_secrets.py --help` shows the 4 new flags with descriptions
- [x] Lizard clean (max CCN 3.4)
- [x] Semgrep clean

## Follow-up

The operational secret-sync workflow (fine-grained PAT with `repo.secrets:write` + `audit/secrets-sync.jsonl` append) is tracked separately. This PR wires the DETECTION + ALERT-OPENING half; the sync itself is operational.


___

## **CodeAnt-AI Description**
Open missing-secret alerts when quality checks find absent required secrets

### What Changed
- `check_quality_secrets.py` can now open one `alert:secret-missing` issue for each missing required secret on the platform repo.
- New command-line options let callers turn alert creation on, run it in dry-run mode, and choose the platform and target repository.
- Re-running the check with the same missing secrets does not create duplicate alerts.
- Added tests for no missing secrets, dry-run behavior, real alert creation, and ignoring blank entries.

### Impact
`✅ Faster missing-secret follow-up`
`✅ Fewer duplicate alert issues`
`✅ Safer alert checks in test runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2naIRPN5HvUT7TYixxSyoxkTdet0DUvlty3T95D-sAU&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
