### PR TITLE
feat(qzp-v2 phase 5 inc-10): bump_workflow_shas — fleet-wide reusable-workflow SHA bumper

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -38,6 +38,7 @@ engines:
       - "scripts/quality/alert_dispatch.py"
       - "scripts/quality/bump_rollout.py"
       - "scripts/quality/secrets_sync.py"
+      - "scripts/quality/bump_workflow_shas.py"
 exclude_paths:
   - "generated/**"
   - "tests/**"

--- a/scripts/quality/bump_workflow_shas.py
+++ b/scripts/quality/bump_workflow_shas.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Phase-5 follow-up: fleet-wide reusable-workflow SHA bumper.
+
+Discovered 2026-04-26 by auditing the QZP fleet: 14 of 14 consumer
+repos pin pre-Phase-2 SHAs in their caller workflows
+(``codecov-analytics.yml``, ``quality-zero-gate.yml``, etc.). The
+drift-sync wave doesn't touch these — its templates render
+``codecov.yml`` / ``ci.yml`` / etc, not the workflow callers.
+
+This module is the pure logic that walks workflow text, identifies
+``uses: Prekzursil/quality-zero-platform/.github/workflows/<name>.yml@<sha>``
+references, and rewrites every SHA to a target. The companion
+workflow (``bump-workflow-shas-wave.yml``, separate increment) uses
+this to fan out across ``inventory/repos.yml`` and open a bump PR
+on each consumer repo.
+
+Public API:
+
+* ``find_reusable_pins(text)`` — list of ``(workflow_name, sha)``
+  tuples extracted from the text. Branch / tag pins are ignored
+  (only 40-char hex SHAs count as canonical pins).
+* ``bump_pins_to_target(text, target_sha)`` → ``(new_text, count)``.
+  Refuses non-40-char-hex targets to protect against accidental
+  branch-name pinning.
+* ``bump_workflow_files(files, target_sha)`` → ``{path: {bumped, new_text}}``
+  convenience wrapper for the workflow caller.
+"""
+
+from __future__ import absolute_import
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Tuple
+
+
+def _ensure_platform_on_syspath() -> None:
+    """Stage the platform repo root on ``sys.path`` for direct CLI use."""
+    platform_root = Path(__file__).resolve().parents[2]
+    if str(platform_root) in sys.path:
+        return
+    sys.path.insert(0, str(platform_root))  # pragma: no cover
+
+
+_ensure_platform_on_syspath()
+
+
+_QZP_PIN_RE = re.compile(
+    r"Prekzursil/quality-zero-platform/\.github/workflows/"
+    r"(?P<name>[A-Za-z0-9_.-]+\.yml)@(?P<sha>[0-9a-f]{40})\b",
+)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def find_reusable_pins(text: str) -> List[Tuple[str, str]]:
+    """Return ``[(workflow_name, sha), ...]`` for every QZP pin in ``text``."""
+    return [(m.group("name"), m.group("sha")) for m in _QZP_PIN_RE.finditer(text)]
+
+
+def bump_pins_to_target(text: str, *, target_sha: str) -> Tuple[str, int]:
+    """Rewrite every QZP pin in ``text`` to ``target_sha``.
+
+    Returns ``(new_text, count)`` where ``count`` is the number of pins
+    that were actually CHANGED (already-current pins don't increment).
+
+    Raises ``ValueError`` for non-40-char-hex target SHAs to protect
+    against accidental branch-name pinning.
+    """
+    if not _SHA_RE.match(target_sha or ""):
+        raise ValueError(
+            f"target_sha must be a 40-char hex SHA; got {target_sha!r}",
+        )
+    bumps = 0
+
+    def _replace(match: "re.Match[str]") -> str:
+        nonlocal bumps
+        old_sha = match.group("sha")
+        if old_sha == target_sha:
+            return match.group(0)
+        bumps += 1
+        return (
+            f"Prekzursil/quality-zero-platform/.github/workflows/"
+            f"{match.group('name')}@{target_sha}"
+        )
+
+    new_text = _QZP_PIN_RE.sub(_replace, text)
+    return new_text, bumps
+
+
+def bump_workflow_files(
+    files: Mapping[str, str], *, target_sha: str,
+) -> Dict[str, Dict[str, Any]]:
+    """Apply ``bump_pins_to_target`` to every ``{path: text}`` pair.
+
+    Returns ``{path: {"bumped": int, "new_text": str}}``. Files with no
+    QZP pins (``bumped == 0``) keep their original text in ``new_text``.
+    """
+    if not _SHA_RE.match(target_sha or ""):
+        raise ValueError(
+            f"target_sha must be a 40-char hex SHA; got {target_sha!r}",
+        )
+    results: Dict[str, Dict[str, Any]] = {}
+    for path, text in files.items():
+        new_text, count = bump_pins_to_target(text, target_sha=target_sha)
+        results[path] = {"bumped": count, "new_text": new_text}
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target-sha", required=True,
+        help="40-char hex SHA to pin all QZP reusable workflows to.",
+    )
+    parser.add_argument(
+        "--workflow-dir", default=".github/workflows",
+        help="Directory whose .yml files should be bumped in-place.",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Write changes to disk (default: dry-run, prints a summary).",
+    )
+    _args = parser.parse_args()
+
+    _wd = Path(_args.workflow_dir)
+    if not _wd.is_dir():
+        print(f"workflow dir not found: {_wd}", file=sys.stderr)
+        raise SystemExit(2)
+
+    _files = {
+        str(p): p.read_text(encoding="utf-8")
+        for p in sorted(_wd.glob("*.yml"))
+    }
+    _results = bump_workflow_files(_files, target_sha=_args.target_sha)
+
+    summary = {
+        path: result["bumped"] for path, result in _results.items()
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if _args.apply:
+        for path, result in _results.items():
+            if result["bumped"]:
+                Path(path).write_text(result["new_text"], encoding="utf-8")
+                print(f"wrote {path} ({result['bumped']} pin(s) bumped)",
+                      file=sys.stderr)

--- a/tests/test_bump_workflow_shas.py
+++ b/tests/test_bump_workflow_shas.py
@@ -1,0 +1,165 @@
+"""Tests for ``scripts.quality.bump_workflow_shas`` — fleet-wide reusable-workflow SHA bumper.
+
+Discovered by auditing the QZP fleet 2026-04-26: 14 of 14 consumer
+repos pin pre-Phase-2 reusable-workflow SHAs. Drift-sync renders new
+content for codecov.yml / ci.yml / etc but does NOT touch the
+caller workflows that pin platform SHAs. This module is the pure
+logic that walks workflow text, identifies QZP reusable-workflow
+``uses:`` lines, and bumps each SHA to a target.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+from scripts.quality import bump_workflow_shas as bws
+
+
+class FindReusablePinsTests(unittest.TestCase):
+    """``find_reusable_pins`` extracts (name, sha) tuples from workflow text."""
+
+    def test_extracts_single_pin(self) -> None:
+        """One ``uses:`` line → one pin."""
+        text = (
+            "    uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-codecov-analytics.yml@cc7e3095598478230cd85566a72e310acd1a8923\n"
+        )
+        pins = bws.find_reusable_pins(text)
+        self.assertEqual(
+            pins,
+            [("reusable-codecov-analytics.yml",
+              "cc7e3095598478230cd85566a72e310acd1a8923")],
+        )
+
+    def test_extracts_multiple_pins_in_order(self) -> None:
+        """Multiple ``uses:`` references → preserved in document order."""
+        text = (
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-codeql.yml@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-scanner-matrix.yml@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        )
+        pins = bws.find_reusable_pins(text)
+        self.assertEqual(len(pins), 2)
+        self.assertEqual(pins[0][0], "reusable-codeql.yml")
+        self.assertEqual(pins[1][0], "reusable-scanner-matrix.yml")
+
+    def test_ignores_other_repo_workflows(self) -> None:
+        """Pins on workflows from OTHER repos are NOT touched."""
+        text = (
+            "uses: actions/checkout@v4\n"
+            "uses: SomeOtherOrg/other-repo/.github/workflows/x.yml@"
+            "1234567890123456789012345678901234567890\n"
+        )
+        self.assertEqual(bws.find_reusable_pins(text), [])
+
+    def test_ignores_branch_or_tag_pins(self) -> None:
+        """Only 40-char hex SHAs are considered pins (skip @main / @v1 etc)."""
+        text = (
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-codeql.yml@main\n"
+        )
+        self.assertEqual(bws.find_reusable_pins(text), [])
+
+    def test_short_sha_is_ignored(self) -> None:
+        """Short SHAs (<40 chars) are not full pins — skip them."""
+        text = (
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-codeql.yml@cc7e3095\n"
+        )
+        self.assertEqual(bws.find_reusable_pins(text), [])
+
+
+class BumpPinsToTargetTests(unittest.TestCase):
+    """``bump_pins_to_target`` rewrites every QZP SHA to ``target_sha``."""
+
+    def test_bumps_every_qzp_pin(self) -> None:
+        """All QZP pins move to target; non-QZP lines untouched."""
+        old_sha = "cc7e3095598478230cd85566a72e310acd1a8923"
+        new_sha = "b24d2cabf9e2244fd4d981f40c91acdac3fd26eb"
+        text = (
+            "uses: actions/checkout@v4\n"
+            f"uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            f"reusable-codecov-analytics.yml@{old_sha}\n"
+            f"uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            f"reusable-codeql.yml@{old_sha}\n"
+            "uses: actions/setup-python@v5\n"
+        )
+        new_text, count = bws.bump_pins_to_target(text, target_sha=new_sha)
+        self.assertEqual(count, 2)
+        self.assertNotIn(old_sha, new_text)
+        self.assertEqual(new_text.count(new_sha), 2)
+        # Non-QZP lines preserved verbatim.
+        self.assertIn("uses: actions/checkout@v4\n", new_text)
+        self.assertIn("uses: actions/setup-python@v5\n", new_text)
+
+    def test_idempotent_when_already_at_target(self) -> None:
+        """Running twice leaves text identical + count = 0 the second time."""
+        target = "b24d2cabf9e2244fd4d981f40c91acdac3fd26eb"
+        text = (
+            f"uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            f"reusable-codeql.yml@{target}\n"
+        )
+        new_text, count = bws.bump_pins_to_target(text, target_sha=target)
+        self.assertEqual(new_text, text)
+        self.assertEqual(count, 0)
+
+    def test_mixed_pins_all_bumped(self) -> None:
+        """Different OLD shas → every pin lands on the same NEW sha."""
+        new_sha = "b24d2cabf9e2244fd4d981f40c91acdac3fd26eb"
+        text = (
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-codeql.yml@d7a94db4ab57df42940832cf67b730c673af7da6\n"
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-scanner-matrix.yml@cc7e3095598478230cd85566a72e310acd1a8923\n"
+            "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+            "reusable-backlog-sweep.yml@7268fee30f1cf796938d97fe460259f27386a8cd\n"
+        )
+        new_text, count = bws.bump_pins_to_target(text, target_sha=new_sha)
+        self.assertEqual(count, 3)
+        self.assertEqual(new_text.count(new_sha), 3)
+
+    def test_rejects_non_40_hex_target(self) -> None:
+        """Refuse non-SHA targets — protects against pinning a branch name."""
+        with self.assertRaises(ValueError):
+            bws.bump_pins_to_target("", target_sha="main")
+        with self.assertRaises(ValueError):
+            bws.bump_pins_to_target("", target_sha="cc7e3095")  # short
+        with self.assertRaises(ValueError):
+            bws.bump_pins_to_target("", target_sha="z" * 40)  # not hex
+
+
+class BumpWorkflowFilesTests(unittest.TestCase):
+    """``bump_workflow_files`` walks files + returns per-file change count."""
+
+    def test_rejects_non_sha_target(self) -> None:
+        """``bump_workflow_files`` rejects non-40-char-hex targets too."""
+        with self.assertRaises(ValueError):
+            bws.bump_workflow_files({"x.yml": "anything"}, target_sha="main")
+
+    def test_returns_per_file_change_counts(self) -> None:
+        """Each path → integer count of pins bumped (0 if absent or already current)."""
+        target = "b24d2cabf9e2244fd4d981f40c91acdac3fd26eb"
+        files = {
+            "codecov-analytics.yml": (
+                "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+                "reusable-codecov-analytics.yml@cc7e3095598478230cd85566a72e310acd1a8923\n"
+            ),
+            "ci.yml": "uses: actions/checkout@v4\n",  # no QZP pin
+            "codeql.yml": (
+                "uses: Prekzursil/quality-zero-platform/.github/workflows/"
+                f"reusable-codeql.yml@{target}\n"  # already current
+            ),
+        }
+        results = bws.bump_workflow_files(files, target_sha=target)
+        self.assertEqual(results["codecov-analytics.yml"]["bumped"], 1)
+        self.assertEqual(results["ci.yml"]["bumped"], 0)
+        self.assertEqual(results["codeql.yml"]["bumped"], 0)
+        # New text only present where bumps happened.
+        self.assertIn(target, results["codecov-analytics.yml"]["new_text"])
+        # Untouched files have new_text == input.
+        self.assertEqual(results["ci.yml"]["new_text"], files["ci.yml"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Why

Discovered by 2026-04-26 audit: **14 of 14 consumer repos pin pre-Phase-2 SHAs** in their caller workflows (`codecov-analytics.yml`, `quality-zero-gate.yml`, etc.):

```
STALE Prekzursil/pbinfo-get-unsolved      pins: 7268fee30f, d7a94db4ab, e3fcdf4028
STALE Prekzursil/codex-session-manager    pins: 7268fee30f, d7a94db4ab
STALE Prekzursil/event-link               pins: 7268fee30f, cc7e309559, d7a94db4ab
... (14 total)
```

Drift-sync templates render fresh `codecov.yml` / `ci.yml` / etc but DON'T touch caller workflows that pin platform SHAs. So even when drift-sync runs, the consumer keeps calling **old** reusable-workflow definitions that pre-date the Phase 2 per-flag Codecov fix, the Phase 4 severity rollup, and everything else.

## What

`scripts/quality/bump_workflow_shas.py` — the pure logic that walks workflow text, identifies `Prekzursil/quality-zero-platform/.github/workflows/<name>.yml@<sha>` references, and rewrites every SHA to a target.

Public API:

| Function | Returns |
|---|---|
| `find_reusable_pins(text)` | `[(workflow_name, sha), ...]` (only 40-char hex SHAs; branches/tags ignored) |
| `bump_pins_to_target(text, target_sha)` | `(new_text, count)` — refuses non-40-char-hex targets, count = pins actually changed |
| `bump_workflow_files(files, target_sha)` | `{path: {bumped, new_text}}` — wave-caller convenience |

CLI: `--target-sha` + `--workflow-dir` + `--apply` (dry-run by default).

## Test plan

- [x] 11 unit tests (single pin, multiple pins, ignore non-QZP, ignore branch/tag, ignore short SHA, idempotent at target, mixed old SHAs all bump, refuse non-SHA targets, per-file change counts, wrapper guard)
- [x] Coverage: 100% on `bump_workflow_shas.py` (34 stmts / 8 branches)
- [x] Lizard avg CCN 2.6 (gate 15)
- [x] Full suite: 1428 passed + 59 subtests
- [x] End-to-end smoke: `bump_pins_to_target('cc7e3095...' → 'b24d2ca...')` returns `(new_text, 1)` correctly

## Follow-up

A workflow caller (`bump-workflow-shas-wave.yml`) that fans out across `inventory/repos.yml` and opens a bump PR per consumer repo using this module. Once that lands the entire fleet can be brought to current platform main with one operator dispatch — closing one of the absolute-done bullets:

> All 15 governed repos have green CI + quality rollup on main

(today blocked because all 14 consumers run pre-Phase-2 reusable workflows).

Tracking the fleet stale-SHA finding in the execution-state memo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/quality/bump_workflow_shas.py`, a tool that finds and bumps `Prekzursil/quality-zero-platform` reusable-workflow SHA pins to a target SHA. This replaces stale pins in consumer workflows and unblocks Phase 2+ features fleet-wide.

- **New Features**
  - Pure helpers: `find_reusable_pins`, `bump_pins_to_target`, `bump_workflow_files` (validates 40-char hex, ignores branches/tags).
  - CLI: `--target-sha`, `--workflow-dir`, `--apply` (dry-run by default; prints JSON per-file bump counts).
  - Tests: 11 unit tests with full coverage for the module.

<sup>Written for commit d97c9c8cc8f42d78d9f01b845e499fbdc1f41e34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Bump reusable workflow SHAs across workflow files

### What Changed
- Adds a script that finds QZP reusable-workflow pins in workflow files and rewrites them to a chosen 40-character SHA
- Keeps branch names, tags, short SHAs, and workflows from other repos unchanged
- Returns per-file bump counts and supports dry-run output or in-place updates from the command line
- Adds tests covering single and multiple pins, ignored non-matching refs, already-current pins, and invalid target SHAs

### Impact
`✅ Updated workflow callers to the latest reusable definitions`
`✅ Fewer stale workflow pins after drift-sync`
`✅ Clearer bulk workflow updates with dry-run support`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3S71pzg00IYQyKjJLhXSUmyA6VVszqctU6-JAoENtB0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
