### PR TITLE
feat(qzp-v2 phase 5 inc-11): bump-workflow-shas-wave — operator-dispatchable fleet SHA bumper

### DIFF
--- a/.github/workflows/bump-workflow-shas-wave.yml
+++ b/.github/workflows/bump-workflow-shas-wave.yml
@@ -1,0 +1,112 @@
+name: Bump Workflow SHAs Wave
+
+# Operator-dispatched fleet sweep. Loops every consumer repo in
+# ``inventory/repos.yml`` and dispatches
+# ``reusable-bump-workflow-shas.yml`` against each, bumping every QZP
+# reusable-workflow ``uses:`` pin to the supplied target SHA. Default
+# is dry-run; the operator must opt into PR-creation by passing
+# ``dry_run=false`` AND a ``DRIFT_SYNC_PAT`` secret.
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        type: string
+        required: true
+        description: "40-char hex SHA every QZP reusable-workflow pin should be bumped to."
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, per-repo bump computes diffs but opens no PR."
+      slug_filter:
+        type: string
+        required: false
+        default: ""
+        description: "Optional substring filter — only repos whose slug contains this run."
+
+concurrency:
+  group: bump-workflow-shas-wave
+  cancel-in-progress: false
+
+jobs:
+  resolve-fleet:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      slugs: ${{ steps.plan.outputs.slugs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Enumerate governed repos
+        id: plan
+        env:
+          QZ_SLUG_FILTER: ${{ inputs.slug_filter }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          inventory = yaml.safe_load(
+              Path("inventory/repos.yml").read_text(encoding="utf-8"),
+          ) or {}
+          repos = inventory.get("repos", [])
+          slug_filter = os.environ.get("QZ_SLUG_FILTER", "").strip()
+          slugs = []
+          for entry in repos:
+              if not isinstance(entry, dict):
+                  continue
+              slug = str(entry.get("slug", "")).strip()
+              if not slug:
+                  continue
+              if slug_filter and slug_filter not in slug:
+                  continue
+              # Skip the platform repo itself — it's the source of the
+              # reusable workflows, no SHA pinning to bump.
+              if slug == "Prekzursil/quality-zero-platform":
+                  continue
+              slugs.append(slug)
+          out = os.environ.get("GITHUB_OUTPUT")
+          if out:
+              with open(out, "a", encoding="utf-8") as fh:
+                  fh.write(f"slugs={json.dumps(slugs)}\n")
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write("## SHA Bump Wave — fleet resolution\n\n")
+                  fh.write(f"- Total repos in inventory: {len(repos)}\n")
+                  fh.write(f"- Selected after filter (excludes platform self): {len(slugs)}\n")
+                  for slug in slugs:
+                      fh.write(f"  - `{slug}`\n")
+          PY
+
+  bump:
+    needs: resolve-fleet
+    if: ${{ needs.resolve-fleet.outputs.slugs != '[]' && needs.resolve-fleet.outputs.slugs != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        slug: ${{ fromJson(needs.resolve-fleet.outputs.slugs) }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    uses: ./.github/workflows/reusable-bump-workflow-shas.yml
+    with:
+      repo_slug: ${{ matrix.slug }}
+      target_sha: ${{ inputs.target_sha }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      DRIFT_SYNC_PAT: ${{ secrets.DRIFT_SYNC_PAT }}

--- a/.github/workflows/reusable-bump-workflow-shas.yml
+++ b/.github/workflows/reusable-bump-workflow-shas.yml
@@ -1,0 +1,174 @@
+name: Reusable Bump Workflow SHAs
+
+# QZP v2 Phase 5 follow-up — bump every reusable-workflow ``uses:``
+# pin in a single consumer repo to ``target_sha`` and open a PR.
+# Fan-out (``bump-workflow-shas-wave.yml``) loops the inventory and
+# calls this once per repo.
+#
+# Per-repo workflow because each consumer may have a different set
+# of caller workflow files; ``bump_workflow_shas.py`` walks
+# ``.github/workflows/`` per checkout and only rewrites the QZP
+# pins (skipping ``actions/checkout@v4`` and friends).
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      repo_slug:
+        type: string
+        required: true
+        description: "owner/name of the target consumer repo."
+      target_sha:
+        type: string
+        required: true
+        description: "40-char hex SHA every QZP reusable-workflow pin should be bumped to."
+      default_branch:
+        type: string
+        required: false
+        default: main
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, compute bumps but do not open a PR."
+    secrets:
+      DRIFT_SYNC_PAT:
+        required: false
+        description: "Fine-grained PAT with pull-requests:write on the target repo. Absent = dry-run only."
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: platform
+          persist-credentials: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo_slug }}
+          ref: ${{ inputs.default_branch }}
+          path: repo
+          token: ${{ secrets.DRIFT_SYNC_PAT || github.token }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r platform/requirements-dev.txt
+
+      - name: Compute artifact-safe slug
+        id: artifact_name
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+        run: |
+          set -euo pipefail
+          slug="${REPO_SLUG:-unknown}"
+          safe="${slug//\//__}"
+          printf 'slug_safe=%s\n' "$safe" >> "$GITHUB_OUTPUT"
+
+      - name: Bump SHAs (dry-run)
+        id: bump
+        env:
+          BUMP_TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from scripts.quality.bump_workflow_shas import bump_workflow_files
+
+          target = os.environ["BUMP_TARGET_SHA"].strip()
+          repo_root = Path(os.environ["GITHUB_WORKSPACE"]) / "repo"
+          wf_dir = repo_root / ".github" / "workflows"
+          if not wf_dir.is_dir():
+              print("repo has no .github/workflows directory — nothing to bump")
+              return_code = 0
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                  fh.write("bumped_total=0\n")
+                  fh.write("changed_files=[]\n")
+              raise SystemExit(0)
+
+          files = {
+              p.name: p.read_text(encoding="utf-8")
+              for p in sorted(wf_dir.glob("*.yml"))
+          }
+          results = bump_workflow_files(files, target_sha=target)
+
+          changed = []
+          for name, r in results.items():
+              if r["bumped"]:
+                  (wf_dir / name).write_text(r["new_text"], encoding="utf-8")
+                  changed.append({"file": name, "bumps": r["bumped"]})
+
+          # Emit a JSON report as workflow artifact + step output.
+          report = {
+              "repo": os.environ.get("GITHUB_REPOSITORY", ""),
+              "target_sha": target,
+              "files": changed,
+              "bumped_total": sum(c["bumps"] for c in changed),
+          }
+          report_path = Path(os.environ["RUNNER_TEMP"]) / "sha-bump.json"
+          report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+          print(f"Wrote {report_path}")
+
+          out = os.environ.get("GITHUB_OUTPUT")
+          if out:
+              with open(out, "a", encoding="utf-8") as fh:
+                  fh.write(f"bumped_total={report['bumped_total']}\n")
+                  fh.write(f"changed_files={json.dumps([c['file'] for c in changed])}\n")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"## Bump SHAs — {os.environ.get('GITHUB_REPOSITORY','?')}\n\n")
+                  fh.write(f"- Target SHA: `{target}`\n")
+                  fh.write(f"- Files changed: {len(changed)}\n")
+                  fh.write(f"- Total pins bumped: {report['bumped_total']}\n")
+                  for c in changed:
+                      fh.write(f"  - `{c['file']}` ({c['bumps']} pin(s))\n")
+          PY
+
+      - name: Upload bump report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sha-bump-${{ steps.artifact_name.outputs.slug_safe }}
+          path: ${{ runner.temp }}/sha-bump.json
+          if-no-files-found: ignore
+
+      - name: Open bump PR on consumer repo
+        if: ${{ !inputs.dry_run && steps.bump.outputs.bumped_total != '0' && env.DRIFT_SYNC_PAT_PRESENT == 'true' }}
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+          DEFAULT_BRANCH: ${{ inputs.default_branch }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+          BUMPED_TOTAL: ${{ steps.bump.outputs.bumped_total }}
+          GH_TOKEN: ${{ secrets.DRIFT_SYNC_PAT }}
+          DRIFT_SYNC_PAT_PRESENT: ${{ secrets.DRIFT_SYNC_PAT != '' }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          short_sha="${TARGET_SHA:0:10}"
+          branch_name="qzp/bump-workflow-shas-${short_sha}"
+          git config user.email "platform-bot@quality-zero.local"
+          git config user.name "quality-zero-platform sha-bumper"
+          git checkout -b "$branch_name"
+          git add .github/workflows
+          git commit -m "fix(ci): bump QZP reusable-workflow SHAs to platform main ${short_sha}
+
+          ${BUMPED_TOTAL} pins bumped via reusable-bump-workflow-shas.yml.
+          Target: Prekzursil/quality-zero-platform@${TARGET_SHA}"
+          git push -u origin "$branch_name"
+          gh pr create \
+            --title "fix(ci): bump QZP reusable-workflow SHAs to platform main ${short_sha}" \
+            --body "Automated SHA bump from \`reusable-bump-workflow-shas.yml\`. ${BUMPED_TOTAL} pins moved to \`Prekzursil/quality-zero-platform@${TARGET_SHA}\`. Review the diff for any unexpected changes; the bumper only rewrites \`Prekzursil/quality-zero-platform/.github/workflows/<name>.yml@<old-sha>\` references." \
+            --label "qzp-bump-workflow-shas" \
+            --base "$DEFAULT_BRANCH" || true

--- a/tests/test_bump_workflow_shas_wave.py
+++ b/tests/test_bump_workflow_shas_wave.py
@@ -1,0 +1,125 @@
+"""Contract tests for the SHA-bump wave workflows.
+
+Pins the per-repo and fleet-wide invariants for
+``reusable-bump-workflow-shas.yml`` + ``bump-workflow-shas-wave.yml``.
+"""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_BASE = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_PER_REPO = _BASE / "reusable-bump-workflow-shas.yml"
+_WAVE = _BASE / "bump-workflow-shas-wave.yml"
+
+
+class ReusableBumpWorkflowShasContract(unittest.TestCase):
+    """Per-repo bump workflow invariants."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = _PER_REPO.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_call_only(self) -> None:
+        """Per-repo workflow is reusable, never directly dispatched."""
+        on = self.doc[True]
+        self.assertIn("workflow_call", on)
+        self.assertNotIn("workflow_dispatch", on)
+        self.assertNotIn("schedule", on)
+
+    def test_required_inputs(self) -> None:
+        """``repo_slug`` + ``target_sha`` are mandatory."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        for required in ("repo_slug", "target_sha"):
+            with self.subTest(input=required):
+                self.assertIn(required, inputs)
+                self.assertTrue(inputs[required].get("required"))
+
+    def test_dry_run_default_true(self) -> None:
+        """Safety net: dry-run unless operator opts out."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        self.assertTrue(inputs["dry_run"].get("default", False))
+
+    def test_artifact_name_uses_safe_slug(self) -> None:
+        """Bump-report artifact name uses the slash-escaped slug."""
+        steps = self.doc["jobs"]["bump"]["steps"]
+        upload_steps = [
+            s for s in steps
+            if "uses" in s and "upload-artifact" in s["uses"]
+        ]
+        self.assertEqual(len(upload_steps), 1)
+        name = upload_steps[0]["with"]["name"]
+        self.assertIn("steps.artifact_name.outputs.slug_safe", name)
+
+    def test_open_pr_step_gated_on_dry_run_and_pat_and_bumps(self) -> None:
+        """PR step requires (a) opt-out of dry-run, (b) PAT present, (c) >0 bumps."""
+        steps = self.doc["jobs"]["bump"]["steps"]
+        pr_steps = [
+            s for s in steps if "Open bump PR" in s.get("name", "")
+        ]
+        self.assertEqual(len(pr_steps), 1)
+        cond = pr_steps[0].get("if", "")
+        self.assertIn("!inputs.dry_run", cond)
+        self.assertIn("DRIFT_SYNC_PAT_PRESENT", cond)
+        self.assertIn("steps.bump.outputs.bumped_total", cond)
+
+    def test_env_var_indirection_inside_heredocs(self) -> None:
+        """No ``${{ inputs.* }}`` / ``${{ secrets.* }}`` inside python heredoc."""
+        for body in re.findall(r"<<'PY'(.+?)PY", self.text, flags=re.DOTALL):
+            with self.subTest(body_excerpt=body[:60]):
+                self.assertNotIn("${{ inputs.", body)
+                self.assertNotIn("${{ secrets.", body)
+                self.assertNotIn("${{ github.", body)
+
+
+class WaveDispatcherContract(unittest.TestCase):
+    """Fleet-wide bump dispatcher invariants."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = _WAVE.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_dispatch_only_no_cron(self) -> None:
+        """Manual operator initiation only — no recurring fleet sweep."""
+        on = self.doc[True]
+        self.assertIn("workflow_dispatch", on)
+        self.assertNotIn("schedule", on)
+
+    def test_target_sha_required_dry_run_default_true(self) -> None:
+        """Operator MUST supply target_sha; dry_run safety-net default."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        self.assertTrue(inputs["target_sha"].get("required"))
+        self.assertTrue(inputs["dry_run"].get("default", False))
+
+    def test_concurrency_is_fixed_string(self) -> None:
+        """Single-flight wave."""
+        self.assertEqual(self.doc["concurrency"]["group"], "bump-workflow-shas-wave")
+
+    def test_resolve_excludes_platform_self(self) -> None:
+        """Enumeration step skips the platform repo itself (source of reusables)."""
+        # The exclusion is in the python heredoc; check the source text.
+        self.assertIn(
+            "Prekzursil/quality-zero-platform",
+            self.text,
+        )
+        self.assertRegex(
+            self.text,
+            r"if\s+slug\s*==\s*\"Prekzursil/quality-zero-platform\"",
+        )
+
+    def test_bump_job_calls_per_repo_reusable(self) -> None:
+        """Wave's matrix job invokes the per-repo reusable workflow."""
+        bump_job = self.doc["jobs"]["bump"]
+        self.assertIn("reusable-bump-workflow-shas.yml", bump_job["uses"])
+        self.assertIs(bump_job["strategy"].get("fail-fast"), False)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Why

Operationalises the `bump_workflow_shas` module merged in #132. With this PR, the operator has a single `gh workflow run` to bring the entire fleet's reusable-workflow SHA pins to current platform main — closing the structural gap that blocks the absolute-done bullet:

> All 15 governed repos have green CI + quality rollup on main

(today blocked because all 14 consumers run pre-Phase-2 reusable workflows — see [the 2026-04-26 audit](execution-state.md)).

## Two new workflows

### 1. `reusable-bump-workflow-shas.yml` (per-repo)

`workflow_call` — checks out target repo, runs `bump_workflow_files` on every `.github/workflows/*.yml`, uploads a JSON report as artifact, opens a PR when not dry-running.

### 2. `bump-workflow-shas-wave.yml` (fleet caller)

`workflow_dispatch` — loops `inventory/repos.yml`, excludes platform self (it's the source of truth), fans out via `matrix` with `fail-fast: false`.

## Pinned invariants (11 contract tests + 3 subtests)

| Invariant | Rationale |
|---|---|
| `workflow_call` only on per-repo, `workflow_dispatch` only on wave | No accidental fleet sweeps from cron |
| `target_sha` mandatory; `dry_run` defaults to `true` | Operator must opt out explicitly |
| Artifact name uses slash-escaped slug | NTFS portability rule (lessoned learned in #130) |
| Env-var indirection for every `${{ ... }}` in heredocs | CWE-78 defence |
| PR-creation step gated on `!dry_run AND DRIFT_SYNC_PAT_PRESENT AND bumped_total > 0` | Three-factor safety |
| Wave excludes `Prekzursil/quality-zero-platform` | Don't try to bump SHAs on the source-of-truth repo |
| `fail-fast: false` on matrix | One bad repo can't abort the others |

## Test plan

- [x] 11 contract tests + 3 subtests across both workflows
- [x] Full suite: **1439 passed + 62 subtests**
- [x] Semgrep clean
- [x] Per-repo workflow follows the same dry-run/PAT/fail-fast pattern as drift-sync-wave.yml + secrets-sync.yml

## Operator usage

```bash
# Dry-run first to see which repos / pins would change
gh workflow run bump-workflow-shas-wave.yml --ref main \
  -f target_sha=<latest-platform-main-sha> \
  -f dry_run=true

# After verifying the dry-run reports + configuring DRIFT_SYNC_PAT,
# re-dispatch with dry_run=false to fan PRs across the fleet.
gh workflow run bump-workflow-shas-wave.yml --ref main \
  -f target_sha=<latest-platform-main-sha> \
  -f dry_run=false
```

## Sequencing

Best dispatched AFTER #133 (CodeQL config-file consumer-safe fix) merges, so the SHA the wave bumps to includes both fixes. Otherwise consumers will pin a SHA that re-introduces the CodeQL `configuration file does not exist` error from #130.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds two GitHub Actions workflows that let an operator bump every consumer repo’s QZP reusable-workflow SHA pins to a given `Prekzursil/quality-zero-platform` main SHA. Runs as a dry-run by default and opens per-repo PRs when `dry_run=false` with a valid `DRIFT_SYNC_PAT`.

- New Features
  - `reusable-bump-workflow-shas.yml` (per-repo): checks out the target repo, runs `bump_workflow_files`, uploads a JSON report, and opens a PR when not dry-running.
  - `bump-workflow-shas-wave.yml` (fleet): reads `inventory/repos.yml`, skips `Prekzursil/quality-zero-platform`, and fans out via matrix with `fail-fast: false`.
  - Safety: `dry_run` defaults to true; PRs require `dry_run=false`, a present `DRIFT_SYNC_PAT`, and at least one bump; artifact name uses a slash-escaped slug. 

- Migration
  - Dispatch `bump-workflow-shas-wave.yml` with `target_sha=<platform-main-sha>`; review dry-run artifacts (default).
  - Configure `DRIFT_SYNC_PAT` and re-run with `dry_run=false` to open PRs across the fleet.

<sup>Written for commit 9baa8615f27e342324ccf7ef884e377cfa0ed5cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Run a fleet-wide SHA bump for reusable workflows, with a safe dry-run by default**

### What Changed
- Adds a manual wave workflow that scans governed repos, skips the platform repo itself, and dispatches a SHA bump for each selected repo.
- Adds a reusable per-repo workflow that updates QZP reusable-workflow pins to a chosen target SHA, writes a bump report, and opens a PR only when dry-run is off and the sync token is available.
- Keeps the first run safe by default: dry-run is enabled unless the operator explicitly turns it off.
- Adds contract tests that lock in the dispatch rules, required inputs, dry-run default, repo exclusion, and PR-opening conditions.

### Impact
`✅ Faster fleet-wide workflow pin updates`
`✅ Fewer accidental PRs during SHA bumps`
`✅ Safer operator-driven maintenance runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Nj87XSjpHUTbVRjpGl30rRgK07VFy9fNm494ukDYZ5A&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
