### PR TITLE
chore(qzp-v2): refresh execution-state — wave round-2 + 24 PRs across 2026-04-23..26

### DIFF
--- a/.beads/context/execution-state.md
+++ b/.beads/context/execution-state.md
@@ -73,6 +73,63 @@ Delivered in PR #88 (7 commits + 6 remediation rounds):
 
 Ralph loop emits `<promise>QZP_V2_FULLY_SHIPPED_AND_VERIFIED</promise>` ONLY when every ABSOLUTE DONE bullet is literally true, verified via gh CLI / curl / code inspection — not belief.
 
-## Last action
+## Last action — superseded
 
 Phase 1 PR #88 merged 2026-04-23 05:34Z (squash → `3b57801`). Execution state updated here. About to create `feat/qzp-v2-phase-2-codecov-flag-split` off main.
+
+---
+
+## 2026-04-26 — current state (post wave-dispatch round 2)
+
+**Branch:** main (all in-flight branches merged). 24 PRs merged across the
+2026-04-23 → 2026-04-26 push (PRs #107..#130 — phase-5 inc series + 5
+dependabot bumps + 2 wave-cycle fixes).
+
+**`verify_v2_deployment.py --all` → exit 0** (39 ok / 0 missing / 0 warnings).
+
+### Phase 5 — code-complete
+
+Every Phase 5 bullet has merged code:
+
+- `verify_v2_deployment.py` (#107)
+- `alerts.py` 9-type AlertType enum + dedupe-by-title opener (#108, #117)
+- `bootstrap_repo.py` + `reusable-bootstrap-repo.yml` accepting `repo_slug + stack + initial_mode` trio (#109, #122)
+- `bumps.py` schema loader + canonical Node-20→24 canary recipe (#110)
+- `bump_rollout.py` + `reusable-bumps.yml` plan workflow (#115)
+- `admin_dashboard_pages.py` 3 extra pages + redaction (#111) + state-JSON wiring (#120)
+- `alert_triggers.py` 7 detectors (#112) + `detect_secret_missing` (#117)
+- `alert_dispatch.py` glue (#114) + scheduled cron (#121)
+- self-governance profile @ phase:absolute (#113)
+- `secrets_sync.py` + `reusable-secrets-sync.yml` with closure-based secret handoff + CodeQL config (#119)
+- `check_quality_secrets.py` opens alert:secret-missing (#118)
+- `drift-sync-wave.yml` fleet dispatcher (#123)
+- `coverage_inputs.flag` passthrough fix (#129)
+- drift-sync artifact-name escape fix (#130)
+- §9 migration plan status table (#116)
+
+### Operational wave status
+
+- **Dashboard:** deployed to <https://prekzursil.github.io/quality-zero-platform/> — all 4 pages serve HTTP 200 (curl-verified 2026-04-24). Placeholder content while state JSON is empty.
+- **Drift-sync wave:** dispatched twice. After #129 + #130 the wave runs end-to-end on all 15 fleet repos; per-repo drift reports upload as artifacts. Each report shows real drift (event-link: 5 missing, 1 drift, 0 in_sync). Wave currently exits 1 in dry-run as designed (the "drift detected" sentinel). Real PR-opening run requires `dry_run=false` + `DRIFT_SYNC_PAT` secret.
+- **`alert:*` issues open on platform:** zero (verified 2026-04-24).
+
+### Absolute-done remaining (ordered by tractability)
+
+1. **Drift-sync conflicts resolved** — operator dispatches wave with `dry_run=false` + valid `DRIFT_SYNC_PAT`, reviews + merges 15 PRs, fleet repos converge.
+2. **All 15 governed repos green on main** — follows from (1) + downstream merges.
+3. **event-link Codecov per-flag rows visible** — depends on event-link PR #129 (Coverage 100 Gate currently red on `fix/bump-reusable-codecov-sha`) being remediated + merged + a fresh Codecov run.
+4. **Bumps full-flow tested with Node-20→24 canary** — operator dispatches `reusable-bumps.yml` with `dry_run=false` after staging-wave green.
+
+### Pattern: each wave dispatch surfaced one latent contract bug
+
+| Round | Block | Fix PR |
+| --- | --- | --- |
+| 1 | `codecov.yml.j2` UndefinedError on `flag` (normaliser dropped it) | #129 |
+| 2 | `upload-artifact@v4` rejects `/` in name (`drift-report-Prekzursil/repo`) | #130 |
+| 3 | "Fail on drift when dry_run" exits 1 (intended dry-run signal — not a bug) | n/a |
+
+The wave is now functioning as a fleet-wide integration test — exactly the role the Phase 3 design called for.
+
+## Last action
+
+Drift-sync wave run `24964344652` completed 2026-04-26 ~18:35Z; all 15 jobs reach the dry-run drift-detected sentinel. Wave is behaving correctly. Awaiting operator action for `dry_run=false` rollout.


### PR DESCRIPTION
## **User description**
## Summary

The loop's memory file (`.beads/context/execution-state.md`) was stuck on 2026-04-23 (Phase 2 in-flight) while reality moved well past it: 24 PRs landed (`#107..#130`) covering all of Phase 5 plus the two wave-cycle fixes #129 (coverage-input flag passthrough) and #130 (artifact-name slash-escape).

Appends a fresh `2026-04-26 — current state` section enumerating:

- All 16 Phase 5 increment PRs by topic
- Operational verification: dashboard deployed (curl 200 on all 4 pages), drift-sync wave running end-to-end, zero open `alert:*`
- Absolute-done bullets remaining (operator-action only — fleet PR rollout, event-link CI fix, full-flow bump dispatch)
- Wave-dispatch pattern as fleet-wide integration test (3 rounds so far — 2 bugs caught + fixed, round-3 is the intended dry-run sentinel)

`verify_v2_deployment.py --all` currently reports **39/39 ok** — every required Phase 1-5 deliverable is on disk.

## Test plan

Docs-only change. No code paths affected.

## Why now

Per the loop's per-iteration workflow:
> 4. After each phase PR merges, update `.beads/context/execution-state.md` with what's done and what's next. This is the loop's memory.

The 16-PR backlog of state updates is consolidated here so a future loop iteration that resumes from cold context picks up the right starting point instead of redoing completed work.


___

## **CodeAnt-AI Description**
**Refresh the execution-state log with the latest wave status and merged work**

### What Changed
- Replaces the outdated 2026-04-23 status with a 2026-04-26 snapshot after the second wave-dispatch round
- Lists the Phase 5 work now merged, including dashboard pages, alert handling, secrets sync, bump rollout, and drift-sync fixes
- Updates the operational status: deployment checks pass, the dashboard is live, the drift-sync wave runs end-to-end, and there are no open `alert:*` issues
- Records the remaining operator-only steps and the two wave-dispatch bugs that were found and fixed

### Impact
`✅ Clearer project status`
`✅ Less duplicate work after context restarts`
`✅ Faster handoff for the next operator`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2XPhcbbT-gM8VyqhnwqBnanOcZvtdLcqxBk7MunSpns&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
