### PR TITLE
fix(qzp-v2 phase 5 inc-11): bump-shas heredoc — PYTHONPATH points at platform checkout

### DIFF
--- a/.github/workflows/reusable-bump-workflow-shas.yml
+++ b/.github/workflows/reusable-bump-workflow-shas.yml
@@ -78,6 +78,9 @@ jobs:
         id: bump
         env:
           BUMP_TARGET_SHA: ${{ inputs.target_sha }}
+          # Platform package was checked out at ``./platform/``, so add
+          # that to PYTHONPATH so ``from scripts.quality...`` resolves.
+          PYTHONPATH: ${{ github.workspace }}/platform
         run: |
           python - <<'PY'
           import json
@@ -90,7 +93,6 @@ jobs:
           wf_dir = repo_root / ".github" / "workflows"
           if not wf_dir.is_dir():
               print("repo has no .github/workflows directory — nothing to bump")
-              return_code = 0
               with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
                   fh.write("bumped_total=0\n")
                   fh.write("changed_files=[]\n")

--- a/tests/test_bump_workflow_shas_wave.py
+++ b/tests/test_bump_workflow_shas_wave.py
@@ -77,6 +77,18 @@ class ReusableBumpWorkflowShasContract(unittest.TestCase):
                 self.assertNotIn("${{ secrets.", body)
                 self.assertNotIn("${{ github.", body)
 
+    def test_bump_step_sets_pythonpath_to_platform_checkout(self) -> None:
+        """Platform was checked out at ``platform/``; PYTHONPATH must add it
+        so ``from scripts.quality...`` resolves. First wave dispatch
+        (run 24965679041) failed 14/14 with ``ModuleNotFoundError: No
+        module named 'scripts'`` because this wiring was missing."""
+        steps = self.doc["jobs"]["bump"]["steps"]
+        bump_steps = [s for s in steps if s.get("id") == "bump"]
+        self.assertEqual(len(bump_steps), 1)
+        env = bump_steps[0].get("env", {}) or {}
+        self.assertIn("PYTHONPATH", env)
+        self.assertIn("platform", str(env["PYTHONPATH"]))
+
 
 class WaveDispatcherContract(unittest.TestCase):
     """Fleet-wide bump dispatcher invariants."""


### PR DESCRIPTION
## **User description**
## Root cause

First operational dispatch of `bump-workflow-shas-wave` (run [`24965679041`](https://github.com/Prekzursil/quality-zero-platform/actions/runs/24965679041)) failed 14/14 at the `Bump SHAs (dry-run)` step:

```
ModuleNotFoundError: No module named 'scripts'
```

The per-repo workflow checks the platform out at `path: platform/`, then a python heredoc does:

```python
from scripts.quality.bump_workflow_shas import bump_workflow_files
```

…but the python interpreter's default `sys.path` doesn't include `platform/`, so the import fails.

Other reusable workflows that use `path: platform` invoke the script via `python platform/scripts/...` (running a script file implicitly adds its directory to `sys.path`). This workflow used a heredoc instead, which doesn't get that treatment.

## Fix

Set `PYTHONPATH: ${{ github.workspace }}/platform` on the `Bump SHAs (dry-run)` step's `env:` block. Heredoc imports resolve normally.

Also drops a stray `return_code = 0` dead-code line in the early-exit branch (no functional change; cosmetic).

New contract test `test_bump_step_sets_pythonpath_to_platform_checkout` pins the PYTHONPATH wiring so this regression can't sneak back.

## Test plan

- [x] 12 contract tests + 3 subtests
- [x] Full suite: **1443 passed + 62 subtests**
- [x] Semgrep clean

## Follow-up

After this lands, re-dispatch the wave with the post-fix SHA:

```
gh workflow run bump-workflow-shas-wave.yml --ref main \
  -f target_sha=<new-platform-main-sha> -f dry_run=true
```

The bumper module itself (#132) was already verified locally and via unit tests — this PR only fixes the heredoc invocation plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module import resolution in the automation workflow used for repository version bumping.

* **Tests**
  * Added test coverage to validate runtime module path resolution in the bump workflow automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix the bump workflow so it can import platform code during the dry run**

### What Changed
- The bump step now includes the platform checkout in `PYTHONPATH`, so the workflow can import the bumping logic instead of failing with `ModuleNotFoundError`
- The early-exit path no longer contains a stray unused line when a repository has no workflow files to update
- Added a contract test to verify the bump step keeps the platform path wired in

### Impact
`✅ Fewer wave dispatch failures`
`✅ Clearer import behavior in bump runs`
`✅ Safer workflow changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=M_pPsx_-JR8PnJj2bQiZ2P6skZFaCpxe8j7edEOxbac&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
