### PR TITLE
feat(qzp-v2 phase 5 inc-4.5): wire dashboard pages to real state JSON

### DIFF
--- a/.github/workflows/publish-admin-dashboard.yml
+++ b/.github/workflows/publish-admin-dashboard.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           python scripts/quality/admin_dashboard_pages.py \
             --audit-jsonl audit/break-glass.jsonl \
+            --coverage-json quality-rollup/coverage-trend.json \
+            --drift-jsonl audit/drift-sync.jsonl \
             --output-dir site
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/scripts/quality/admin_dashboard_pages.py
+++ b/scripts/quality/admin_dashboard_pages.py
@@ -182,22 +182,52 @@ def load_audit_jsonl(path: Path) -> List[Dict[str, Any]]:
     return records
 
 
+def load_coverage_rows(path: Path) -> List[Dict[str, Any]]:
+    """Load a per-repo coverage-trend JSON file; empty list if absent."""
+    if not path.is_file():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("repos"), list):
+        raw_rows = payload["repos"]
+    elif isinstance(payload, list):
+        raw_rows = payload
+    else:
+        return []
+    return [dict(row) for row in raw_rows if isinstance(row, dict)]
+
+
+def load_drift_entries(path: Path) -> List[Dict[str, Any]]:
+    """Load drift-sync entries from a JSONL file; empty list if absent."""
+    return load_audit_jsonl(path)
+
+
 if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
     import argparse
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--audit-jsonl", default="")
+    parser.add_argument("--coverage-json", default="")
+    parser.add_argument("--drift-jsonl", default="")
     parser.add_argument("--output-dir", required=True)
     _args = parser.parse_args()
 
     _out = Path(_args.output_dir)
     _out.mkdir(parents=True, exist_ok=True)
+
+    _cov_rows = redact_private_repos(
+        load_coverage_rows(Path(_args.coverage_json)) if _args.coverage_json else []
+    )
     (_out / "coverage.html").write_text(
-        render_coverage_trend_page(rows=[]), encoding="utf-8",
+        render_coverage_trend_page(rows=_cov_rows), encoding="utf-8",
+    )
+
+    _drift_rows = redact_private_repos(
+        load_drift_entries(Path(_args.drift_jsonl)) if _args.drift_jsonl else []
     )
     (_out / "drift.html").write_text(
-        render_drift_page(entries=[]), encoding="utf-8",
+        render_drift_page(entries=_drift_rows), encoding="utf-8",
     )
+
     _audit_rows = (
         load_audit_jsonl(Path(_args.audit_jsonl)) if _args.audit_jsonl else []
     )

--- a/tests/test_admin_dashboard_pages.py
+++ b/tests/test_admin_dashboard_pages.py
@@ -181,5 +181,77 @@ class LoadAuditJsonlTests(unittest.TestCase):
         self.assertEqual(loaded[0]["label"], "real")
 
 
+class LoadCoverageRowsTests(unittest.TestCase):
+    """``load_coverage_rows`` parses per-repo coverage state JSON."""
+
+    def test_direct_list_returns_rows(self) -> None:
+        """File containing a bare JSON list of dicts → rows returned as-is."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "coverage.json"
+            path.write_text(json.dumps([
+                {"slug": "org/a", "coverage_percent": 100.0},
+                {"slug": "org/b", "coverage_percent": 98.5},
+            ]), encoding="utf-8")
+            rows = pages.load_coverage_rows(path)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["slug"], "org/a")
+
+    def test_object_with_repos_key_returns_inner_list(self) -> None:
+        """``{"repos": [...]}`` wrapper (matches inventory shape) also works."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "coverage.json"
+            path.write_text(json.dumps({"repos": [
+                {"slug": "org/a", "coverage_percent": 100.0},
+            ]}), encoding="utf-8")
+            rows = pages.load_coverage_rows(path)
+        self.assertEqual(len(rows), 1)
+
+    def test_missing_file_returns_empty(self) -> None:
+        """Absent path → empty list, no exception."""
+        rows = pages.load_coverage_rows(Path("/does/not/exist.json"))
+        self.assertEqual(rows, [])
+
+    def test_non_dict_rows_filtered(self) -> None:
+        """Rows that aren't dicts (stray scalars) are dropped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "coverage.json"
+            path.write_text(json.dumps([
+                "not-a-dict",
+                {"slug": "org/a", "coverage_percent": 100.0},
+            ]), encoding="utf-8")
+            rows = pages.load_coverage_rows(path)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["slug"], "org/a")
+
+    def test_unexpected_root_shape_returns_empty(self) -> None:
+        """Root scalar (or dict without 'repos') → empty list, no exception."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "coverage.json"
+            path.write_text(json.dumps("just-a-string"), encoding="utf-8")
+            rows = pages.load_coverage_rows(path)
+        self.assertEqual(rows, [])
+
+
+class LoadDriftEntriesTests(unittest.TestCase):
+    """``load_drift_entries`` parses drift-sync JSONL."""
+
+    def test_loads_each_line_as_dict(self) -> None:
+        """One JSONL line per entry."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "drift.jsonl"
+            path.write_text(
+                json.dumps({"slug": "org/a", "status": "open"}) + "\n"
+                + json.dumps({"slug": "org/b", "status": "closed"}) + "\n",
+                encoding="utf-8",
+            )
+            entries = pages.load_drift_entries(path)
+        self.assertEqual(len(entries), 2)
+
+    def test_missing_file_returns_empty(self) -> None:
+        """Absent drift file → empty list."""
+        entries = pages.load_drift_entries(Path("/nope.jsonl"))
+        self.assertEqual(entries, [])
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Closes task #44: wires the 3 Phase 5 dashboard pages to real state JSON instead of rendering empty placeholders.

## Changes

- `scripts/quality/admin_dashboard_pages.py` — two new loaders:
  - `load_coverage_rows(path)` — reads JSON (accepts both bare list and `{"repos": [...]}` wrapper shapes), filters non-dict entries, returns `[]` on missing file / unexpected root shape.
  - `load_drift_entries(path)` — JSONL loader (thin reuse of `load_audit_jsonl` since both are one-record-per-line).
- `.github/workflows/publish-admin-dashboard.yml` — new flags passed to the page builder:
  - `--coverage-json quality-rollup/coverage-trend.json`
  - `--drift-jsonl audit/drift-sync.jsonl`
  - `--audit-jsonl audit/break-glass.jsonl` (unchanged)
- Coverage rows and drift entries both flow through `redact_private_repos()` before rendering, so `visibility: private` rows land on the public dashboard with slug replaced by `<private>`.

## Defensive design

- Missing state files → empty list → placeholder paragraph renders. Safe to merge before the first drift-sync wave or quality rollup actually lands. No runtime error when files absent.
- Both JSON and JSONL loaders tolerate malformed / non-dict entries without throwing.

## Test plan

- [x] 6 new tests (4 coverage + 2 drift), 20 total on the module
- [x] Coverage: 100% on `admin_dashboard_pages.py` (89 stmts / 32 branches)
- [x] Full suite: 1371 passed + 43 subtests
- [x] Lizard max CCN 3.4 (gate = 15)
- [x] Semgrep clean

Part of QZP v2 Phase 5 follow-ups (task #44).

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Wire the three Phase 5 admin dashboard pages to real state JSON so they show coverage and drift data instead of placeholders. Fulfills task #44 with resilient loaders, workflow flags, private-repo redaction, and safe fallbacks when files are missing.

- **New Features**
  - `load_coverage_rows(path)`: supports list or `{"repos": [...]}`, filters non-dict rows, returns `[]` if missing/unexpected.
  - `load_drift_entries(path)`: JSONL loader via `load_audit_jsonl`.
  - Publish workflow now passes `--coverage-json quality-rollup/coverage-trend.json` and `--drift-jsonl audit/drift-sync.jsonl`; all rows go through `redact_private_repos()` before render.

<sup>Written for commit 8a0295918305a244b0a1f587169f7f38ca8e2a40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Wire Phase 5 dashboard pages to real coverage and drift data**

### What Changed
- The dashboard now shows coverage trend data and drift-sync entries instead of empty placeholder pages.
- Coverage data is read from the published coverage trend file, including both plain lists and wrapped `repos` data.
- Drift data is read from the drift-sync log file, and private repository entries are still hidden before rendering.
- Missing or malformed state files now fall back to empty pages instead of breaking the dashboard build.
- Added tests for coverage loading, drift loading, missing files, and invalid rows.

### Impact
`✅ Coverage dashboard shows current repo data`
`✅ Drift page reflects synced state`
`✅ Fewer dashboard build failures when state files are missing`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=IzWWoO0lO6v8cKqXh_M1kLv-yjjsMTl4HeAjNHe8Lys&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
