### PR TITLE
feat(qzp-v2 phase 5 inc-12): bumps applier — regex-based replace block + Node 20→24 wired

### DIFF
--- a/profiles/bumps/2026-04-23-node-24.yml
+++ b/profiles/bumps/2026-04-23-node-24.yml
@@ -6,8 +6,19 @@ name: Node 20 -> 24
 
 target:
   - file_glob: "**/.github/workflows/*.yml"
+    # ``yaml_path`` is documentation / future-work for a real yamlpath
+    # evaluator; the in-tree applier today uses the ``replace`` block
+    # below, which keeps the canary executable without depending on a
+    # full yamlpath interpreter. The abstract spec stays so a future
+    # evaluator can be wired against the SAME recipe shape.
     yaml_path: "jobs.*.steps[?.uses contains 'setup-node'].with.node-version"
     value: '24'
+    replace:
+      # Match ``node-version: '20'`` / ``"20"`` (any indent), keep the
+      # surrounding indentation (re.MULTILINE + ^...$ anchors are NOT
+      # used so leading whitespace is preserved by the pattern).
+      pattern: "node-version:\\s*['\\\"]20['\\\"]"
+      replacement: "node-version: '24'"
 
 affects_stacks:
   - fullstack-web

--- a/scripts/quality/bumps.py
+++ b/scripts/quality/bumps.py
@@ -157,6 +157,61 @@ def apply_bump_text(
     return new_text, count
 
 
+def _resolve_replace_block(
+    target: Mapping[str, Any],
+) -> Tuple[str, str]:
+    """Extract ``(pattern, replacement)`` from a target's ``replace`` block.
+
+    Returns ``("", "")`` when the block is absent or has no ``pattern``;
+    callers treat that as a skip signal (the target's abstract
+    ``yaml_path`` is documentation-only for now).
+    """
+    replace_block = target.get("replace")
+    if not isinstance(replace_block, Mapping):
+        return "", ""
+    pattern = str(replace_block.get("pattern", ""))
+    if not pattern:
+        return "", ""
+    replacement = str(replace_block.get("replacement", ""))
+    return pattern, replacement
+
+
+def _apply_target_to_files(
+    *,
+    target: Mapping[str, Any],
+    target_index: int,
+    repo_root: Path,
+    pattern: str,
+    replacement: str,
+    files_changed: Dict[str, str],
+    edited: List[Dict[str, Any]],
+) -> None:
+    """Walk ``target.file_glob`` and apply the replace block in-place.
+
+    Mutates ``files_changed`` (path → new text) and ``edited`` (list of
+    ``{path, target_index, replacements}``). No return — the caller
+    owns the aggregate result accumulators.
+    """
+    glob = str(target["file_glob"])
+    for hit in sorted(repo_root.glob(glob)):
+        if not hit.is_file():
+            continue
+        key = hit.relative_to(repo_root).as_posix()
+        current = files_changed.get(key)
+        if current is None:
+            current = hit.read_text(encoding="utf-8")
+        new_text, count = apply_bump_text(
+            current, pattern=pattern, replacement=replacement,
+        )
+        if count > 0:
+            files_changed[key] = new_text
+            edited.append({
+                "path": key,
+                "target_index": target_index,
+                "replacements": count,
+            })
+
+
 def apply_bump_files(
     *,
     repo_root: Path,
@@ -171,50 +226,32 @@ def apply_bump_files(
     future yamlpath evaluator and is treated as documentation only
     by this applier.
 
-    Returns ``{bumped_files, bumped_total, skipped_targets, edited}``:
-
-    * ``bumped_files``: number of distinct files written.
-    * ``bumped_total``: total ``re.subn`` substitutions applied
-      (sum across all (file, target) pairs that hit).
-    * ``skipped_targets``: list of indices into ``targets`` that
-      were skipped (no ``replace`` block).
-    * ``edited``: list of ``{path, target_index, replacements}`` records.
+    Returns ``{bumped_files, bumped_total, skipped_targets, edited}``.
     """
-    target_list = list(targets)
     skipped: List[int] = []
     edited: List[Dict[str, Any]] = []
     files_changed: Dict[str, str] = {}
 
-    for idx, target in enumerate(target_list):
-        replace_block = target.get("replace") if isinstance(target, Mapping) else None
-        if not isinstance(replace_block, Mapping):
+    for idx, target in enumerate(targets):
+        if not isinstance(target, Mapping):
             skipped.append(idx)
             continue
-        pattern = str(replace_block.get("pattern", ""))
-        replacement = str(replace_block.get("replacement", ""))
+        pattern, replacement = _resolve_replace_block(target)
         if not pattern:
             skipped.append(idx)
             continue
+        _apply_target_to_files(
+            target=target,
+            target_index=idx,
+            repo_root=repo_root,
+            pattern=pattern,
+            replacement=replacement,
+            files_changed=files_changed,
+            edited=edited,
+        )
 
-        glob = str(target["file_glob"])
-        for hit in sorted(repo_root.glob(glob)):
-            if not hit.is_file():
-                continue
-            key = hit.relative_to(repo_root).as_posix()
-            current = files_changed.get(key)
-            if current is None:
-                current = hit.read_text(encoding="utf-8")
-            new_text, count = apply_bump_text(
-                current, pattern=pattern, replacement=replacement,
-            )
-            if count > 0:
-                files_changed[key] = new_text
-                edited.append({
-                    "path": key, "target_index": idx, "replacements": count,
-                })
-
-    # Persist all changed files at the end (one write per file, even
-    # when multiple targets edited it).
+    # Persist changed files (one write per file, even when multiple
+    # targets edited the same file).
     for key, new_text in files_changed.items():
         (repo_root / key).write_text(new_text, encoding="utf-8")
 

--- a/scripts/quality/bumps.py
+++ b/scripts/quality/bumps.py
@@ -35,9 +35,10 @@ rollback_on_failure: true          # optional, defaults to True
 
 from __future__ import absolute_import
 
+import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
 import yaml  # type: ignore[import-untyped]
 
@@ -140,6 +141,89 @@ def resolve_target_files(
                 key = hit.relative_to(repo_root).as_posix()
                 seen.setdefault(key, hit)
     return [seen[k] for k in sorted(seen)]
+
+
+def apply_bump_text(
+    text: str, *, pattern: str, replacement: str,
+) -> Tuple[str, int]:
+    """Run ``re.subn`` on ``text``; return ``(new_text, replacement_count)``.
+
+    Thin wrapper kept separate from the file walker so the regex
+    semantics are unit-testable in isolation. ``re.error`` from a
+    malformed pattern propagates to the caller — the recipe author
+    must own that regex correctness.
+    """
+    new_text, count = re.subn(pattern, replacement, text, flags=re.MULTILINE)
+    return new_text, count
+
+
+def apply_bump_files(
+    *,
+    repo_root: Path,
+    targets: Iterable[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Apply every target's ``replace`` block to matching files.
+
+    Walks each target's ``file_glob``, finds files, and (when the
+    target carries an optional ``replace: {pattern, replacement}``
+    block) rewrites them in-place. Targets without ``replace`` are
+    skipped — the abstract ``yaml_path`` field is reserved for a
+    future yamlpath evaluator and is treated as documentation only
+    by this applier.
+
+    Returns ``{bumped_files, bumped_total, skipped_targets, edited}``:
+
+    * ``bumped_files``: number of distinct files written.
+    * ``bumped_total``: total ``re.subn`` substitutions applied
+      (sum across all (file, target) pairs that hit).
+    * ``skipped_targets``: list of indices into ``targets`` that
+      were skipped (no ``replace`` block).
+    * ``edited``: list of ``{path, target_index, replacements}`` records.
+    """
+    target_list = list(targets)
+    skipped: List[int] = []
+    edited: List[Dict[str, Any]] = []
+    files_changed: Dict[str, str] = {}
+
+    for idx, target in enumerate(target_list):
+        replace_block = target.get("replace") if isinstance(target, Mapping) else None
+        if not isinstance(replace_block, Mapping):
+            skipped.append(idx)
+            continue
+        pattern = str(replace_block.get("pattern", ""))
+        replacement = str(replace_block.get("replacement", ""))
+        if not pattern:
+            skipped.append(idx)
+            continue
+
+        glob = str(target["file_glob"])
+        for hit in sorted(repo_root.glob(glob)):
+            if not hit.is_file():
+                continue
+            key = hit.relative_to(repo_root).as_posix()
+            current = files_changed.get(key)
+            if current is None:
+                current = hit.read_text(encoding="utf-8")
+            new_text, count = apply_bump_text(
+                current, pattern=pattern, replacement=replacement,
+            )
+            if count > 0:
+                files_changed[key] = new_text
+                edited.append({
+                    "path": key, "target_index": idx, "replacements": count,
+                })
+
+    # Persist all changed files at the end (one write per file, even
+    # when multiple targets edited it).
+    for key, new_text in files_changed.items():
+        (repo_root / key).write_text(new_text, encoding="utf-8")
+
+    return {
+        "bumped_files": len(files_changed),
+        "bumped_total": sum(e["replacements"] for e in edited),
+        "skipped_targets": skipped,
+        "edited": edited,
+    }
 
 
 if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI

--- a/tests/test_bumps_applier.py
+++ b/tests/test_bumps_applier.py
@@ -172,6 +172,17 @@ class ApplyFilesTests(unittest.TestCase):
             self.assertEqual(results["bumped_total"], 0)
             self.assertIn(0, results["skipped_targets"])
 
+    def test_non_mapping_target_skipped(self) -> None:
+        """Defensive: a target that isn't a dict is recorded in skipped_targets."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = bumps.apply_bump_files(
+                repo_root=root,
+                targets=["not-a-dict", 42],
+            )
+            self.assertEqual(results["bumped_total"], 0)
+            self.assertEqual(sorted(results["skipped_targets"]), [0, 1])
+
     def test_directory_match_skipped(self) -> None:
         """Glob hit that's a directory (not a file) is silently skipped."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_bumps_applier.py
+++ b/tests/test_bumps_applier.py
@@ -1,0 +1,234 @@
+"""Tests for the bump applier added to ``scripts.quality.bumps``.
+
+The applier is the missing piece that makes
+``reusable-bumps.yml`` actually rewrite consumer-repo files. It uses
+the OPTIONAL ``replace: {pattern, replacement}`` block on each
+recipe target — a pragmatic regex-based approach that handles the
+Node 20→24 canary without needing a full yamlpath evaluator.
+"""
+
+from __future__ import absolute_import
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts.quality import bumps
+
+
+class ApplyTextTests(unittest.TestCase):
+    """``apply_bump_text`` rewrites a single string by regex."""
+
+    def test_basic_substitution(self) -> None:
+        """Plain pattern → replacement."""
+        text = "node-version: '20'\nfoo: bar\n"
+        new_text, count = bumps.apply_bump_text(
+            text,
+            pattern=r"node-version:\s*['\"]20['\"]",
+            replacement="node-version: '24'",
+        )
+        self.assertEqual(new_text, "node-version: '24'\nfoo: bar\n")
+        self.assertEqual(count, 1)
+
+    def test_multiple_matches_all_replaced(self) -> None:
+        """All matches replaced; count = total."""
+        text = "a: '20'\nb: '20'\n"
+        new_text, count = bumps.apply_bump_text(
+            text,
+            pattern=r"'20'",
+            replacement="'24'",
+        )
+        self.assertEqual(count, 2)
+        self.assertNotIn("'20'", new_text)
+
+    def test_no_matches_returns_input(self) -> None:
+        """No match → original text + count 0."""
+        text = "node-version: '24'\n"
+        new_text, count = bumps.apply_bump_text(
+            text, pattern=r"'20'", replacement="'24'",
+        )
+        self.assertEqual(new_text, text)
+        self.assertEqual(count, 0)
+
+    def test_invalid_regex_raises(self) -> None:
+        """Malformed regex surfaces as ``re.error``."""
+        with self.assertRaises(Exception):
+            bumps.apply_bump_text(
+                "x", pattern=r"[unclosed", replacement="y",
+            )
+
+
+class ApplyFilesTests(unittest.TestCase):
+    """``apply_bump_files`` walks file_globs + applies regex per target."""
+
+    def test_writes_changed_files_only(self) -> None:
+        """Only files that match get rewritten; others byte-identical."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            ci_with_node = root / ".github" / "workflows" / "ci.yml"
+            ci_with_node.write_text(textwrap.dedent("""\
+                jobs:
+                  build:
+                    steps:
+                      - uses: actions/setup-node@v4
+                        with:
+                          node-version: '20'
+                """), encoding="utf-8")
+            ci_without_node = root / ".github" / "workflows" / "lint.yml"
+            ci_without_node.write_text("name: lint\n", encoding="utf-8")
+
+            recipe_targets = [{
+                "file_glob": "**/.github/workflows/*.yml",
+                "yaml_path": "jobs.*.steps[?].with.node-version",
+                "value": "24",
+                "replace": {
+                    "pattern": r"node-version:\s*['\"]20['\"]",
+                    "replacement": "node-version: '24'",
+                },
+            }]
+            results = bumps.apply_bump_files(
+                repo_root=root, targets=recipe_targets,
+            )
+            self.assertEqual(results["bumped_files"], 1)
+            self.assertEqual(results["bumped_total"], 1)
+            # Changed file rewritten:
+            self.assertIn("'24'", ci_with_node.read_text(encoding="utf-8"))
+            # Unchanged file untouched (no need to re-write a no-op):
+            self.assertEqual(
+                ci_without_node.read_text(encoding="utf-8"), "name: lint\n",
+            )
+
+    def test_targets_without_replace_are_skipped(self) -> None:
+        """Recipe targets that lack a ``replace`` block don't crash;
+        they're skipped (with the abstract yaml_path future-work TODO)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "ci.yml").write_text("node-version: '20'\n", encoding="utf-8")
+            results = bumps.apply_bump_files(
+                repo_root=root,
+                targets=[{
+                    "file_glob": "**/ci.yml",
+                    "yaml_path": "x.y",
+                    "value": "24",
+                    # NO replace block
+                }],
+            )
+        self.assertEqual(results["bumped_files"], 0)
+        self.assertEqual(results["bumped_total"], 0)
+        self.assertGreater(len(results["skipped_targets"]), 0)
+
+    def test_multiple_targets_aggregate_counts(self) -> None:
+        """Two targets matching the same file → counts add up correctly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ci = root / "ci.yml"
+            ci.write_text("a: 20\nb: 20\n", encoding="utf-8")
+            results = bumps.apply_bump_files(
+                repo_root=root,
+                targets=[
+                    {
+                        "file_glob": "ci.yml",
+                        "yaml_path": "a", "value": "24",
+                        "replace": {"pattern": r"^a: 20$",
+                                    "replacement": "a: 24"},
+                    },
+                    {
+                        "file_glob": "ci.yml",
+                        "yaml_path": "b", "value": "24",
+                        "replace": {"pattern": r"^b: 20$",
+                                    "replacement": "b: 24"},
+                    },
+                ],
+            )
+            self.assertEqual(results["bumped_total"], 2)
+            # Same file edited twice — count it once for `bumped_files`.
+            self.assertEqual(results["bumped_files"], 1)
+            self.assertEqual(ci.read_text(encoding="utf-8"), "a: 24\nb: 24\n")
+
+    def test_empty_targets_returns_zeros(self) -> None:
+        """Empty targets list → nothing changed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = bumps.apply_bump_files(repo_root=root, targets=[])
+        self.assertEqual(results["bumped_total"], 0)
+        self.assertEqual(results["bumped_files"], 0)
+
+    def test_empty_pattern_skipped_like_missing_replace(self) -> None:
+        """``replace`` block with empty ``pattern`` → target skipped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "ci.yml").write_text("x\n", encoding="utf-8")
+            results = bumps.apply_bump_files(
+                repo_root=root,
+                targets=[{
+                    "file_glob": "**/ci.yml",
+                    "yaml_path": "x",
+                    "value": "y",
+                    "replace": {"pattern": "", "replacement": "y"},
+                }],
+            )
+            self.assertEqual(results["bumped_total"], 0)
+            self.assertIn(0, results["skipped_targets"])
+
+    def test_directory_match_skipped(self) -> None:
+        """Glob hit that's a directory (not a file) is silently skipped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # A DIRECTORY named ci.yml — should not be treated as a file.
+            (root / "ci.yml").mkdir()
+            # And a real file under sub/ci.yml — should still be processed.
+            (root / "sub").mkdir()
+            real = root / "sub" / "ci.yml"
+            real.write_text("node-version: '20'\n", encoding="utf-8")
+            results = bumps.apply_bump_files(
+                repo_root=root,
+                targets=[{
+                    "file_glob": "**/ci.yml",
+                    "yaml_path": "x", "value": "y",
+                    "replace": {
+                        "pattern": r"'20'",
+                        "replacement": "'24'",
+                    },
+                }],
+            )
+            self.assertEqual(results["bumped_files"], 1)
+            self.assertIn("'24'", real.read_text(encoding="utf-8"))
+
+
+class CanaryRecipeIntegrationTests(unittest.TestCase):
+    """Shipped Node-canary recipe applies cleanly to a synthetic event-link CI."""
+
+    def test_node_canary_replaces_setup_node_v20(self) -> None:
+        """Loading the canary + applying it to a synthetic CI flips '20' → '24'."""
+        recipe_path = (
+            Path(__file__).resolve().parents[1]
+            / "profiles" / "bumps" / "2026-04-23-node-24.yml"
+        )
+        recipe = bumps.load_bump_recipe(recipe_path)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            (root / ".github" / "workflows" / "ci.yml").write_text(
+                "      - uses: actions/setup-node@v4\n"
+                "        with:\n"
+                "          node-version: '20'\n",
+                encoding="utf-8",
+            )
+            results = bumps.apply_bump_files(
+                repo_root=root, targets=recipe["target"],
+            )
+        # Either the canary recipe ships a replace block (then bumped > 0)
+        # OR it's still abstract (then skipped). The shipped recipe MUST
+        # include a replace block for the bumps wave to actually do work.
+        self.assertGreater(
+            results["bumped_total"], 0,
+            "the canonical Node 20→24 recipe must include a `replace` block "
+            "on at least one target; otherwise `reusable-bumps.yml` can't "
+            "actually rewrite consumer files",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## What

Closes the gap between `bumps.py`'s schema validator and an actually-executable bump rollout. Until now the recipe carried only an abstract `yaml_path` field with no evaluator behind it — so `reusable-bumps.yml` had nothing to commit.

## Approach

Ship a **regex-based applier** that uses an OPTIONAL `replace: {pattern, replacement}` block per target. The abstract `yaml_path` field stays in the schema as documentation / future-work for a real yamlpath evaluator, but the in-tree applier today operates on `replace` only. Targets without `replace` are skipped (recorded in `skipped_targets`).

This is a pragmatic call: writing a full yamlpath evaluator (handling `*` wildcards + `[?... contains ...]` predicates) is multi-PR scope and unnecessary for the Node 20→24 canary, where a 2-line regex is sufficient and reviewable.

## Public API additions

`scripts/quality/bumps.py`:

| Function | Returns |
|---|---|
| `apply_bump_text(text, *, pattern, replacement)` | `(new_text, count)` — thin wrapper over `re.subn(MULTILINE)` |
| `apply_bump_files(*, repo_root, targets)` | `{bumped_files, bumped_total, skipped_targets, edited}` |

## Canary recipe wired

`profiles/bumps/2026-04-23-node-24.yml` extended with a `replace` block on its single target:

```yaml
replace:
  pattern: "node-version:\s*['\\\"]20['\\\"]"
  replacement: "node-version: '24'"
```

The canary recipe is now executable end-to-end through `apply_bump_files`.

## Test plan

- [x] **10 new tests** + integration test that the canary recipe applies cleanly to a synthetic event-link CI
- [x] Coverage: **100%** on `bumps.py` (86 stmts / 44 branches)
- [x] Lizard avg CCN 4.5 (gate 15)
- [x] Semgrep clean
- [x] Full suite: **1454 passed + 62 subtests**

## Follow-up

This unblocks the `reusable-bumps.yml` workflow extension that opens per-staging-repo PRs — without an applier, that workflow had nothing to actually commit. That extension is the next increment.


___

## **CodeAnt-AI Description**
Add a regex-based bump applier and make the Node 20→24 recipe runnable

### What Changed
- Bump recipes can now rewrite matching workflow files using a simple pattern-and-replacement rule
- Targets without a replacement rule are skipped instead of failing
- The Node 20→24 canary recipe now includes a replacement rule, so it can update consumer files end to end
- New tests cover text replacement, file updates, skipped targets, repeated matches, and the shipped canary recipe

### Impact
`✅ Runnable bump recipes`
`✅ Fewer failed Node version updates`
`✅ Clearer bump test coverage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ybXOelEycXNlf_JqU8wdjMrO78p8GHqJ5zwuot8Sbi0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
