### PR TITLE
fix(qzp-v2 sec): block path-traversal in admin-dashboard CLI (Sonar S2083 ×3)

### DIFF
--- a/scripts/quality/admin_dashboard_pages.py
+++ b/scripts/quality/admin_dashboard_pages.py
@@ -204,6 +204,8 @@ def load_drift_entries(path: Path) -> List[Dict[str, Any]]:
 if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
     import argparse
 
+    from scripts.quality.common import safe_output_path
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--audit-jsonl", default="")
     parser.add_argument("--coverage-json", default="")
@@ -211,27 +213,39 @@ if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
     parser.add_argument("--output-dir", required=True)
     _args = parser.parse_args()
 
-    _out = Path(_args.output_dir)
+    # ``safe_output_path`` resolves ``--output-dir`` against the
+    # current working directory and rejects any path that escapes
+    # the workspace (Sonar S2083 path-traversal defence). Each
+    # rendered page filename is a hardcoded constant, so the only
+    # user-controllable component is the parent directory — and
+    # that's pinned to the workspace by ``_ensure_within_root``.
+    _out = safe_output_path(_args.output_dir, fallback="site")
     _out.mkdir(parents=True, exist_ok=True)
 
     _cov_rows = redact_private_repos(
         load_coverage_rows(Path(_args.coverage_json)) if _args.coverage_json else []
     )
-    (_out / "coverage.html").write_text(
+    _coverage_path = (_out / "coverage.html").resolve()
+    _ensure_path_within_workspace = _coverage_path.relative_to(_out.resolve())
+    _coverage_path.write_text(
         render_coverage_trend_page(rows=_cov_rows), encoding="utf-8",
     )
 
     _drift_rows = redact_private_repos(
         load_drift_entries(Path(_args.drift_jsonl)) if _args.drift_jsonl else []
     )
-    (_out / "drift.html").write_text(
+    _drift_path = (_out / "drift.html").resolve()
+    _ensure_path_within_workspace = _drift_path.relative_to(_out.resolve())
+    _drift_path.write_text(
         render_drift_page(entries=_drift_rows), encoding="utf-8",
     )
 
     _audit_rows = (
         load_audit_jsonl(Path(_args.audit_jsonl)) if _args.audit_jsonl else []
     )
-    (_out / "audit.html").write_text(
+    _audit_path = (_out / "audit.html").resolve()
+    _ensure_path_within_workspace = _audit_path.relative_to(_out.resolve())
+    _audit_path.write_text(
         render_audit_page(entries=_audit_rows), encoding="utf-8",
     )
     print(f"Wrote coverage.html, drift.html, audit.html to {_out}")


### PR DESCRIPTION
## **User description**
## Summary

- The ad-hoc CLI in `scripts/quality/admin_dashboard_pages.py` (introduced in PR #111) read `--output-dir` straight into `Path()` and wrote 3 HTML pages from it. SonarCloud rule `pythonsecurity:S2083` (BLOCKER) flagged 3 issues — one per page write — because the path is user-controlled and could escape the workspace.
- Wraps the arg with the existing `safe_output_path()` helper (`scripts/quality/common.py`) — same pattern already used by the ratchet and severity-rollup CLIs.
- Adds belt-and-braces `.relative_to(_out.resolve())` assertions per page so any computed path that somehow escaped `_out` would raise immediately.
- Closes 3 BLOCKER S2083 issues; clears the highest-severity Sonar cluster on platform main.

## Test plan

- [x] `pytest tests/test_admin_dashboard_pages.py` — 20/20 passing
- [x] `semgrep scan --config auto` on the changed file — clean
- [x] `lizard -C 15` on the changed file — clean (max CCN 7, all under 15)
- [x] Pre-push verify hook (15 profiles, 9 codex tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent the admin dashboard export tool from writing files outside the chosen folder**

### What Changed
- The admin dashboard export now rejects output paths that escape the selected folder, reducing the risk of writing files outside the workspace.
- The generated `coverage.html`, `drift.html`, and `audit.html` files are each checked to stay inside the output folder before being written.
- If no output folder is provided, the export uses the default `site` folder.

### Impact
`✅ Safer admin dashboard exports`
`✅ Fewer accidental writes outside the workspace`
`✅ Clearer protection against path-traversal issues`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=s7XdCCSKPmqiiXrgsp_HHrWiXJ7Vut9KaEbihZe1HcI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
