### PR TITLE
feat(qzp-v2 phase 5 inc-13): reusable-bump-apply workflow — per-repo bump worker

### DIFF
--- a/.github/workflows/reusable-bump-apply.yml
+++ b/.github/workflows/reusable-bump-apply.yml
@@ -1,0 +1,173 @@
+name: Reusable Bump Apply
+
+# QZP v2 Phase 5 §5.5 per-repo bump worker. Loads a recipe from
+# ``profiles/bumps/<file>.yml`` on the platform repo, runs
+# ``apply_bump_files`` against the consumer repo's checkout, commits
+# the changes on a fresh branch, and opens a PR. Dry-run = compute
+# + report only (no commit, no PR).
+#
+# Called per repo by ``reusable-bumps.yml`` in matrix mode (wave
+# dispatcher arrives in a follow-up increment). Designed to mirror
+# the per-repo pattern already established in
+# ``reusable-drift-sync.yml`` and ``reusable-bump-workflow-shas.yml``.
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      repo_slug:
+        type: string
+        required: true
+        description: "owner/name of the target consumer repo."
+      recipe_path:
+        type: string
+        required: true
+        description: "Path to the bump recipe YAML on the platform repo (e.g. ``profiles/bumps/2026-04-23-node-24.yml``)."
+      default_branch:
+        type: string
+        required: false
+        default: main
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, compute but do not commit / open a PR."
+    secrets:
+      DRIFT_SYNC_PAT:
+        required: false
+        description: "Fine-grained PAT with pull-requests:write + contents:write on the target repo. Absent = dry-run only."
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: platform
+          persist-credentials: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo_slug }}
+          ref: ${{ inputs.default_branch }}
+          path: repo
+          token: ${{ secrets.DRIFT_SYNC_PAT || github.token }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r platform/requirements-dev.txt
+
+      - name: Compute artifact-safe slug
+        id: artifact_name
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+        run: |
+          set -euo pipefail
+          slug="${REPO_SLUG:-unknown}"
+          safe="${slug//\//__}"
+          printf 'slug_safe=%s\n' "$safe" >> "$GITHUB_OUTPUT"
+
+      - name: Apply bump recipe
+        id: apply
+        env:
+          BUMP_RECIPE_PATH: ${{ inputs.recipe_path }}
+          BUMP_REPO_SLUG: ${{ inputs.repo_slug }}
+          # Platform was checked out at ``./platform/`` — add it to
+          # PYTHONPATH so heredoc imports of ``scripts.quality.bumps``
+          # resolve. (Same plumbing as reusable-bump-workflow-shas.yml.)
+          PYTHONPATH: ${{ github.workspace }}/platform
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from scripts.quality import bumps
+
+          recipe_rel = os.environ["BUMP_RECIPE_PATH"].strip()
+          repo_root = Path(os.environ["GITHUB_WORKSPACE"]) / "repo"
+          platform_root = Path(os.environ["GITHUB_WORKSPACE"]) / "platform"
+          recipe_path = platform_root / recipe_rel
+
+          recipe = bumps.load_bump_recipe(recipe_path)
+          results = bumps.apply_bump_files(
+              repo_root=repo_root, targets=recipe["target"],
+          )
+
+          report = {
+              "consumer_repo": os.environ.get("BUMP_REPO_SLUG", ""),
+              "recipe_name": recipe["name"],
+              "recipe_path": str(recipe_path),
+              "bumped_files": results["bumped_files"],
+              "bumped_total": results["bumped_total"],
+              "skipped_targets": results["skipped_targets"],
+              "edited": results["edited"],
+          }
+          report_path = Path(os.environ["RUNNER_TEMP"]) / "bump-apply.json"
+          report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+          print(f"Wrote {report_path}")
+
+          out = os.environ.get("GITHUB_OUTPUT")
+          if out:
+              with open(out, "a", encoding="utf-8") as fh:
+                  fh.write(f"bumped_total={report['bumped_total']}\n")
+                  fh.write(f"bumped_files={report['bumped_files']}\n")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"## Bump Apply — {report['consumer_repo']}\n\n")
+                  fh.write(f"- Recipe: `{recipe['name']}`\n")
+                  fh.write(f"- Files changed: {report['bumped_files']}\n")
+                  fh.write(f"- Total replacements: {report['bumped_total']}\n")
+                  if report["skipped_targets"]:
+                      fh.write(f"- Skipped targets (no `replace` block): {report['skipped_targets']}\n")
+                  for entry in report["edited"]:
+                      fh.write(f"  - `{entry['path']}` (target {entry['target_index']}, "
+                               f"{entry['replacements']} replacement(s))\n")
+          PY
+
+      - name: Upload bump-apply report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bump-apply-${{ steps.artifact_name.outputs.slug_safe }}
+          path: ${{ runner.temp }}/bump-apply.json
+          if-no-files-found: ignore
+
+      - name: Commit + open bump PR on consumer repo
+        if: ${{ !inputs.dry_run && steps.apply.outputs.bumped_total != '0' && env.DRIFT_SYNC_PAT_PRESENT == 'true' }}
+        env:
+          REPO_SLUG: ${{ inputs.repo_slug }}
+          DEFAULT_BRANCH: ${{ inputs.default_branch }}
+          BUMPED_TOTAL: ${{ steps.apply.outputs.bumped_total }}
+          BUMPED_FILES: ${{ steps.apply.outputs.bumped_files }}
+          RECIPE_PATH: ${{ inputs.recipe_path }}
+          GH_TOKEN: ${{ secrets.DRIFT_SYNC_PAT }}
+          DRIFT_SYNC_PAT_PRESENT: ${{ secrets.DRIFT_SYNC_PAT != '' }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          recipe_basename=$(basename "$RECIPE_PATH" .yml)
+          branch_name="qzp/bump-${recipe_basename}"
+          git config user.email "platform-bot@quality-zero.local"
+          git config user.name "quality-zero-platform bumper"
+          git checkout -b "$branch_name"
+          git add -A
+          git commit -m "fix(ci): apply bump recipe ${recipe_basename}
+
+          ${BUMPED_TOTAL} replacement(s) across ${BUMPED_FILES} file(s).
+          Recipe: Prekzursil/quality-zero-platform/${RECIPE_PATH}"
+          git push -u origin "$branch_name"
+          gh pr create \
+            --title "fix(ci): apply bump recipe ${recipe_basename}" \
+            --body "Automated bump from \`reusable-bump-apply.yml\`. ${BUMPED_TOTAL} replacement(s) across ${BUMPED_FILES} file(s) per recipe \`Prekzursil/quality-zero-platform/${RECIPE_PATH}\`. Review the diff; the bumper only rewrites content matched by the recipe's \`replace.pattern\` regex." \
+            --label "qzp-bump-recipe" \
+            --base "$DEFAULT_BRANCH" || true

--- a/tests/test_reusable_bump_apply.py
+++ b/tests/test_reusable_bump_apply.py
@@ -1,0 +1,119 @@
+"""Contract tests for ``reusable-bump-apply.yml``.
+
+Pins the cross-repo invariants for the per-repo bump applier:
+
+* Reusable workflow shape (workflow_call only).
+* dry_run defaults to true; real PR-opening requires (a) opt-out
+  of dry-run, (b) PAT present, (c) >0 replacements.
+* PYTHONPATH wiring so heredoc imports of ``scripts.quality.bumps``
+  resolve against the ``platform/`` checkout.
+* Artifact name uses slash-escaped slug.
+* Env-var indirection for every ``${{ ... }}`` inside heredocs.
+"""
+
+from __future__ import absolute_import
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "workflows" / "reusable-bump-apply.yml"
+)
+
+
+class ReusableBumpApplyContract(unittest.TestCase):
+    """Per-repo bump applier invariants."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the YAML once per test class."""
+        cls.text = _WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_workflow_call_only(self) -> None:
+        """Reusable, never directly dispatched."""
+        on = self.doc[True]
+        self.assertIn("workflow_call", on)
+        self.assertNotIn("workflow_dispatch", on)
+        self.assertNotIn("schedule", on)
+
+    def test_required_inputs(self) -> None:
+        """``repo_slug`` + ``recipe_path`` are mandatory."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        for required in ("repo_slug", "recipe_path"):
+            with self.subTest(input=required):
+                self.assertIn(required, inputs)
+                self.assertTrue(inputs[required].get("required"))
+
+    def test_dry_run_default_true(self) -> None:
+        """Safety net: operator must opt out of dry-run explicitly."""
+        inputs = self.doc[True]["workflow_call"]["inputs"]
+        self.assertTrue(inputs["dry_run"].get("default", False))
+
+    def test_drift_sync_pat_secret_optional(self) -> None:
+        """PAT is optional — its absence falls through to dry-run."""
+        secrets = self.doc[True]["workflow_call"].get("secrets", {})
+        self.assertIn("DRIFT_SYNC_PAT", secrets)
+        # ``required: false`` means the workflow runs without the
+        # PAT and the commit step's ``if`` guard skips PR-creation.
+        self.assertFalse(secrets["DRIFT_SYNC_PAT"].get("required", False))
+
+    def test_apply_step_sets_pythonpath(self) -> None:
+        """Heredoc imports ``scripts.quality.bumps`` — PYTHONPATH must
+        include ``platform/`` (where the platform repo is checked out)
+        so the import resolves. Same fix shape as PR #136."""
+        steps = self.doc["jobs"]["apply"]["steps"]
+        apply_steps = [s for s in steps if s.get("id") == "apply"]
+        self.assertEqual(len(apply_steps), 1)
+        env = apply_steps[0].get("env", {}) or {}
+        self.assertIn("PYTHONPATH", env)
+        self.assertIn("platform", str(env["PYTHONPATH"]))
+
+    def test_artifact_name_uses_safe_slug(self) -> None:
+        """Bump-apply report artifact name uses slash-escaped slug
+        (NTFS portability rule, learned in #130)."""
+        steps = self.doc["jobs"]["apply"]["steps"]
+        upload_steps = [
+            s for s in steps
+            if "uses" in s and "upload-artifact" in s["uses"]
+        ]
+        self.assertEqual(len(upload_steps), 1)
+        self.assertIn(
+            "steps.artifact_name.outputs.slug_safe",
+            upload_steps[0]["with"]["name"],
+        )
+
+    def test_pr_step_gated_three_factors(self) -> None:
+        """PR step requires (a) !dry_run, (b) DRIFT_SYNC_PAT present,
+        (c) bumped_total > 0. Same shape as bump-shas-wave."""
+        steps = self.doc["jobs"]["apply"]["steps"]
+        pr_steps = [
+            s for s in steps if "Commit + open bump PR" in s.get("name", "")
+        ]
+        self.assertEqual(len(pr_steps), 1)
+        cond = pr_steps[0].get("if", "")
+        self.assertIn("!inputs.dry_run", cond)
+        self.assertIn("DRIFT_SYNC_PAT_PRESENT", cond)
+        self.assertIn("steps.apply.outputs.bumped_total", cond)
+
+    def test_env_var_indirection_inside_heredocs(self) -> None:
+        """No ``${{ inputs.* }}`` / ``${{ secrets.* }}`` / ``${{ github.* }}``
+        inside python heredocs — env-var indirection is the CWE-78 defence."""
+        for body in re.findall(r"<<'PY'(.+?)PY", self.text, flags=re.DOTALL):
+            with self.subTest(body_excerpt=body[:60]):
+                self.assertNotIn("${{ inputs.", body)
+                self.assertNotIn("${{ secrets.", body)
+                self.assertNotIn("${{ github.", body)
+
+    def test_top_level_permissions_empty(self) -> None:
+        """Top-level perms empty; per-job perms locked down."""
+        self.assertEqual(self.doc.get("permissions"), {})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## **User description**
## What

Adds the per-repo bump worker that `reusable-bumps.yml` will call per staging / rollout repo. Today's plan step (PR #115) only computed a plan; with the bumps applier merged in #137, this workflow is what actually rewrites a consumer repo and (when not dry-running + with `DRIFT_SYNC_PAT`) opens the PR.

## Pattern

Mirrors the prior per-repo workers (`reusable-drift-sync.yml`, `reusable-bump-workflow-shas.yml`):

1. Checkout platform → `platform/`, consumer → `repo/` (consumer with `DRIFT_SYNC_PAT` or fallback `github.token`).
2. Compute artifact-safe slug (`/` → `__`, NTFS rule from #130).
3. Apply step calls `bumps.load_bump_recipe(...)` + `bumps.apply_bump_files(...)`. Reports `{bumped_files, bumped_total, skipped_targets, edited}` to outputs + step summary.
4. Upload `bump-apply.json` as artifact.
5. Commit + open PR — three-factor gate: `!inputs.dry_run` + `DRIFT_SYNC_PAT_PRESENT` + `bumped_total != '0'`.

`PYTHONPATH: ${{ github.workspace }}/platform` set on the apply step so heredoc imports resolve (same fix shape as #136).

## Pinned invariants (9 tests + 3 subtests)

- workflow_call only (no dispatch / cron)
- `repo_slug` + `recipe_path` mandatory
- `dry_run` default `true` (operator opt-out)
- `DRIFT_SYNC_PAT` secret optional (absence = dry-run only)
- `PYTHONPATH` includes `platform/` (PR #136 lesson)
- artifact name escapes `/` (PR #130 lesson)
- PR step three-factor gate
- No `${{ ... }}` interpolations inside python heredoc (CWE-78)

## Test plan

- [x] 9 contract tests + 3 subtests
- [x] Full suite: **1464 passed + 65 subtests**
- [x] Semgrep clean

## Follow-up

Extending `reusable-bumps.yml` to call this in a matrix over `staging_repos` + then `rollout` after staging-CI green, plus the rollback path that opens `alert:fleet-bump-fail` on staging failure — that's the next increment.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds `reusable-bump-apply.yml`, a per-repo bump worker that reads a bump recipe from the platform repo, applies changes to a consumer repo, uploads a report, and (when not dry-running with a valid `DRIFT_SYNC_PAT` and changes found) opens a PR. This turns bump plans into real edits and enables `reusable-bumps.yml` to fan out per repo.

- **New Features**
  - Reusable `workflow_call` workflow with `repo_slug` and `recipe_path` required; `dry_run` defaults to true.
  - Checks out platform → `platform/` and target → `repo/`; sets `PYTHONPATH` to include `platform/`.
  - Applies recipe via `scripts.quality.bumps`, outputs `bump-apply.json`, and uploads it with a slash-escaped slug.
  - PR creation gated by three checks: `!inputs.dry_run`, `DRIFT_SYNC_PAT` present, and `bumped_total != '0'`.
  - Contract tests pin these invariants.

<sup>Written for commit 036dfc5fcdf2152f351de7a0ffc9cfd77201ee49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add a reusable workflow that applies bump recipes to consumer repos and can open a PR**

### What Changed
- Added a reusable bump-apply workflow that checks out the platform and target repo, applies a bump recipe, and records a report of changed files and replacement counts.
- The workflow now uploads a bump report artifact and shows a step summary with the recipe name, changed files, skipped targets, and edited paths.
- When dry-run is turned off, changes were made, and a PAT is available, it now commits the bump on a new branch and opens a pull request in the target repo.
- Added contract tests to lock in the workflow behavior, including dry-run safety, required inputs, report naming, and PR creation rules.

### Impact
`✅ Automated repo bump PRs`
`✅ Safer dry-run by default`
`✅ Clearer bump reports`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=9bPBpmC3Loz3dweUVeVmj2irhJWtzskiGsxfBtsTt3g&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
