### PR TITLE
fix(qzp-v2 phase 3): drift-sync artifact name rejects '/' — escape it

### DIFF
--- a/.github/workflows/reusable-drift-sync.yml
+++ b/.github/workflows/reusable-drift-sync.yml
@@ -74,6 +74,20 @@ jobs:
             --repo-slug "$REPO_SLUG" \
             --out-json "$RUNNER_TEMP/profile.json"
 
+      - name: Compute artifact-safe slug
+        id: artifact_name
+        # ``actions/upload-artifact@v4`` rejects ``/`` in artifact names
+        # (NTFS portability rule), so replace it with ``__``. Empty
+        # slugs fall back to ``unknown`` to keep the artifact step
+        # idempotent in degenerate inputs.
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+        run: |
+          set -euo pipefail
+          slug="${REPO_SLUG:-unknown}"
+          safe="${slug//\//__}"
+          printf 'slug_safe=%s\n' "$safe" >> "$GITHUB_OUTPUT"
+
       - name: Detect template drift
         id: detect
         run: |
@@ -86,7 +100,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: drift-report-${{ inputs.repo_slug == '' && 'unknown' || inputs.repo_slug }}
+          name: drift-report-${{ steps.artifact_name.outputs.slug_safe }}
           path: ${{ runner.temp }}/drift.json
 
       - name: Summarise drift

--- a/tests/test_reusable_drift_sync.py
+++ b/tests/test_reusable_drift_sync.py
@@ -1,0 +1,91 @@
+"""Contract tests for ``reusable-drift-sync.yml``.
+
+Pins the Phase 3 §4 invariants that the per-repo drift-sync workflow
+must hold. Most importantly: the artifact name escapes ``/`` since
+``actions/upload-artifact@v4`` rejects forward slashes (NTFS rule)
+and the wave was failing 15/15 on this exact issue before the
+artifact-name step landed.
+"""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "reusable-drift-sync.yml"
+)
+
+
+class ReusableDriftSyncWorkflowTests(unittest.TestCase):
+    """Invariants on the per-repo drift-sync workflow."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_is_workflow_call(self) -> None:
+        """Drift-sync is invoked from a caller workflow per-repo."""
+        # ``on:`` parses as YAML boolean True under PyYAML.
+        self.assertIn("workflow_call", self.doc[True])
+
+    def test_required_inputs_are_declared(self) -> None:
+        """``repo_slug`` is the only mandatory input (others have defaults)."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        self.assertIn("repo_slug", inputs)
+        self.assertTrue(inputs["repo_slug"].get("required"))
+
+    def test_artifact_name_step_replaces_forward_slash(self) -> None:
+        """``Compute artifact-safe slug`` step replaces ``/`` so ``upload-
+        artifact@v4`` doesn't reject names like ``Prekzursil/event-link``.
+        Without this escape the entire wave failed 15/15 — see the
+        first run of ``drift-sync-wave.yml`` (24963891110)."""
+        steps = self.doc["jobs"]["drift-sync"]["steps"]
+        compute_steps = [
+            s for s in steps
+            if s.get("id") == "artifact_name"
+        ]
+        self.assertEqual(
+            len(compute_steps), 1,
+            "artifact_name step missing — upload-artifact will reject "
+            "names containing forward slashes",
+        )
+        run_body = compute_steps[0].get("run", "")
+        # Use a substitution that produces a slash-free identifier.
+        self.assertRegex(run_body, r"\$\{slug//\\?/")
+
+    def test_upload_step_uses_artifact_safe_slug(self) -> None:
+        """upload-artifact ``name:`` references the computed safe slug."""
+        steps = self.doc["jobs"]["drift-sync"]["steps"]
+        upload_steps = [
+            s for s in steps
+            if "uses" in s and "upload-artifact" in s["uses"]
+        ]
+        self.assertEqual(len(upload_steps), 1)
+        name = upload_steps[0]["with"]["name"]
+        self.assertIn("steps.artifact_name.outputs.slug_safe", name)
+        self.assertNotIn("inputs.repo_slug", name)
+
+    def test_consumer_repo_checkout_uses_drift_sync_pat_or_default(self) -> None:
+        """Consumer-repo checkout falls back to ``github.token`` when no PAT."""
+        steps = self.doc["jobs"]["drift-sync"]["steps"]
+        consumer_checkouts = [
+            s for s in steps
+            if "uses" in s and s["uses"].startswith("actions/checkout")
+            and "inputs.repo_slug" in str(s.get("with", {}).get("repository", ""))
+        ]
+        self.assertEqual(len(consumer_checkouts), 1)
+        token_expr = consumer_checkouts[0]["with"]["token"]
+        self.assertIn("DRIFT_SYNC_PAT", token_expr)
+        self.assertIn("github.token", token_expr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Root cause

Second drift-sync-wave dispatch (run [`24963891110`](https://github.com/Prekzursil/quality-zero-platform/actions/runs/24963891110), after the `flag` passthrough fix in #129) cleared the `codecov.yml.j2` `StrictUndefined` crash but every per-repo job failed at `Upload drift report`:

```
##[error] The artifact name is not valid: drift-report-Prekzursil/event-link.
  Contains the following character: Forward slash /
```

`actions/upload-artifact@v4` rejects `/` in names per the NTFS portability rule. The workflow was building the artifact name as `drift-report-${{ inputs.repo_slug }}` where `repo_slug` is `owner/name` by definition — so 15/15 jobs failed identically.

## Fix

Add a `Compute artifact-safe slug` step that runs:

```bash
slug="${REPO_SLUG:-unknown}"
safe="${slug//\//__}"
printf 'slug_safe=%s\n' "$safe" >> "$GITHUB_OUTPUT"
```

Upload step then references `steps.artifact_name.outputs.slug_safe` instead of the raw input.

## Test plan

- [x] `tests/test_reusable_drift_sync.py` (5 contract tests, new file)
  - workflow_call shape + `repo_slug` required
  - `artifact_name` step exists with bash slash-escape substitution
  - Upload step references the computed safe slug, not raw input
  - Consumer-repo checkout still uses `DRIFT_SYNC_PAT || github.token`
- [x] Full suite: **1417 passed + 59 subtests**
- [x] Semgrep clean

## Follow-up

Re-dispatch the wave after merge. This is the second of likely several latent bugs the wave surfaces — each fix advances the wave one more step.


___

## **CodeAnt-AI Description**
**Escape repository names so drift report uploads succeed**

### What Changed
- Drift report uploads now replace `/` in repository names, so repos like `owner/name` no longer fail at the upload step
- Empty or missing repository names now use `unknown` instead of breaking the upload name
- Added contract tests to lock in the workflow behavior, including the slash-safe artifact name and the fallback for repository checkout

### Impact
`✅ Fewer drift-sync upload failures`
`✅ Successful reports for repos with owner/name slugs`
`✅ Stable wave runs with clearer failure coverage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=idjABdyFOcqG2AkEET3YILNrfDwAq0yCgeHBzR-QcG8&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
