### PR TITLE
fix(qzp-v2 phase 5): reusable-codeql consumer-safe — codeql_config_file becomes optional input

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,3 +29,8 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       platform_repository: ${{ github.repository }}
       platform_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      # Platform-internal: wire the false-positive suppressions for
+      # secrets_sync.py via the per-repo config file. Fleet consumers
+      # leave codeql_config_file empty so init doesn't try to read a
+      # file they don't ship.
+      codeql_config_file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -24,6 +24,17 @@ on:
         type: string
         required: false
         default: main
+      codeql_config_file:
+        type: string
+        required: false
+        default: ""
+        description: |
+          Optional path (relative to the consumer-repo checkout root)
+          to a CodeQL config YAML. Empty string = no config file is
+          passed to ``github/codeql-action/init``. Platform-internal
+          callers pass ``./.github/codeql/codeql-config.yml`` to wire
+          the false-positive suppressions for ``secrets_sync.py``;
+          fleet consumers leave this empty.
 
 jobs:
   resolve-profile:
@@ -117,9 +128,12 @@ jobs:
         with:
           languages: ${{ needs.resolve-profile.outputs.languages_csv }}
           build-mode: ${{ needs.resolve-profile.outputs.build_mode }}
-          # Config file carries per-repo query-filter exclusions for
-          # verified false positives (see file header for rationale).
-          config-file: ./.github/codeql/codeql-config.yml
+          # Config file is OPTIONAL — defaults to empty so consumer
+          # fleet repos (which don't ship the platform-internal
+          # ``codeql-config.yml``) don't error at init. The platform's
+          # own ``codeql.yml`` caller passes ``./.github/codeql/codeql-config.yml``
+          # to wire the false-positive suppressions for ``secrets_sync.py``.
+          config-file: ${{ inputs.codeql_config_file }}
           queries: security-and-quality
 
       - name: Autobuild

--- a/tests/test_reusable_codeql.py
+++ b/tests/test_reusable_codeql.py
@@ -1,0 +1,82 @@
+"""Contract tests for ``reusable-codeql.yml``.
+
+Pins the cross-repo invariants the reusable CodeQL workflow MUST hold
+so that fleet consumers can pin it without shipping platform-only
+artefacts:
+
+* ``codeql_config_file`` is an OPTIONAL input with empty-string default
+  so consumers don't need to ship ``.github/codeql/codeql-config.yml``.
+* The platform's own ``codeql.yml`` caller passes the config-file path
+  explicitly; consumers leave it empty.
+
+These invariants exist because PR #119 introduced a
+``config-file: ./.github/codeql/codeql-config.yml`` hardcode in the
+reusable workflow, breaking every fleet consumer that didn't ship that
+file (event-link PR #130 first surfaced the regression: ``The
+configuration file ".github/codeql/codeql-config.yml" does not exist``).
+"""
+
+from __future__ import absolute_import
+
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_REUSABLE = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "reusable-codeql.yml"
+)
+_CALLER = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "codeql.yml"
+)
+
+
+class ReusableCodeQLContract(unittest.TestCase):
+    """Reusable workflow stays consumer-safe."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse both workflow YAMLs once."""
+        cls.reusable = yaml.safe_load(_REUSABLE.read_text(encoding="utf-8"))
+        cls.caller = yaml.safe_load(_CALLER.read_text(encoding="utf-8"))
+
+    def test_codeql_config_file_input_is_optional_with_empty_default(self) -> None:
+        """``codeql_config_file`` is optional + defaults to empty string."""
+        # ``on:`` parses as YAML boolean True under PyYAML.
+        inputs = self.reusable[True]["workflow_call"]["inputs"]
+        self.assertIn("codeql_config_file", inputs)
+        self.assertFalse(inputs["codeql_config_file"].get("required", False))
+        # Default must be the EMPTY string so the actions/codeql ``init``
+        # step skips ``--config-file`` entirely when no path is wired.
+        self.assertEqual(inputs["codeql_config_file"].get("default"), "")
+
+    def test_init_step_uses_codeql_config_file_input(self) -> None:
+        """``codeql-action/init`` ``config-file`` references the input, not a hardcode."""
+        steps = self.reusable["jobs"]["codeql"]["steps"]
+        init_steps = [
+            s for s in steps
+            if "uses" in s and s["uses"].startswith("github/codeql-action/init")
+        ]
+        self.assertEqual(len(init_steps), 1)
+        config_value = init_steps[0]["with"].get("config-file")
+        self.assertEqual(
+            config_value, "${{ inputs.codeql_config_file }}",
+            "init step must thread the input through, not hardcode a "
+            "platform-only path that fleet consumers don't have",
+        )
+
+    def test_platform_caller_passes_config_file_path(self) -> None:
+        """Platform's own ``codeql.yml`` caller passes the config-file path."""
+        caller_with = self.caller["jobs"]["codeql"].get("with", {}) or {}
+        cfg = caller_with.get("codeql_config_file", "")
+        self.assertIn("codeql-config.yml", cfg,
+            "platform's CALLER must pass the config-file path so the "
+            "platform's own CodeQL run keeps its false-positive "
+            "suppressions for secrets_sync.py")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Cross-repo regression

PR #119 (CodeQL false-positive suppression for `secrets_sync.py`) hardcoded:

```yaml
config-file: ./.github/codeql/codeql-config.yml
```

…directly into `reusable-codeql.yml`. The platform-internal fix worked locally but **every fleet consumer that pins this reusable workflow now needs to ship a copy of that file** — none do.

Surfaced by **event-link PR #130** (which bumped to platform main `b24d2ca`):

```
##[error] The configuration file ".github/codeql/codeql-config.yml" does not exist
```

The reusable-workflow contract was violated: a reusable step should never assume consumer-side files exist.

## Fix

1. `reusable-codeql.yml` — `codeql_config_file` becomes a `workflow_call` input with `""` default. The init step now passes:
   ```yaml
   config-file: ${{ inputs.codeql_config_file }}
   ```
   When empty, `codeql-action/init` skips the `--config-file` flag entirely.

2. Platform's own `codeql.yml` caller passes:
   ```yaml
   codeql_config_file: ./.github/codeql/codeql-config.yml
   ```
   so the platform keeps its false-positive suppressions for `secrets_sync.py` — same behaviour as before #119, but now opt-in.

3. New `tests/test_reusable_codeql.py` (3 contract tests) pins:
   - Input is optional with empty default
   - Init step references the input (no hardcoded path)
   - Platform caller still passes the config-file path

## Test plan

- [x] 3 contract tests
- [x] Full suite: 1420 passed + 59 subtests
- [x] Semgrep clean

## Why this matters for the absolute-done bullets

Without this fix, the fleet-wide SHA bump (#132's companion wave) cannot succeed — consumers' CodeQL init would crash. With it, consumers can safely pin platform main and CodeQL stays green via the standard `security-and-quality` query suite (no suppressions, since the consumer's own `secrets_sync.py` doesn't exist).

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Makes the CodeQL reusable workflow consumer-safe by making the config file an optional input. Prevents failures in fleet repos that don’t ship `./.github/codeql/codeql-config.yml`.

- **Bug Fixes**
  - `reusable-codeql.yml`: added `codeql_config_file` input (default `""`) and passed it through as `config-file: ${{ inputs.codeql_config_file }}` so `github/codeql-action/init` skips the flag when empty.
  - Platform `codeql.yml` now passes `./.github/codeql/codeql-config.yml` to keep false-positive suppressions for `secrets_sync.py`.
  - Added `tests/test_reusable_codeql.py` to pin the optional input, ensure the init step uses it, and verify the platform caller wires the path.

<sup>Written for commit 8eeca7cde48c87d7664b64d85ec656fd392a5164. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Make the reusable CodeQL workflow safe for consumer repositories

### What Changed
- The reusable CodeQL workflow now accepts an optional config file path instead of assuming every repository has the platform’s CodeQL config file.
- If no path is provided, CodeQL setup runs without that file, so consumer repositories no longer fail when they pin this workflow.
- The platform’s own CodeQL workflow still passes its config file path, keeping the existing false-positive suppressions for `secrets_sync.py`.
- Added contract tests to ensure the config path stays optional, is passed through correctly, and remains set in the platform caller.

### Impact
`✅ Fewer CodeQL setup failures in consumer repositories`
`✅ Safer reuse of the platform CodeQL workflow`
`✅ Preserved suppressions for the platform's own scans`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=C0BdaY1X-bFD5WYYiSVBuoa69vf9ld-aXkexs95iofY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
