### PR TITLE
fix(qzp-v2): coverage-input normaliser drops Phase 2 flag — drift-sync wave broke

### DIFF
--- a/scripts/quality/profile_coverage_normalization.py
+++ b/scripts/quality/profile_coverage_normalization.py
@@ -74,26 +74,51 @@ def infer_required_sources(raw_coverage: Mapping[str, Any] | None) -> List[str]:
     return dedupe_strings(inferred)
 
 
-def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, str]]:
-    """Normalize raw coverage input mappings into the shared schema."""
+def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, Any]]:
+    """Normalize raw coverage input mappings into the shared schema.
+
+    Always emits ``format``, ``name``, ``path``. Optional fields are
+    passed through ONLY when present on the raw input:
+
+    * ``flag``       — Phase 2 Codecov per-flag upload identifier.
+                       Required by reusable-codecov-analytics.yml.
+    * ``sources``    — list of source-root globs used by drift-sync
+                       templates (``codecov.yml.j2`` in particular).
+    * ``min_percent``— per-input coverage threshold override.
+
+    Filtering rule unchanged: drop non-dict entries and entries
+    without xml/lcov format or with empty name/path.
+    """
     if not isinstance(raw_inputs, list):
         return []
 
-    normalized_items: List[Dict[str, str]] = []
+    normalized_items: List[Dict[str, Any]] = []
     for item in raw_inputs:
         if not isinstance(item, dict):
             continue
-        normalized_item = {
+        normalized_item: Dict[str, Any] = {
             "format": str(item.get("format", "")).strip().lower(),
             "name": str(item.get("name", "")).strip(),
             "path": str(item.get("path", "")).strip(),
         }
         if (
-            normalized_item["format"] in {"xml", "lcov"}
-            and normalized_item["name"]
-            and normalized_item["path"]
+            normalized_item["format"] not in {"xml", "lcov"}
+            or not normalized_item["name"]
+            or not normalized_item["path"]
         ):
-            normalized_items.append(normalized_item)
+            continue
+        if "flag" in item:
+            normalized_item["flag"] = str(item["flag"]).strip()
+        if "sources" in item and isinstance(item["sources"], list):
+            normalized_item["sources"] = [
+                str(s).strip() for s in item["sources"] if str(s).strip()
+            ]
+        if "min_percent" in item:
+            try:
+                normalized_item["min_percent"] = float(item["min_percent"])
+            except (TypeError, ValueError):
+                pass
+        normalized_items.append(normalized_item)
     return normalized_items
 
 

--- a/scripts/quality/profile_normalization.py
+++ b/scripts/quality/profile_normalization.py
@@ -114,12 +114,12 @@ def merge_required_contexts(
     )
 
 
-def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, str]]:
+def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, Any]]:
     """Handle normalize coverage inputs."""
     return profile_coverage_normalization.normalize_coverage_inputs(raw_inputs)
 
 
-def infer_coverage_inputs(coverage: Mapping[str, Any] | None) -> List[Dict[str, str]]:
+def infer_coverage_inputs(coverage: Mapping[str, Any] | None) -> List[Dict[str, Any]]:
     """Handle infer coverage inputs."""
     return profile_coverage_normalization.infer_coverage_inputs(coverage)
 

--- a/tests/test_control_plane_profiles.py
+++ b/tests/test_control_plane_profiles.py
@@ -209,14 +209,24 @@ class ControlPlaneProfileTests(unittest.TestCase, ControlPlaneAssertions):
             "shared-scanner-matrix / DeepSource Visible Zero",
             profile["required_contexts"]["target"],
         )
+        # Phase 2 contract: ``flag`` MUST flow through the normalizer
+        # so reusable-codecov-analytics.yml can upload one Codecov flag
+        # per coverage input. Drift-sync's ``codecov.yml.j2`` template
+        # also dereferences ``item.flag`` directly under StrictUndefined.
         self.assertEqual(
             profile["coverage"]["inputs"],
             [
-                {"format": "xml", "name": "backend", "path": "backend/coverage.xml"},
+                {
+                    "format": "xml",
+                    "name": "backend",
+                    "path": "backend/coverage.xml",
+                    "flag": "backend",
+                },
                 {
                     "format": "xml",
                     "name": "frontend",
                     "path": "ui/coverage/cobertura-coverage.xml",
+                    "flag": "frontend",
                 },
             ],
         )

--- a/tests/test_quality_common.py
+++ b/tests/test_quality_common.py
@@ -299,6 +299,43 @@ class QualityCommonTests(unittest.TestCase):
                 {"format": "lcov", "name": "lcov", "path": "lcov.info"},
             ],
         )
+
+    def test_normalize_coverage_inputs_passes_phase2_optional_fields(self) -> None:
+        """Phase 2 ``flag`` + Phase 3 ``sources`` + per-input ``min_percent``
+        all survive the normalizer (they previously were silently dropped,
+        breaking ``codecov.yml.j2`` rendering during the drift-sync wave)."""
+        normalised = normalize_coverage_inputs(
+            [
+                {
+                    "format": "xml", "name": "backend", "path": "backend/cov.xml",
+                    "flag": "backend", "sources": ["backend/", " ui/api/ "],
+                    "min_percent": 99.5,
+                },
+                {
+                    "format": "lcov", "name": "ui", "path": "ui/lcov.info",
+                    "flag": " ui ",  # whitespace stripped on flag too
+                    "min_percent": "100",  # numeric strings coerce to float
+                },
+                {
+                    "format": "xml", "name": "no-extras",
+                    "path": "p/cov.xml",
+                    # min_percent of unparseable type is silently dropped
+                    "min_percent": [123],
+                    "sources": "not-a-list",  # silently ignored — must be list
+                },
+            ],
+        )
+        self.assertEqual(len(normalised), 3)
+        self.assertEqual(normalised[0]["flag"], "backend")
+        self.assertEqual(normalised[0]["sources"], ["backend/", "ui/api/"])
+        self.assertEqual(normalised[0]["min_percent"], 99.5)
+        self.assertEqual(normalised[1]["flag"], "ui")
+        self.assertEqual(normalised[1]["min_percent"], 100.0)
+        # Defensive entries: unparseable min_percent + non-list sources
+        # do NOT appear in the normalised dict.
+        self.assertNotIn("min_percent", normalised[2])
+        self.assertNotIn("sources", normalised[2])
+        self.assertNotIn("flag", normalised[2])  # absent on raw → absent on output
         self.assertEqual(
             infer_coverage_inputs(
                 {


### PR DESCRIPTION
## **User description**
## Root cause

Discovered by dispatching the **first drift-sync wave** (run [`24963387413`](https://github.com/Prekzursil/quality-zero-platform/actions/runs/24963387413), opened by PR #123). All 15 per-repo `Detect template drift` jobs crashed identically:

```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'flag'
  at profiles/templates/common/codecov.yml.j2 line 21
```

`profile_coverage_normalization.normalize_coverage_inputs` was silently dropping every field besides `format / name / path`. The raw YAML profiles correctly declared `flag:` per Phase 2 §2.2, but the resolved JSON emitted by `export_profile.py` lost it, so `codecov.yml.j2`'s `{{ item.flag }}` (rendered under `StrictUndefined`) tripped.

## Fix

`normalize_coverage_inputs` now passes through:

- `flag` (string, stripped) — Phase 2 Codecov per-flag upload identifier
- `sources` (list, items stripped + filtered) — Phase 3 templates reference this
- `min_percent` (coerced to float; unparseable values silently dropped)

Optional fields are emitted **only when present** on the raw item — preserving the absent/empty distinction so profiles that don't opt in stay byte-identical pre-fix.

## Test plan

- [x] New unit test `test_normalize_coverage_inputs_passes_phase2_optional_fields` covering: stripped flag, non-list `sources` defence, numeric-string `min_percent` coerced, unparseable `min_percent` dropped
- [x] Existing `test_event_link_profile_installs_lizard_and_enforces_branch_coverage` updated — it was pinning the broken behavior. Now asserts `flag` is preserved on both backend / frontend inputs
- [x] End-to-end verified locally:
  - `export_profile.py` resolved JSON carries `flag: backend / flag: frontend`
  - `template_render('common/codecov.yml.j2', profile)` renders the expected per-flag block (previously crashed)
- [x] Full suite: **1412 passed + 59 subtests**
- [x] Lizard max CCN 5.0 (gate 15)
- [x] Semgrep clean

## Follow-up

After merge, re-dispatch the drift-sync wave:

```
gh workflow run drift-sync-wave.yml -R Prekzursil/quality-zero-platform -f dry_run=true
```

Closes the underlying defect that surfaced via PR #123's wave dispatch.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes drift-sync wave crashes caused by the coverage-input normalizer dropping the Phase 2 `flag`. Optional fields now pass through so Codecov templates render and uploads work per-flag.

- **Bug Fixes**
  - Pass through optional fields when present: `flag` (string, stripped), `sources` (list, items stripped), `min_percent` (float; invalid dropped).
  - Keep existing filters on `format`/`name`/`path`; ignore non-list `sources`.
  - Update types to `List[Dict[str, Any]]` to allow `min_percent` and `sources`.
  - Update/add tests; verified `codecov.yml.j2` renders; full suite passes.

- **Migration**
  - Re-dispatch the drift-sync wave: `gh workflow run drift-sync-wave.yml -R Prekzursil/quality-zero-platform -f dry_run=true`

<sup>Written for commit c10f06ba2277b27f0606e82ca47d1aade6ee1a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Preserve coverage flags and optional fields when profiles are normalized

### What Changed
- Coverage inputs now keep each input's `flag`, so Codecov templates can render per-flag uploads without failing.
- Optional `sources` and `min_percent` values are also kept when present, while invalid or missing values are left out.
- Existing filtering still skips non-coverage entries and inputs missing a valid format, name, or path.
- Tests now cover preserved flags, stripped values, numeric threshold conversion, and ignored invalid extras.

### Impact
`✅ Fewer drift-sync template failures`
`✅ Correct per-flag Codecov uploads`
`✅ Clearer coverage profile output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=yLgfPGde2-84rAF4eZPFGbMKqqjlmT3x_X4RfzD1u9I&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
