### PR TITLE
fix(qzp-v2 sec): switch S2083 sanitizer to os.path.realpath + open()

### DIFF
--- a/scripts/quality/rollup_v2/apply_deterministic_patches.py
+++ b/scripts/quality/rollup_v2/apply_deterministic_patches.py
@@ -140,18 +140,15 @@ def main() -> int:
     repo_dir = Path(args.repo_dir)
 
     # Inline path-traversal sanitisation (Sonar pythonsecurity:S2083).
-    # Sonar's taint analyser doesn't follow ``safe_output_path()`` from
-    # ``scripts.quality.common`` inter-procedurally, so the validation
-    # is performed inline here using the explicit ``str().startswith()``
-    # pattern Sonar recognises as a containment check. Resolves the raw
-    # arg against ``Path.cwd()`` (Python's ``Path.__truediv__`` discards
-    # the left operand when the right operand is absolute, so this
-    # single expression handles both relative and absolute inputs), then
-    # rejects anything that escapes that root.
-    workspace_root = Path.cwd().resolve()
-    out_path = (workspace_root / Path(args.out_json)).resolve(strict=False)
-    workspace_root_str = str(workspace_root)
-    out_path_str = str(out_path)
+    # Uses the os.path.realpath + str.startswith pattern that SonarPython's
+    # taint analyser canonically recognises as breaking the taint chain.
+    # The previous pathlib-based check (PR #150) wasn't followed by Sonar's
+    # taint propagation through Path() conversions; staying in str/os.path
+    # land end-to-end makes the validation visible.
+    workspace_root_str = os.path.realpath(os.getcwd())
+    out_path_str = os.path.realpath(
+        os.path.join(os.getcwd(), args.out_json),
+    )
     if not out_path_str.startswith(workspace_root_str + os.sep):
         raise ValueError(
             f"--out-json escapes workspace root: {out_path_str}",
@@ -160,11 +157,12 @@ def main() -> int:
     canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
     result = run_patcher(canonical, repo_dir)
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(
-        json.dumps(result, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    # File I/O via os/builtin open() — keeps taint flow on the sanitised
+    # string variable rather than crossing through pathlib (which Sonar's
+    # taint analyser appears to lose track of).
+    os.makedirs(os.path.dirname(out_path_str) or ".", exist_ok=True)
+    with open(out_path_str, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(result, indent=2) + "\n")
 
     return 0
 


### PR DESCRIPTION
## **User description**
## Summary

PR #150's pathlib-based inline sanitizer (`Path.cwd().resolve()` + `Path.__truediv__` + `Path.resolve(strict=False)` + `str().startswith`) **still** triggered SonarPython's taint analyzer — same BLOCKER `AZ12OZ5q3D5PhlS90BLb` re-appeared at line 164-167 after main re-analysis with PR #150's content. The taint flow appears to break (or fail to track) when `out_path` crosses a `Path()` conversion boundary.

This rewrite stays in `str/os.path` land end-to-end so the validated value never crosses out of taint-tracked types:

```python
workspace_root_str = os.path.realpath(os.getcwd())
out_path_str = os.path.realpath(
    os.path.join(os.getcwd(), args.out_json),
)
if not out_path_str.startswith(workspace_root_str + os.sep):
    raise ValueError(...)
os.makedirs(os.path.dirname(out_path_str) or ".", exist_ok=True)
with open(out_path_str, "w", encoding="utf-8") as fh:
    fh.write(...)
```

The `os.path.realpath + str.startswith` pattern is the canonical SonarPython S2083 sanitizer recipe; the I/O sink is plain `open()` with the validated string — no Path() crossing.

## Test plan

- [x] `pytest tests/quality/rollup_v2/test_apply_deterministic_patches.py` — 10/10 passing
- [x] `coverage report` — 57 stmts, 10 branches, 0 missing → 100%
- [x] `lizard -C 15` — clean (max CCN 5)
- [x] Pre-push verify hook — green
- [ ] Post-merge: SonarCloud re-analyses main → S2083 issue auto-closes (last OPEN security issue, gating `new_security_rating: 5 → 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replace the pathlib-based sanitizer with a `str`/`os.path` flow to satisfy SonarPython S2083 and prevent the path traversal false positive. This keeps taint tracking intact and unblocks the security gate.

- **Bug Fixes**
  - Validate output path using `os.path.realpath(os.getcwd())`, `os.path.join(...)`, and `startswith(workspace_root + os.sep)`.
  - Perform I/O with `os.makedirs(...)` and `open()` to avoid `Path()` conversions that broke taint tracking.
  - Enforces workspace containment; raises `ValueError` on escape. All tests pass (10/10), coverage stays 100%.

<sup>Written for commit 83b4175f9d9bdf21b58db5b56847704fd8f4e258. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Use a Sonar-safe workspace path check for patch output**

### What Changed
- The script now validates `--out-json` with a workspace-root check that stays in plain path strings
- Output files are still blocked if they point outside the workspace
- The output file is now created with standard file handling after its parent folder is made if needed

### Impact
`✅ Fewer false security warnings`
`✅ Safer patch output paths`
`✅ Output files still blocked from escaping the workspace`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=TLnibBXWZQcoL0Y67jiExlQBuWc6B8eYEz0fkMAfN5Y&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
