### PR TITLE
fix(qzp-v2 sec): block path-traversal in rollup-patcher CLI (Sonar S2083)

### DIFF
--- a/scripts/quality/rollup_v2/apply_deterministic_patches.py
+++ b/scripts/quality/rollup_v2/apply_deterministic_patches.py
@@ -15,6 +15,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
 
+from scripts.quality.common import safe_output_path
+
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
@@ -137,7 +139,13 @@ def main() -> int:
     args = parse_args()
     canonical_path = Path(args.canonical_json)
     repo_dir = Path(args.repo_dir)
-    out_path = Path(args.out_json)
+
+    # ``safe_output_path`` resolves --out-json against the current
+    # working directory and rejects any path that escapes the workspace
+    # (Sonar pythonsecurity:S2083 path-traversal defence). Callers must
+    # invoke this script with cwd anchored to the workspace whose subtree
+    # should contain the result file.
+    out_path = safe_output_path(args.out_json, fallback="patcher-result.json")
 
     canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
     result = run_patcher(canonical, repo_dir)

--- a/tests/quality/rollup_v2/test_apply_deterministic_patches.py
+++ b/tests/quality/rollup_v2/test_apply_deterministic_patches.py
@@ -330,22 +330,63 @@ class CLITests(unittest.TestCase):
                 encoding="utf-8",
             )
 
+            # ``safe_output_path`` (Sonar S2083 defence in main()) resolves
+            # the --out-json argument against ``Path.cwd()`` and rejects
+            # anything that escapes that root. Chdir into tmp so the
+            # relative path resolves inside the workspace; restore cwd on
+            # the way out so the fixture cannot leak across tests.
             out_path = Path(tmp) / "result.json"
-            with patch(
-                "sys.argv",
-                [
-                    "apply_deterministic_patches.py",
-                    "--canonical-json", str(canonical_path),
-                    "--repo-dir", str(repo_dir),
-                    "--out-json", str(out_path),
-                ],
-            ):
-                exit_code = main()
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                with patch(
+                    "sys.argv",
+                    [
+                        "apply_deterministic_patches.py",
+                        "--canonical-json", str(canonical_path),
+                        "--repo-dir", str(repo_dir),
+                        "--out-json", "result.json",
+                    ],
+                ):
+                    exit_code = main()
+            finally:
+                os.chdir(original_cwd)
             self.assertEqual(exit_code, 0)
             self.assertTrue(out_path.exists())
             result = json.loads(out_path.read_text(encoding="utf-8"))
             self.assertEqual(result["applied_count"], 0)
             self.assertEqual(result["skipped_count"], 0)
+
+
+    def test_main_rejects_path_traversal_escape(self) -> None:
+        """``safe_output_path`` MUST reject --out-json values that escape cwd.
+
+        The Sonar S2083 fix relies on the fact that an attacker-supplied
+        ``--out-json=../../etc/passwd`` cannot reach the workspace. This
+        test exercises that rejection path so a future refactor that
+        accidentally drops ``safe_output_path`` is caught here.
+        """
+        from scripts.quality.rollup_v2.apply_deterministic_patches import main
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                # Escape the workspace via leading ``..`` components.
+                with patch(
+                    "sys.argv",
+                    [
+                        "apply_deterministic_patches.py",
+                        "--canonical-json", "canonical.json",
+                        "--repo-dir", ".",
+                        "--out-json", "../../escape.json",
+                    ],
+                ):
+                    with self.assertRaises(ValueError) as ctx:
+                        main()
+                self.assertIn("escapes workspace root", str(ctx.exception))
+            finally:
+                os.chdir(original_cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **User description**
## Summary

- The deterministic-patch applier (`scripts/quality/rollup_v2/apply_deterministic_patches.py`) read `--out-json` straight into `Path()` then `write_text()`. SonarCloud `pythonsecurity:S2083` (BLOCKER) flagged this as taint flow from argparse to file I/O without sanitisation.
- Wraps the arg with the existing `safe_output_path()` helper — same pattern already used by ratchet, severity rollup, and the admin-dashboard CLI (the other half of this S2083 cleanup is PR #144).
- Test fixture updated to chdir into tmp + use relative `--out-json` (the canonical CLI invocation pattern). Adds a new test that proves the S2083 defence rejects `../../escape.json` so a future refactor that drops `safe_output_path` is caught at test time.
- Closes the 4th and final BLOCKER S2083 issue on platform main.

## Test plan

- [x] `pytest tests/quality/rollup_v2/test_apply_deterministic_patches.py` — 10/10 passing (was 9/10, added the new defence test)
- [x] `semgrep scan --config auto` on changed file — clean
- [x] `lizard -C 15` on changed file — clean (max CCN 5)
- [x] Pre-push verify hook (15 profiles, 9 codex tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Block unsafe output paths in the rollup patcher CLI**

### What Changed
- The rollup patcher now rejects `--out-json` values that point outside the current workspace, preventing unsafe file writes
- Valid output paths still work and the result file is written normally
- Tests now cover both a successful workspace-local output path and a path-traversal attempt that must fail

### Impact
`✅ Fewer unsafe file writes`
`✅ Blocked workspace path escapes`
`✅ Safer CLI output handling`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=QN1WYZBA6KZXNFijcoyC_Q5qfWyyR7znpEA5YcL_dq0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
