### PR TITLE
fix(qzp-v2 sec): inline workspace containment for Sonar S2083 visibility

### DIFF
--- a/scripts/quality/rollup_v2/apply_deterministic_patches.py
+++ b/scripts/quality/rollup_v2/apply_deterministic_patches.py
@@ -9,13 +9,12 @@ from __future__ import absolute_import
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
-
-from scripts.quality.common import safe_output_path
 
 
 def parse_args() -> argparse.Namespace:
@@ -140,12 +139,23 @@ def main() -> int:
     canonical_path = Path(args.canonical_json)
     repo_dir = Path(args.repo_dir)
 
-    # ``safe_output_path`` resolves --out-json against the current
-    # working directory and rejects any path that escapes the workspace
-    # (Sonar pythonsecurity:S2083 path-traversal defence). Callers must
-    # invoke this script with cwd anchored to the workspace whose subtree
-    # should contain the result file.
-    out_path = safe_output_path(args.out_json, fallback="patcher-result.json")
+    # Inline path-traversal sanitisation (Sonar pythonsecurity:S2083).
+    # Sonar's taint analyser doesn't follow ``safe_output_path()`` from
+    # ``scripts.quality.common`` inter-procedurally, so the validation
+    # is performed inline here using the explicit ``str().startswith()``
+    # pattern Sonar recognises as a containment check. Resolves the raw
+    # arg against ``Path.cwd()`` (Python's ``Path.__truediv__`` discards
+    # the left operand when the right operand is absolute, so this
+    # single expression handles both relative and absolute inputs), then
+    # rejects anything that escapes that root.
+    workspace_root = Path.cwd().resolve()
+    out_path = (workspace_root / Path(args.out_json)).resolve(strict=False)
+    workspace_root_str = str(workspace_root)
+    out_path_str = str(out_path)
+    if not out_path_str.startswith(workspace_root_str + os.sep):
+        raise ValueError(
+            f"--out-json escapes workspace root: {out_path_str}",
+        )
 
     canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
     result = run_patcher(canonical, repo_dir)


### PR DESCRIPTION
## **User description**
## Summary

PR #145 added `safe_output_path()` to `apply_deterministic_patches.py` which functionally sanitizes `--out-json`, but **Sonar's intra-procedural taint analyzer didn't follow the helper inter-procedurally** and kept flagging the `write_text` sink (BLOCKER S2083 issue `AZ12OZ5q3D5PhlS90BLb` re-appeared after main re-analysis with shifted line numbers 154-157).

The admin-dashboard CLI (PR #144) cleared because it used inline `Path.relative_to()` calls Sonar recognises. The rollup-patcher CLI was the outlier.

This fix makes the sanitization visible to Sonar's analyzer:

```python
workspace_root = Path.cwd().resolve()
out_path = (workspace_root / Path(args.out_json)).resolve(strict=False)
workspace_root_str = str(workspace_root)
out_path_str = str(out_path)
if not out_path_str.startswith(workspace_root_str + os.sep):
    raise ValueError(f"--out-json escapes workspace root: {out_path_str}")
```

The `str().startswith()` pattern is in Sonar's S2083 sanitizer allowlist. Drops the helper call (which was redundant once we added the inline check; coverage gate caught the dead-branch redundancy on first push).

## Test plan

- [x] `pytest tests/quality/rollup_v2/test_apply_deterministic_patches.py` — 10/10 passing (existing tests cover both code paths)
- [x] `coverage report` on the file — 58 stmts, 10 branches, 0 missing → 100%
- [x] `lizard -C 15` — clean (max CCN 5)
- [x] `semgrep --config auto` — clean
- [x] Pre-push verify hook (15 profiles, 9 codex tests, fail_under=100) — green
- [ ] Post-merge: SonarCloud re-analyses main → S2083 issue auto-closes (last OPEN security issue on platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Inlines a workspace containment check in `scripts/quality/rollup_v2/apply_deterministic_patches.py` so Sonar S2083 recognizes the `--out-json` path-traversal sanitization. Replaces `safe_output_path()` with an explicit `str().startswith()` check and adds `os` for `os.sep`.

- **Bug Fixes**
  - Resolve `--out-json` against `Path.cwd()` and verify it stays within the workspace using `str(out_path).startswith(str(workspace_root) + os.sep)`.
  - Remove the helper call Sonar didn’t follow; behavior remains the same but the sanitizer is now visible to the analyzer.

<sup>Written for commit 718dda799dc2c019b9d019902c8b5fa4d31c2d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject output files that escape the workspace root**

### What Changed
- The script now checks `--out-json` inline and rejects paths that point outside the current workspace.
- Absolute and relative output paths are both resolved against the workspace before the file is written.
- Invalid paths now raise a clear error instead of writing outside the allowed folder.

### Impact
`✅ Fewer unsafe output-file writes`
`✅ Clearer path validation errors`
`✅ Less risk of workspace escape`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=H_j7__dZ11BHKLFdt3y-jSUC9hlTmBq_DDUQ2bVnU14&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
