### PR TITLE
feat(qzp-v2 phase 5 inc-8): reusable-bootstrap-repo accepts stack + initial_mode

### DIFF
--- a/.github/workflows/reusable-bootstrap-repo.yml
+++ b/.github/workflows/reusable-bootstrap-repo.yml
@@ -24,10 +24,34 @@ on:
         type: string
         required: true
         description: "Target consumer repo, ``owner/name``. Used to poll CI."
+      stack:
+        type: choice
+        required: true
+        options:
+          - fullstack-web
+          - python-only
+          - react-vite-vitest
+          - go
+          - rust
+          - swift
+          - cpp-cmake
+          - dotnet-wpf
+          - gradle-java
+          - python-tooling
+        description: "Stack template that seeds the new profile (Phase 5 §5.4)."
+      initial_mode:
+        type: choice
+        required: true
+        options:
+          - shadow
+          - ratchet
+          - absolute
+        description: "Starting ``mode.phase`` for the new profile."
       profile_path:
         type: string
-        required: true
-        description: "Path to the profile in this repo, e.g. ``profiles/repos/event-link.yml``."
+        required: false
+        default: ""
+        description: "Path to the profile YAML (defaults to ``profiles/repos/<sanitised-slug>.yml``)."
       workflow_name:
         type: string
         required: false
@@ -40,7 +64,8 @@ on:
         description: "Target branch on the consumer repo whose runs we count."
       target_phase:
         type: choice
-        required: true
+        required: false
+        default: absolute
         options: [ratchet, absolute]
         description: "Mode to flip to once 3 greens land."
       required_green:
@@ -73,6 +98,8 @@ jobs:
         id: plan
         env:
           BOOTSTRAP_REPO_SLUG: ${{ inputs.repo_slug }}
+          BOOTSTRAP_STACK: ${{ inputs.stack }}
+          BOOTSTRAP_INITIAL_MODE: ${{ inputs.initial_mode }}
           BOOTSTRAP_PROFILE: ${{ inputs.profile_path }}
           BOOTSTRAP_WORKFLOW: ${{ inputs.workflow_name }}
           BOOTSTRAP_BRANCH: ${{ inputs.branch }}
@@ -87,21 +114,55 @@ jobs:
           from scripts.quality import bootstrap_repo as br
 
           slug = os.environ["BOOTSTRAP_REPO_SLUG"].strip()
-          profile_path = Path(os.environ["BOOTSTRAP_PROFILE"].strip())
+          # Default the profile path from the slug when the caller
+          # didn't supply one. ``profiles/repos/<repo-name>.yml`` is the
+          # canonical location for v2 profiles.
+          profile_env = os.environ.get("BOOTSTRAP_PROFILE", "").strip()
+          if not profile_env:
+              profile_env = f"profiles/repos/{slug.split('/', 1)[-1]}.yml"
+          profile_path = Path(profile_env)
           workflow = os.environ["BOOTSTRAP_WORKFLOW"].strip()
           branch = os.environ["BOOTSTRAP_BRANCH"].strip()
           target_phase = os.environ["BOOTSTRAP_TARGET_PHASE"].strip()
           required = int(os.environ.get("BOOTSTRAP_REQUIRED", "3"))
+          stack = os.environ.get("BOOTSTRAP_STACK", "").strip()
+          initial_mode = os.environ.get("BOOTSTRAP_INITIAL_MODE", "").strip()
+
+          # When the profile doesn't exist yet, this is a fresh onboarding
+          # dispatch — write a minimal starter profile using the stack
+          # scaffold so the rest of the workflow can act on it. Full
+          # template rendering from ``profiles/templates/stack/`` arrives
+          # in a follow-up; this starter is enough for verify_v2_deployment
+          # + quality-rollup to recognise the repo.
+          if not profile_path.is_file():
+              profile_path.parent.mkdir(parents=True, exist_ok=True)
+              profile_path.write_text(
+                  f"slug: {slug}\n"
+                  f"version: 2\n"
+                  f"stack: {stack}\n"
+                  f"mode:\n"
+                  f"  phase: {initial_mode}\n"
+                  f"  shadow_until: null\n",
+                  encoding="utf-8",
+              )
+              print(f"Seeded starter profile at {profile_path}")
 
           profile_text = profile_path.read_text(encoding="utf-8")
-          plan = br.compute_promotion_plan(
-              slug=slug,
-              workflow=workflow,
-              branch=branch,
-              profile_yaml=profile_text,
-              target_phase=target_phase,
-              required_green=required,
-          )
+          # Short-circuit when the profile is already at or past the
+          # target phase (nothing to promote). promote_profile raises
+          # ValueError in that case; we short-circuit cleanly instead.
+          try:
+              plan = br.compute_promotion_plan(
+                  slug=slug,
+                  workflow=workflow,
+                  branch=branch,
+                  profile_yaml=profile_text,
+                  target_phase=target_phase,
+                  required_green=required,
+              )
+          except ValueError as exc:
+              print(f"Skipping promotion — {exc}")
+              plan = {"ready": False, "green_runs": 0, "promoted_yaml": ""}
 
           output_path = os.environ.get("GITHUB_OUTPUT")
           if output_path:

--- a/tests/test_reusable_bootstrap_repo.py
+++ b/tests/test_reusable_bootstrap_repo.py
@@ -41,10 +41,28 @@ class ReusableBootstrapRepoWorkflowTests(unittest.TestCase):
     def test_required_inputs_are_declared(self) -> None:
         """Every field the Python planner reads must be a declared input."""
         inputs = self.doc[True]["workflow_dispatch"]["inputs"]
-        for required in ("repo_slug", "profile_path", "target_phase"):
+        for required in ("repo_slug", "stack", "initial_mode"):
             with self.subTest(input=required):
                 self.assertIn(required, inputs)
                 self.assertTrue(inputs[required].get("required"))
+
+    def test_stack_covers_all_phase3_stacks(self) -> None:
+        """``stack`` options include every Phase 3 seeded stack directory."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        stack_options = set(inputs["stack"].get("options", []))
+        for stack_id in (
+            "fullstack-web", "python-only", "react-vite-vitest",
+            "go", "rust", "swift", "cpp-cmake", "dotnet-wpf",
+            "gradle-java", "python-tooling",
+        ):
+            with self.subTest(stack=stack_id):
+                self.assertIn(stack_id, stack_options)
+
+    def test_initial_mode_options_cover_every_phase(self) -> None:
+        """``initial_mode`` options are shadow / ratchet / absolute."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        options = set(inputs["initial_mode"].get("options", []))
+        self.assertEqual(options, {"shadow", "ratchet", "absolute"})
 
     def test_target_phase_limited_to_ratchet_or_absolute(self) -> None:
         """``shadow`` is the starting state — cannot promote back to it."""


### PR DESCRIPTION
## **User description**
## Summary

Closes the Phase 5 §5.4 input-spec bullet in the absolute-done criteria:

> `reusable-bootstrap-repo.yml workflow_dispatch accepts repo_slug + stack + initial_mode; 3-green-shadow-runs then auto-PRs the flip to absolute/ratchet`

## Changes

- **Adds required `stack` input** — choice over all 10 Phase 3 stacks: `fullstack-web`, `python-only`, `react-vite-vitest`, `go`, `rust`, `swift`, `cpp-cmake`, `dotnet-wpf`, `gradle-java`, `python-tooling`.
- **Adds required `initial_mode` input** — choice: `shadow` / `ratchet` / `absolute`.
- `profile_path` becomes optional — defaults to `profiles/repos/<slug-last-segment>.yml` when empty.
- `target_phase` becomes optional with default `absolute`.
- **Planning heredoc**:
  - If the profile path doesn't exist yet, writes a minimal starter profile (`slug + version:2 + stack + mode.phase:<initial_mode> + shadow_until:null`) so the rest of the workflow can act on it. Enough for `verify_v2_deployment` + quality-rollup to recognise the repo.
  - Catches `ValueError` from `promote_profile` (profile already at/past target phase) and short-circuits to `ready=False` — idempotent re-runs are safe.
- **Contract tests** updated: `repo_slug + stack + initial_mode` required trio; new subtests assert every Phase 3 stack id is in the `stack` choice set; `initial_mode` options cover `shadow/ratchet/absolute`.

## Test plan

- [x] 9 tests + 16 subtests (8 new subtests across stack/mode options)
- [x] Full suite: 1402 passed + 58 subtests
- [x] Semgrep clean

## Follow-up

The starter profile is minimal. A future increment will render it from `profiles/templates/stack/<stack>/*` via `template_render.render_template` so `fullstack-web` onboards match the Phase 3 stack scaffold byte-for-byte.

Part of QZP v2 Phase 5 §5.4.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Implements Phase 5 §5.4 by adding `stack` and `initial_mode` inputs to the reusable bootstrap workflow to seed profiles and streamline onboarding. Also defaults `profile_path` and `target_phase`, auto-creates a minimal profile if missing, and makes re-runs safe.

- **New Features**
  - Adds required `stack` (Phase 3 stack choices) and `initial_mode` (`shadow` | `ratchet` | `absolute`).
  - `profile_path` is now optional; defaults to `profiles/repos/<repo-name>.yml`.
  - `target_phase` is now optional; defaults to `absolute`.
  - Seeds a minimal v2 profile when none exists (slug, version, stack, mode.phase, shadow_until).
  - Idempotent planning: short-circuits when already at/past target phase.
  - Tests updated to assert input trio and option sets.

- **Migration**
  - When dispatching, provide `repo_slug`, `stack`, and `initial_mode`.
  - You can omit `profile_path`; the default path will be used.
  - `target_phase` defaults to `absolute` (set to `ratchet` if needed).

<sup>Written for commit 917092320533cac575343d0e17d7db32fab27946. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Allow onboarding to start from a selected stack and initial mode**

### What Changed
- The onboarding workflow now requires a stack and starting mode when creating a new repo profile.
- If no profile path is provided, it now uses a default location based on the repo name.
- Fresh onboarding runs now create a minimal starter profile automatically so the rest of the flow can continue.
- Re-running promotion after a repo has already reached the target phase now exits cleanly instead of failing.
- Tests now check that the workflow exposes the required inputs, includes every supported stack, and offers all allowed starting modes.

### Impact
`✅ Faster repo onboarding`
`✅ Fewer manual profile setup steps`
`✅ Safer repeat promotion runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=EsImQZjWH5FNbOueqJFj5cFWnnNl0VzpT9VFivhQRJ0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
