### PR TITLE
fix(qzp-v2 phase 5): bump-shas JSON report — populate repo from target slug, not caller

### DIFF
--- a/.github/workflows/reusable-bump-workflow-shas.yml
+++ b/.github/workflows/reusable-bump-workflow-shas.yml
@@ -78,6 +78,12 @@ jobs:
         id: bump
         env:
           BUMP_TARGET_SHA: ${{ inputs.target_sha }}
+          # ``GITHUB_REPOSITORY`` resolves to the CALLER repo on a
+          # workflow_call invocation, not the bump target. Pass the
+          # target slug explicitly so the JSON report records which
+          # consumer was bumped (the artifact name uses the safe slug
+          # already; this aligns the JSON body too).
+          BUMP_TARGET_REPO_SLUG: ${{ inputs.repo_slug }}
           # Platform package was checked out at ``./platform/``, so add
           # that to PYTHONPATH so ``from scripts.quality...`` resolves.
           PYTHONPATH: ${{ github.workspace }}/platform
@@ -111,8 +117,11 @@ jobs:
                   changed.append({"file": name, "bumps": r["bumped"]})
 
           # Emit a JSON report as workflow artifact + step output.
+          # ``repo`` is the BUMP TARGET (consumer) — pulled from the
+          # explicit env var, NOT GITHUB_REPOSITORY which would resolve
+          # to the CALLER repo (platform) on workflow_call.
           report = {
-              "repo": os.environ.get("GITHUB_REPOSITORY", ""),
+              "repo": os.environ.get("BUMP_TARGET_REPO_SLUG", ""),
               "target_sha": target,
               "files": changed,
               "bumped_total": sum(c["bumps"] for c in changed),

--- a/tests/test_bump_workflow_shas_wave.py
+++ b/tests/test_bump_workflow_shas_wave.py
@@ -77,6 +77,30 @@ class ReusableBumpWorkflowShasContract(unittest.TestCase):
                 self.assertNotIn("${{ secrets.", body)
                 self.assertNotIn("${{ github.", body)
 
+    def test_bump_step_passes_target_repo_slug_for_reporting(self) -> None:
+        """JSON report's ``repo`` field reads the explicit target-slug
+        env var, NOT ``GITHUB_REPOSITORY`` (which resolves to the
+        CALLER repo on workflow_call — i.e. the platform, not the
+        consumer being bumped). Cosmetic but important for the
+        artifact's audit trail."""
+        steps = self.doc["jobs"]["bump"]["steps"]
+        bump_steps = [s for s in steps if s.get("id") == "bump"]
+        self.assertEqual(len(bump_steps), 1)
+        env = bump_steps[0].get("env", {}) or {}
+        self.assertIn("BUMP_TARGET_REPO_SLUG", env)
+        self.assertIn("inputs.repo_slug", str(env["BUMP_TARGET_REPO_SLUG"]))
+        # The heredoc body must reference BUMP_TARGET_REPO_SLUG, not
+        # GITHUB_REPOSITORY, when populating the report's repo field.
+        run_body = bump_steps[0].get("run", "")
+        self.assertIn("BUMP_TARGET_REPO_SLUG", run_body)
+        self.assertNotRegex(
+            run_body,
+            r'"repo":\s*os\.environ\.get\(\s*"GITHUB_REPOSITORY"',
+            "report.repo MUST come from BUMP_TARGET_REPO_SLUG, not "
+            "GITHUB_REPOSITORY (which resolves to the caller, not "
+            "the consumer being bumped)",
+        )
+
     def test_bump_step_sets_pythonpath_to_platform_checkout(self) -> None:
         """Platform was checked out at ``platform/``; PYTHONPATH must add it
         so ``from scripts.quality...`` resolves. First wave dispatch


### PR DESCRIPTION
## **User description**
## What

Cosmetic but real correctness fix on the bump-shas wave's per-repo JSON artifact:

```python
# BEFORE
report = {
    "repo": os.environ.get("GITHUB_REPOSITORY", ""),
    ...
}
```

On `workflow_call`, `GITHUB_REPOSITORY` resolves to the **caller** repo (the platform), not the bump target. Every artifact written by the wave run [`24965810326`](https://github.com/Prekzursil/quality-zero-platform/actions/runs/24965810326) reported `Prekzursil/quality-zero-platform` in the JSON `repo` field regardless of which consumer the bumper processed.

The artifact NAME uses the slash-escaped target slug correctly (`sha-bump-Prekzursil__event-link`); only the JSON body was wrong.

## Fix

- Add `BUMP_TARGET_REPO_SLUG: ${{ inputs.repo_slug }}` to the step's `env:` block
- Heredoc reads from that env var for the report's `repo` field
- New contract test `test_bump_step_passes_target_repo_slug_for_reporting` pins the wiring with both a positive assertion (env var is wired) AND a negative assertion (heredoc body does NOT contain the old `os.environ.get("GITHUB_REPOSITORY"...)` pattern), so a future revert fails the test loudly

## Test plan

- [x] 13 contract tests + 3 subtests on the bump-shas wave workflows
- [x] Full suite: **1469 passed + 66 subtests**
- [x] Semgrep clean

## Effect

After merge, future bump-shas wave dispatches produce artifacts with the correct consumer repo in the JSON body. Prior artifacts from #134 / #136 dispatches keep the cosmetic mismatch (the data they recorded is still readable; just the `repo` field misnames the target).

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix bump-shas JSON report to populate the `repo` field from the target repo slug instead of `GITHUB_REPOSITORY`. Artifacts now report the correct consumer for audit.

- **Bug Fixes**
  - Pass `BUMP_TARGET_REPO_SLUG: ${{ inputs.repo_slug }}` to the bump step and use it for the JSON `repo` field.
  - Add a contract test that enforces this wiring and fails if `GITHUB_REPOSITORY` is used.

<sup>Written for commit 35f23d67fc75d6df782cf6d3e8f6fee50aaa9d66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Fix bump-shas artifact reports to name the bumped repo correctly

### What Changed
- The bump-shas JSON report now records the target consumer repo instead of the caller repo.
- The workflow passes the repo slug explicitly so the artifact body matches the repo already used in the artifact name.
- A contract test now checks that the report uses the target repo slug and does not fall back to the caller repo value.

### Impact
`✅ Correct repo names in bump-shas artifacts`
`✅ Clearer audit trail for consumer repo updates`
`✅ Fewer reporting regressions in workflow dispatches`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0d5M6g1JiSnhxtwWKqDUKi-vEzjZVUI-ZivBsH-h5wc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
