### PR TITLE
feat(qzp-v2 phase 5 inc-9): drift-sync-wave.yml fleet-wide dispatcher

### DIFF
--- a/.github/workflows/drift-sync-wave.yml
+++ b/.github/workflows/drift-sync-wave.yml
@@ -1,0 +1,102 @@
+name: Drift Sync Wave
+
+# QZP v2 Phase 3 §4 first-wave dispatcher. Loops every repo in
+# ``inventory/repos.yml`` and calls ``reusable-drift-sync.yml``
+# against each. Dry-run by default — flipping to ``false`` requires
+# both a manual dispatch AND the DRIFT_SYNC_PAT secret so the fleet
+# can never be mass-modified by a scheduled cron by accident.
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, per-repo drift-sync reports drift but opens no PRs."
+      slug_filter:
+        type: string
+        required: false
+        default: ""
+        description: "Optional substring filter — only repos whose slug contains this run."
+
+concurrency:
+  group: drift-sync-wave
+  cancel-in-progress: false
+
+jobs:
+  resolve-fleet:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      slugs: ${{ steps.plan.outputs.slugs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Enumerate governed repos
+        id: plan
+        env:
+          QZ_SLUG_FILTER: ${{ inputs.slug_filter }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          inventory = yaml.safe_load(
+              Path("inventory/repos.yml").read_text(encoding="utf-8"),
+          ) or {}
+          repos = inventory.get("repos", [])
+          slug_filter = os.environ.get("QZ_SLUG_FILTER", "").strip()
+          slugs = []
+          for entry in repos:
+              if not isinstance(entry, dict):
+                  continue
+              slug = str(entry.get("slug", "")).strip()
+              if not slug:
+                  continue
+              if slug_filter and slug_filter not in slug:
+                  continue
+              slugs.append(slug)
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"slugs={json.dumps(slugs)}\n")
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write("## Drift Sync Wave — fleet resolution\n\n")
+                  fh.write(f"- Total repos in inventory: {len(repos)}\n")
+                  fh.write(f"- Selected after filter: {len(slugs)}\n")
+                  for slug in slugs:
+                      fh.write(f"  - `{slug}`\n")
+          PY
+
+  sync:
+    needs: resolve-fleet
+    if: ${{ needs.resolve-fleet.outputs.slugs != '[]' && needs.resolve-fleet.outputs.slugs != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        slug: ${{ fromJson(needs.resolve-fleet.outputs.slugs) }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    uses: ./.github/workflows/reusable-drift-sync.yml
+    with:
+      repo_slug: ${{ matrix.slug }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      DRIFT_SYNC_PAT: ${{ secrets.DRIFT_SYNC_PAT }}

--- a/tests/test_drift_sync_wave.py
+++ b/tests/test_drift_sync_wave.py
@@ -1,0 +1,86 @@
+"""Contract tests for ``drift-sync-wave.yml`` fleet-wide dispatcher."""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "drift-sync-wave.yml"
+)
+
+
+class DriftSyncWaveWorkflowTests(unittest.TestCase):
+    """Invariants on the fleet-wide drift-sync wave dispatcher."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_dispatch_only(self) -> None:
+        """Only ``workflow_dispatch`` — no cron to avoid mass-fleet drift."""
+        on_block = self.doc[True]
+        self.assertIn("workflow_dispatch", on_block)
+        self.assertNotIn("schedule", on_block)
+
+    def test_dry_run_defaults_to_true(self) -> None:
+        """Safety net: operators must explicitly opt out of dry-run."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        self.assertIn("dry_run", inputs)
+        self.assertTrue(inputs["dry_run"].get("default", False))
+
+    def test_concurrency_is_fixed_string(self) -> None:
+        """Single-flight wave — two overlapping dispatches merge."""
+        concurrency = self.doc.get("concurrency", {})
+        self.assertEqual(concurrency.get("group"), "drift-sync-wave")
+
+    def test_env_var_indirection_inside_heredoc(self) -> None:
+        """No ``${{ inputs.* }}`` inside the python body."""
+        heredocs = re.findall(r"<<'PY'(.+?)PY", self.text, flags=re.DOTALL)
+        self.assertTrue(heredocs)
+        for body in heredocs:
+            with self.subTest(body_excerpt=body[:60]):
+                self.assertNotIn("${{ inputs.", body)
+                self.assertNotIn("${{ github.", body)
+                self.assertNotIn("${{ secrets.", body)
+
+    def test_sync_job_uses_reusable_workflow(self) -> None:
+        """The per-repo job invokes ``reusable-drift-sync.yml``."""
+        jobs = self.doc["jobs"]
+        self.assertIn("sync", jobs)
+        uses = jobs["sync"].get("uses", "")
+        self.assertIn("reusable-drift-sync.yml", uses)
+
+    def test_matrix_strategy_fanouts_per_slug(self) -> None:
+        """Matrix strategy expands to one job per fleet slug."""
+        sync_job = self.doc["jobs"]["sync"]
+        strategy = sync_job.get("strategy", {})
+        self.assertIn("matrix", strategy)
+        self.assertIn("slug", strategy["matrix"])
+        # fail-fast MUST be false so one broken repo doesn't abort the wave.
+        self.assertIs(strategy.get("fail-fast"), False)
+
+    def test_drift_sync_pat_forwarded_as_secret(self) -> None:
+        """The wave passes DRIFT_SYNC_PAT into the reusable workflow."""
+        sync_secrets = self.doc["jobs"]["sync"].get("secrets", {})
+        self.assertIn("DRIFT_SYNC_PAT", sync_secrets)
+
+    def test_resolve_job_has_read_only_perms(self) -> None:
+        """Enumeration job only needs contents:read."""
+        perms = self.doc["jobs"]["resolve-fleet"].get("permissions", {})
+        self.assertEqual(perms.get("contents"), "read")
+
+    def test_top_level_permissions_empty(self) -> None:
+        """Top-level permissions block is empty — job-level lockdown."""
+        self.assertEqual(self.doc.get("permissions"), {})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

Closes the Phase 3 missing caller for `reusable-drift-sync.yml`. Fans out a single `workflow_dispatch` across every repo in `inventory/repos.yml`, with dry-run as the default.

## Invariants (pinned by 9 contract tests + 1 subtest)

| Invariant | Why |
|---|---|
| `workflow_dispatch` only (no cron) | Operators explicitly initiate fleet waves |
| `dry_run: default true` | Safety net — no accidental mass-modification |
| `slug_filter` input | Scope a wave to a subset during rollout |
| `concurrency: drift-sync-wave` (fixed) | Two overlapping waves merge, not race |
| Env-var indirection in heredoc | CWE-78 defence |
| `fail-fast: false` on matrix | One broken repo doesn't abort the other 14 |
| `DRIFT_SYNC_PAT` forwarded as secret | Per-repo workflow gets the fine-grained PAT |
| Top-level permissions empty; resolve job read-only | Minimum privilege |

## Test plan

- [x] 9 contract tests + 1 subtest
- [x] Full suite: 1411 passed + 59 subtests
- [x] Semgrep clean

## Operational follow-up

After merge, the wave is **operator-dispatchable**:
```
gh workflow run drift-sync-wave.yml -R Prekzursil/quality-zero-platform \
  -f dry_run=true
```

Actually running it across all 15 repos + reviewing/merging the resulting drift PRs is the final operational step for the `first drift-sync wave run against all 15 repos` absolute-done bullet.

Part of QZP v2 Phase 3 §4.


___

## **CodeAnt-AI Description**
Add a manual workflow to run drift sync across the whole repo fleet

### What Changed
- Added a manually triggered fleet-wide drift sync run that starts only when an operator launches it
- Dry run is on by default, and an optional filter lets operators target only repos whose slug matches a chosen string
- The run now processes each repo separately, so one failing repo does not stop the rest
- Only one fleet wave can run at a time, and the workflow shows a summary of which repos were selected

### Impact
`✅ Safer fleet-wide drift runs`
`✅ Fewer aborted multi-repo syncs`
`✅ Easier staged rollout across selected repos`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=qt76pyJgze6nO7bmDhFJKnM1kaVR3uuBSNmIRfSabmE&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
