### PR TITLE
fix(qzp-v2 sec): sanitize log values to block log injection (Sonar S5145 ×3)

### DIFF
--- a/scripts/beads-fetch-pr-comments.ts
+++ b/scripts/beads-fetch-pr-comments.ts
@@ -21,10 +21,16 @@ import { dirname } from "path";
 // SonarCloud rule tssecurity:S5145 (log injection) flags any log call whose
 // interpolated value can be tainted by network/IO data — even when the value
 // is statically a number, the rule's taint analysis follows it conservatively.
-// Coerce-to-string + strip-control-chars normalises every log-bound value so
-// an attacker can't smuggle CRLF + a fake log line through e.g. a PR title.
+// Stripping the C0 control range (\x00-\x1f, which already covers CR/LF/TAB
+// and friends) prevents an attacker from smuggling CRLF + a fake log line
+// through e.g. a PR title. Objects go through JSON.stringify so we don't
+// emit the useless "[object Object]" placeholder.
 function sanitizeForLog(value: unknown): string {
-  return String(value).replace(/[\r\n\t\v\f\x00-\x1f]/g, " ");
+  const stringified =
+    typeof value === "object" && value !== null
+      ? JSON.stringify(value)
+      : String(value);
+  return stringified.replaceAll(/[\x00-\x1f]/g, " ");
 }
 
 // =============================================================================

--- a/scripts/beads-fetch-pr-comments.ts
+++ b/scripts/beads-fetch-pr-comments.ts
@@ -16,6 +16,18 @@ import { writeFileSync, mkdirSync, existsSync } from "fs";
 import { dirname } from "path";
 
 // =============================================================================
+// Log sanitisation
+// =============================================================================
+// SonarCloud rule tssecurity:S5145 (log injection) flags any log call whose
+// interpolated value can be tainted by network/IO data — even when the value
+// is statically a number, the rule's taint analysis follows it conservatively.
+// Coerce-to-string + strip-control-chars normalises every log-bound value so
+// an attacker can't smuggle CRLF + a fake log line through e.g. a PR title.
+function sanitizeForLog(value: unknown): string {
+  return String(value).replace(/[\r\n\t\v\f\x00-\x1f]/g, " ");
+}
+
+// =============================================================================
 // CLI Arguments
 // =============================================================================
 
@@ -237,7 +249,7 @@ async function main() {
     token
   );
 
-  console.log(`Found ${searchResults.items.length} merged PRs\n`);
+  console.log(`Found ${sanitizeForLog(searchResults.items.length)} merged PRs\n`);
 
   const allComments: PrComment[] = [];
   const byReviewerType: Record<string, number> = {};
@@ -328,7 +340,9 @@ async function main() {
   // Write output
   writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2));
 
-  console.log(`\nFetched ${allComments.length} comments from ${searchResults.items.length} PRs`);
+  console.log(
+    `\nFetched ${sanitizeForLog(allComments.length)} comments from ${sanitizeForLog(searchResults.items.length)} PRs`,
+  );
   console.log(`\nBy reviewer type:`);
   for (const [type, count] of Object.entries(byReviewerType)) {
     console.log(`  ${type}: ${count}`);

--- a/scripts/beads-self-reflect.ts
+++ b/scripts/beads-self-reflect.ts
@@ -23,11 +23,17 @@ import { parseArgs } from "util";
 // Log sanitisation
 // =============================================================================
 // SonarCloud rule tssecurity:S5145 (log injection) flags any log call whose
-// interpolated value can be tainted by network/IO data. Coerce-to-string +
-// strip-control-chars stops an attacker from smuggling CRLF + a fake log line
-// through e.g. a Slack API error string.
+// interpolated value can be tainted by network/IO data. Stripping the C0
+// control range (\x00-\x1f, which already covers CR/LF/TAB and friends)
+// stops an attacker from smuggling CRLF + a fake log line through e.g. a
+// Slack API error string. Objects go through JSON.stringify so we don't
+// emit the useless "[object Object]" placeholder.
 function sanitizeForLog(value: unknown): string {
-  return String(value).replace(/[\r\n\t\v\f\x00-\x1f]/g, " ");
+  const stringified =
+    typeof value === "object" && value !== null
+      ? JSON.stringify(value)
+      : String(value);
+  return stringified.replaceAll(/[\x00-\x1f]/g, " ");
 }
 
 // =============================================================================

--- a/scripts/beads-self-reflect.ts
+++ b/scripts/beads-self-reflect.ts
@@ -20,6 +20,17 @@
 import { parseArgs } from "util";
 
 // =============================================================================
+// Log sanitisation
+// =============================================================================
+// SonarCloud rule tssecurity:S5145 (log injection) flags any log call whose
+// interpolated value can be tainted by network/IO data. Coerce-to-string +
+// strip-control-chars stops an attacker from smuggling CRLF + a fake log line
+// through e.g. a Slack API error string.
+function sanitizeForLog(value: unknown): string {
+  return String(value).replace(/[\r\n\t\v\f\x00-\x1f]/g, " ");
+}
+
+// =============================================================================
 // CLI Arguments
 // =============================================================================
 
@@ -94,7 +105,7 @@ async function postToSlack(message: string, blocks?: unknown[]): Promise<void> {
 
     const data = await response.json();
     if (!data.ok) {
-      console.error("Slack API error:", data.error);
+      console.error("Slack API error:", sanitizeForLog(data.error));
     }
   } catch (error) {
     console.error("Failed to post to Slack:", error);


### PR DESCRIPTION
## **User description**
## Summary

- Three `console.{log,error}` calls in `scripts/beads-*.ts` interpolated values sourced from the network (GitHub search response, Slack API response). SonarCloud `tssecurity:S5145` (MINOR ×3) flagged each as a potential log-injection vector.
- Adds a tiny inline `sanitizeForLog()` helper to each file (these are template scripts users copy verbatim, so each stays self-contained):

  ```ts
  function sanitizeForLog(value: unknown): string {
    return String(value).replace(/[\r\n\t\v\f\x00-\x1f]/g, " ");
  }
  ```

- Wraps the 3 flagged interpolations:
  - `beads-fetch-pr-comments.ts:240` — post-search "Found N PRs"
  - `beads-fetch-pr-comments.ts:331` — final "Fetched N comments"
  - `beads-self-reflect.ts:97` — Slack API error logging

- Closes the last 3 OPEN security issues on platform main. With PR #144 + PR #145 + this PR all merged, SonarCloud's security pane on platform reads **0 BLOCKER / 0 MINOR** for all severities/qualities.

## Test plan

- [x] Smoke-tested `sanitizeForLog` via `tsx --eval`:
  - `"hello\nworld\rfoo\tbar"` → `"hello world foo bar"`
  - `42` → `"42"`
  - `undefined` → `"undefined"`
- [x] Pre-push verify hook (15 profiles, 9 codex tests) — green
- (No tsc/jest in this repo — these are tsx-shebanged template scripts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved logging safety by sanitizing log messages across internal scripts to prevent log-injection attacks and mitigate risks from tainted error strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Sanitize script logs to block injected lines from network data**

### What Changed
- Log messages in the PR comment and self-reflect scripts now strip control characters before printing values that can come from external sources.
- Slack API errors are also logged in a sanitized form, so unexpected response text cannot add fake lines to the output.
- The scripts still show the same status messages, counts, and error context, but with unsafe characters removed.

### Impact
`✅ Lower risk of log injection`
`✅ Safer script output from network errors`
`✅ Cleaner logs for downstream parsers`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wMI7xsKvx_hc4bGNicuM7-iXzM-h6pyiCUPYdLPmSuI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
