### PR TITLE
chore(qzp-v2): refresh execution-state — round 4 (bumps wave code-complete)

### DIFF
--- a/.beads/context/execution-state.md
+++ b/.beads/context/execution-state.md
@@ -210,3 +210,81 @@ PR #134 merged 2026-04-26 ~21:30Z. Platform code complete pending:
 
 verify_v2_deployment.py --all currently reports 39/39 ok (Phase
 1-5 deliverables + the new wave callers + the bumper module).
+
+---
+
+## 2026-04-26 — round 4 (bumps wave code-complete)
+
+### PRs merged this round
+
+| PR | Title | Effect |
+| --- | --- | --- |
+| #136 | bump-shas heredoc PYTHONPATH fix | bump-shas wave actually executes |
+| #137 | bumps applier — regex `replace` block + Node 20→24 wired | recipes can rewrite consumer files |
+| #138 | reusable-bump-apply per-repo bump worker | per-repo PR-opening machinery |
+| #139 | reusable-bumps stage-1 fan-out (staging matrix) | staging wave wired |
+| #140 | reusable-bumps stage-2 + rollback paths | full rollout + alert:fleet-bump-fail wired |
+
+### Operationally verified this round
+
+- bump-workflow-shas-wave dispatched: 14/14 SUCCESS in dry-run
+  after #136 (run 24965810326). event-link bump-report shows 6
+  pins identified. bumper module verified end-to-end.
+
+### Bumps wave is now CODE-COMPLETE
+
+`reusable-bumps.yml` traverses all three design-doc phases:
+
+  1. **plan**     — load recipe + compute staging/rollout split
+  2. **stage-1**  — fan out to staging_repos via matrix
+  3. **stage-2**  — fan out to rollout repos, gated on stage-1
+                    SUCCESS (broken bumps cannot silently
+                    propagate to the rest of the fleet)
+  4. **rollback** — fires on stage-1 FAILURE, opens
+                    `alert:fleet-bump-fail` via
+                    `alerts.open_alert_issue`
+
+Each fan-out matrix entry calls `reusable-bump-apply.yml` (#138),
+which runs `bumps.apply_bump_files(...)` and (when `!dry_run` +
+`DRIFT_SYNC_PAT` present) opens a PR on the consumer repo.
+
+### Absolute-done — every code-side bullet is now true
+
+The remaining **operator-only** bullets:
+
+1. **SonarCloud Auto-Analysis toggle OFF** on event-link →
+   unblocks Coverage 100 Gate → event-link PR #130 merges →
+   per-flag Codecov rows visible.
+2. **`DRIFT_SYNC_PAT` secret** + dispatch
+   `bump-workflow-shas-wave.yml` with `dry_run=false` →
+   14 consumer-repo bump PRs open (refresh stale Phase-1 SHAs).
+3. **Operator dispatches `drift-sync-wave.yml`** with
+   `dry_run=false` → 15 consumer-repo drift PRs open + fleet
+   converges.
+4. **Operator dispatches `reusable-bumps.yml`** with the Node
+   20→24 canary + `dry_run=false` → staging wave runs against
+   env-inspector + webcoder; if green, rollout; if red,
+   `alert:fleet-bump-fail` opens.
+5. After 1-4 settle: all 15 repos green on main, Codecov
+   per-flag for multi-flag repos visible, no open `alert:*`
+   issues, migration plan table fully done. Loop emits
+   `QZP_V2_FULLY_SHIPPED_AND_VERIFIED`.
+
+### Wave-as-integration-test pattern (now 5 rounds)
+
+| Round | Bug surfaced | Fix PR |
+| --- | --- | --- |
+| 1 | `codecov.yml.j2` UndefinedError on `flag` | #129 |
+| 2 | `upload-artifact@v4` rejects `/` in name | #130 |
+| 3 | "Fail on drift when dry_run" exits 1 (intended sentinel) | n/a |
+| 4 | `reusable-codeql` hardcoded consumer-only config-file | #133 |
+| 5 | bump-shas heredoc missing PYTHONPATH | #136 |
+
+Operationally dispatching each wave once per round — this is the
+fleet-wide integration test the design doc called for.
+
+## Last action
+
+PR #140 merged 2026-04-26 ~22:45Z. Platform code now complete for
+every Phase 1-5 absolute-done bullet. ``verify_v2_deployment.py
+--all`` → exit 0 (39/39 ok).


### PR DESCRIPTION
## **User description**
## What

Updates the loop's memory file with this round's work: PRs #136-#140 close the platform-code side of the absolute-done bullet *staging wave + full rollout + rollback paths*.

## Key entries added

- **PRs merged this round** (5): bumper PYTHONPATH fix, applier with regex `replace`, per-repo bump worker, stage-1 fan-out, stage-2 + rollback paths
- **Operationally verified:** bump-workflow-shas-wave dry-run dispatched 14/14 SUCCESS after the PYTHONPATH fix
- **Bumps wave now code-complete:** `reusable-bumps.yml` traverses plan → stage-1 → (stage-2 OR rollback) per the design doc
- **Wave-as-integration-test pattern** now at 5 rounds (3 latent contract bugs caught + fixed: codecov flag, artifact slash, codeql config-file, bumper PYTHONPATH)
- **Absolute-done remaining list** — every bullet is now operator-only:
  1. SonarCloud Auto-Analysis toggle OFF on event-link
  2. Configure `DRIFT_SYNC_PAT` + dispatch `bump-workflow-shas-wave` with `dry_run=false`
  3. Dispatch `drift-sync-wave` with `dry_run=false`
  4. Dispatch `reusable-bumps.yml` with the Node canary + `dry_run=false`
  5. Once 1-4 settle: completion promise emits

`verify_v2_deployment.py --all` continues at **39/39 ok**.

## Test plan

Docs-only — no code paths affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `execution-state.md` for round 4 and records the bumps wave as code-complete across staging, rollout, and rollback. Verified via `bump-workflow-shas-wave` dry-run (14/14 success) and `verify_v2_deployment.py --all` (39/39 OK); no code changes.

- **Migration**
  - Turn off SonarCloud Auto-Analysis on event-link.
  - Add `DRIFT_SYNC_PAT` and run `bump-workflow-shas-wave.yml` with `dry_run=false`.
  - Run `drift-sync-wave.yml` with `dry_run=false`.
  - Run `reusable-bumps.yml` for the Node 20→24 canary with `dry_run=false`.
  - After these settle: all repos green, no `alert:*`, completion signal emits.

<sup>Written for commit 0f22b75cf08b6841b9b7bcb9fb9a5552b3f18df2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Record that the bumps wave is fully wired and the remaining work is operator-only**

### What Changed
- Marks the bumps wave as code-complete across planning, staging, rollout, and rollback
- Notes the successful dry-run dispatch that confirmed the wave now runs end to end
- Updates the remaining checklist to show only manual operator steps are left before full shipment
- Adds a round-by-round record of the integration-test pattern and the issues it surfaced

### Impact
`✅ Clearer release status`
`✅ Easier handoff to operators`
`✅ Faster verification of remaining rollout steps`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=th_XUJHU2eM7wGzb4tcGEemF3uI6tjjyITl02I1ipr4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
