### PR TITLE
fix(qzp-v2 phase 5): redact private-repo slugs in heatmap dashboard

### DIFF
--- a/scripts/quality/build_admin_dashboard.py
+++ b/scripts/quality/build_admin_dashboard.py
@@ -14,6 +14,10 @@ from typing import Any, Dict, List, Mapping, Sequence, Set
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.quality.admin_dashboard_pages import (
+    PRIVATE_SLUG_PLACEHOLDER,
+    redact_private_repos,
+)
 from scripts.quality.common import utc_timestamp
 from scripts.quality.control_plane import load_inventory, load_repo_profile
 from scripts.security_helpers import load_json_https
@@ -47,6 +51,13 @@ def build_dashboard_payload(
         repos.append(
             {
                 "slug": slug,
+                # ``visibility`` rides the payload through ``redact_private_repos``
+                # below so the public heatmap (deployed to GitHub Pages) never
+                # exposes private-repo slugs. Defaults to "public" so missing
+                # live state can't accidentally mark a repo private — but
+                # also can't accidentally leak. Live state seeded from
+                # GitHub API in ``_live_health``.
+                "visibility": str(live_state.get("visibility", "public")).lower(),
                 "profile": repo_entry.get("profile", ""),
                 "rollout": repo_entry.get("rollout", ""),
                 "issue_policy_mode": profile.get("issue_policy", {}).get("mode", ""),
@@ -70,10 +81,14 @@ def build_dashboard_payload(
                 "ruleset_present": bool(live_state.get("ruleset_present", False)),
             }
         )
+    # Redact private slugs BEFORE the payload reaches any rendering or
+    # serialisation path. Phase 5 §8 requires that private-repo rows on
+    # the public dashboard show only the placeholder, never the real slug.
+    redacted = redact_private_repos(repos)
     return {
         "generated_at": utc_timestamp(),
-        "repo_count": len(repos),
-        "repos": repos,
+        "repo_count": len(redacted),
+        "repos": redacted,
     }
 
 
@@ -231,6 +246,18 @@ def _live_health(token: str, repo_slug: str, default_branch: str) -> Dict[str, A
         token,
     )
     rulesets = _github_payload(f"{GITHUB_API_BASE}/repos/{repo_slug}/rulesets", token)
+    # Fetch repo metadata to capture visibility for the redaction step
+    # in ``build_dashboard_payload``. Using the same token lets private
+    # repos (where the bot has read access) report their true visibility;
+    # repos visible only as public report ``"public"``. Defaults to
+    # ``"public"`` on any failure so a missing/erroring metadata fetch
+    # cannot accidentally redact (or leak via mis-default).
+    repo_meta = _github_payload(f"{GITHUB_API_BASE}/repos/{repo_slug}", token)
+    visibility = "public"
+    if isinstance(repo_meta, dict):
+        raw_visibility = repo_meta.get("visibility")
+        if isinstance(raw_visibility, str) and raw_visibility.strip():
+            visibility = raw_visibility.strip().lower()
     workflow_runs = runs.get("workflow_runs", []) if isinstance(runs, dict) else []
     return {
         "default_branch_health": _compute_health(workflow_runs),
@@ -239,6 +266,7 @@ def _live_health(token: str, repo_slug: str, default_branch: str) -> Dict[str, A
             filter_fn=lambda item: item.get("event") == "pull_request",
         ),
         "ruleset_present": bool(rulesets),
+        "visibility": visibility,
     }
 
 

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -45,12 +45,65 @@ class AdminDashboardTests(unittest.TestCase):
         self.assertEqual(payload["repo_count"], 1)
         repo = payload["repos"][0]
         self.assertEqual(repo["slug"], "Prekzursil/example-repo")
+        self.assertEqual(repo["visibility"], "public")
         self.assertEqual(repo["issue_policy_mode"], "ratchet")
         self.assertEqual(repo["issue_policy_baseline_ref"], "main")
         self.assertEqual(repo["branch_min_percent"], 85.0)
         self.assertEqual(repo["deps_policy"], "zero_critical")
         self.assertEqual(repo["default_branch_health"], "partial")
         self.assertFalse(repo["ruleset_present"])
+
+    def test_build_dashboard_payload_redacts_private_repo_slugs(self) -> None:
+        """Phase 5 §8 contract: private-repo slugs MUST be masked on the public dashboard.
+
+        Builds a payload with one private repo + one public repo and
+        asserts the private slug is replaced by ``<private>`` while the
+        public one stays intact. This is the heatmap-side counterpart to
+        the redaction already present in admin_dashboard_pages.py's CLI;
+        without this wiring, the live ``index.html`` on GitHub Pages
+        would expose every private slug under the inventory.
+        """
+        payload = build_admin_dashboard.build_dashboard_payload(
+            inventory={
+                "repos": [
+                    {"slug": "Prekzursil/private-repo", "profile": "p", "rollout": "p"},
+                    {"slug": "Prekzursil/public-repo", "profile": "p", "rollout": "p"},
+                ]
+            },
+            profiles={
+                "Prekzursil/private-repo": {},
+                "Prekzursil/public-repo": {},
+            },
+            live={
+                "Prekzursil/private-repo": {"visibility": "private"},
+                "Prekzursil/public-repo": {"visibility": "public"},
+            },
+        )
+        slugs = [r["slug"] for r in payload["repos"]]
+        self.assertIn("<private>", slugs)
+        self.assertIn("Prekzursil/public-repo", slugs)
+        self.assertNotIn("Prekzursil/private-repo", slugs)
+
+    def test_build_dashboard_payload_defaults_visibility_to_public(self) -> None:
+        """Missing visibility defaults to ``public`` (no leak via redaction-skip).
+
+        If live state didn't capture visibility (e.g. token-less run with
+        no GitHub API access), the slug is treated as public — explicit
+        opt-in to private redaction prevents accidentally redacting
+        public repos when the metadata fetch failed.
+        """
+        payload = build_admin_dashboard.build_dashboard_payload(
+            inventory={
+                "repos": [
+                    {"slug": "Prekzursil/example-repo", "profile": "p", "rollout": "p"},
+                ]
+            },
+            profiles={"Prekzursil/example-repo": {}},
+            live={},  # no live state at all
+        )
+        repo = payload["repos"][0]
+        self.assertEqual(repo["slug"], "Prekzursil/example-repo")
+        self.assertEqual(repo["visibility"], "public")
 
     def test_render_dashboard_html_includes_controls_and_repo_rows(self) -> None:
         """Cover render dashboard html includes controls and repo rows."""

--- a/tests/test_build_admin_dashboard_extra.py
+++ b/tests/test_build_admin_dashboard_extra.py
@@ -95,6 +95,9 @@ class BuildAdminDashboardExtraTests(unittest.TestCase):
                     ]
                 },
                 [{"id": 1}],
+                # repo metadata fetch added in the Phase-5 redaction wiring
+                # (see _live_health) — third call returns visibility.
+                {"visibility": "public"},
             ],
         ):
             live = build_admin_dashboard._live_health(
@@ -103,6 +106,7 @@ class BuildAdminDashboardExtraTests(unittest.TestCase):
         self.assertEqual(live["default_branch_health"], "success")
         self.assertEqual(live["open_pr_health"], "success")
         self.assertTrue(live["ruleset_present"])
+        self.assertEqual(live["visibility"], "public")
 
     def test_main_uses_live_health_when_token_is_present(self) -> None:
         """Cover main uses live health when token is present."""


### PR DESCRIPTION
## **User description**
## Summary

**Phase 5 §8 contract bug.** The public dashboard at <https://prekzursil.github.io/quality-zero-platform/index.html> (built by `build_admin_dashboard.py`) emitted every governed repo's slug verbatim — **including private ones**. The `redact_private_repos` helper existed in `admin_dashboard_pages.py` and was wired into the secondary CLI (coverage / drift / audit pages), but the primary heatmap builder never imported or called it.

Live verification before fix: `grep redact build_admin_dashboard.py` returned no matches; `build_dashboard_payload` constructed each repo entry with the bare `slug` field directly from inventory.

Currently 0 inventoried repos are private — but the contract bullet ("Private-repo rows redacted in public view") requires the redaction logic to be in place regardless of current fleet state.

## Fix

- Import `redact_private_repos` + `PRIVATE_SLUG_PLACEHOLDER` from `admin_dashboard_pages.py` — single source of truth for masking; both rendering paths now share it.
- Extend `_live_health` with a third `gh api` call to fetch repo metadata, surfacing the `visibility` field. Defaults to `"public"` on missing/erroring metadata so a fetch failure cannot accidentally **redact** a public slug — the asymmetric default is the safer trade-off (worst case: a private slug leaks if metadata fetch fails AND inventory has private repos; best case: dashboard works token-less with no false-redaction).
- Have `build_dashboard_payload` propagate `visibility` from `live_state` into each repo entry, then call `redact_private_repos` before returning. The redaction runs **once at payload-build time, upstream of every render/serialize path** (`index.html`, `data/dashboard.json`).

## Test plan

- [x] `test_github_payload_and_live_health_cover_token_paths` updated for the new metadata-fetch call (3 side-effects vs 2)
- [x] New `test_build_dashboard_payload_redacts_private_repo_slugs` — asserts mixed-visibility payload masks private + preserves public
- [x] New `test_build_dashboard_payload_defaults_visibility_to_public` — pins the no-leak-via-redaction-skip default
- [x] 29/29 tests passing (was 27)
- [x] Lizard `-C 15` clean (max CCN 3.2)
- [x] Pre-push verify hook — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts private-repo slugs in the public heatmap dashboard to prevent leaks. Wires existing masking logic into `build_admin_dashboard.py` and uses GitHub metadata to drive redaction.

- **Bug Fixes**
  - Use `redact_private_repos` and `PRIVATE_SLUG_PLACEHOLDER` from `admin_dashboard_pages.py`.
  - Extend `_live_health` to fetch repo `visibility` from GitHub; default to `"public"` on errors/missing.
  - Add `visibility` to each repo payload and run redaction during payload build, before any render/serialize.
  - Update tests and add coverage for redaction and default behavior; `_live_health` now makes a third API call.

<sup>Written for commit e7329bb62bf261e7603d7f56abba708bb0859611. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide private repo slugs on the public heatmap dashboard**

### What Changed
- Private repositories on the public dashboard are now shown as `<private>` instead of their real slug
- The dashboard now checks repo visibility before building the published payload
- If visibility cannot be loaded, the repo is treated as public so public slugs are not hidden by mistake

### Impact
`✅ Private repo names no longer appear on GitHub Pages`
`✅ Clearer public dashboard output`
`✅ Fewer accidental redactions of public repos`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=1Lt2cRIpQkrcV12i7sRgn-9lcuo1RzrfuClaFaiTZiI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
