### PR TITLE
chore(qzp-v2): execution-state round 9 — dashboard redaction wiring fix

### DIFF
--- a/.beads/context/execution-state.md
+++ b/.beads/context/execution-state.md
@@ -568,3 +568,84 @@ PR #155 merged 2026-04-26 ~23:01Z. Round 8 complete:
 Loop continues to be blocked only by the 3 operator-only items
 in issue #154 — every code-side, Sonar-side, and contract bullet
 is verified true.
+
+---
+
+## 2026-04-27 — round 9 (Phase 5 §8 dashboard redaction wiring)
+
+### Real Phase 5 contract bug surfaced by audit
+
+The Phase 5 contract bullet "Private-repo rows redacted in public view"
+read as done because the helper `redact_private_repos` existed in
+`admin_dashboard_pages.py` and was wired into the secondary CLI for
+`coverage.html` / `drift.html` / `audit.html`. **But the primary
+heatmap builder (`build_admin_dashboard.py` → `index.html` +
+`data/dashboard.json`) never imported or called the helper.** The
+public dashboard at `https://prekzursil.github.io/quality-zero-platform/`
+emitted every governed repo's slug verbatim — including private ones
+(if any were in the inventory).
+
+Audit method: traced the call graph backwards from
+`publish-admin-dashboard.yml` → `build_admin_dashboard.py main()` →
+`build_dashboard_payload()` → no `redact_*` call in the path.
+Lesson: Phase audits must trace from the deployment artifact, not
+from the helper.
+
+### Fix landed in PR #157
+
+- Imported `redact_private_repos` + `PRIVATE_SLUG_PLACEHOLDER` from
+  `admin_dashboard_pages.py` (single source of truth — both rendering
+  paths now share the masking logic).
+- Extended `_live_health` with a third gh-api call to fetch repo
+  metadata (`/repos/<slug>`), surfacing `visibility`. Defaults to
+  `"public"` on missing/erroring metadata so a fetch failure cannot
+  accidentally REDACT a public slug — asymmetric default favours
+  detect-and-fix over blanket-blackout.
+- Have `build_dashboard_payload` propagate `visibility` from
+  `live_state` into each repo entry, then call `redact_private_repos`
+  before returning. Redaction runs once at payload-build time,
+  upstream of every render/serialize path (`index.html` AND
+  `data/dashboard.json`).
+
+### Tests + coverage
+
+- Updated `test_github_payload_and_live_health_cover_token_paths`
+  for the new metadata-fetch (3 side-effects vs 2).
+- New `test_build_dashboard_payload_redacts_private_repo_slugs`:
+  asserts mixed-visibility payload masks private + preserves public.
+- New `test_build_dashboard_payload_defaults_visibility_to_public`:
+  pins the no-leak-via-redaction-skip default.
+- 29/29 tests passing (was 27).
+- Lizard `-C 15` clean (max CCN 3.2).
+- Pre-push verify hook — green.
+
+### Other Phase 4 + 5 contract bullets re-audited (all hold)
+
+- `evaluate_break_glass` raises `BypassError` if Incident ID is missing
+  from PR body (Phase 4 contract: "requires Incident ID in PR body" ✅).
+- Audit trail destinations are `audit/break-glass.jsonl` +
+  `audit/skip.jsonl` — match the directive verbatim.
+- `alerts.py` docstring + design exclude any digest/summary
+  aggregation: "Phase 5 alert issue dispatcher — per-event, no
+  digests." Confirmed via full-file grep — no `digest`/`summary`
+  aggregator code path exists.
+
+### Loop blocker count
+
+Same 3 operator-only items as end of round 7 (no change). Tracking
+via platform issue #154.
+
+## Last action
+
+PR #157 merged 2026-04-26 ~23:21Z. Round 9 complete:
+
+- Phase 5 §8 dashboard-redaction contract — restored
+- Heatmap dashboard now masks private slugs at payload-build time,
+  upstream of HTML render + JSON serialize
+- Phase 4 break-glass + skip contract re-audited live
+- Phase 5 per-event-only alert constraint re-audited live
+
+The platform is in its strongest code-side state since the rollout
+started: every code-verifiable absolute-done bullet has been
+re-traced from the deployment artifact backward and confirmed in
+place. Loop continues blocked only by the 3 operator-only items.


### PR DESCRIPTION
## **User description**
## Summary

Round 9 closed PR #157 — the heatmap dashboard now masks private-repo slugs at payload-build time, upstream of every HTML render + JSON serialize path. Previously the Phase 5 §8 contract bullet "Private-repo rows redacted in public view" only held for the secondary `coverage.html` / `drift.html` / `audit.html` pages; the main `index.html` (built by `build_admin_dashboard.py`) leaked every slug verbatim.

The bug surfaced by tracing the call graph backwards from `publish-admin-dashboard.yml` → `build_admin_dashboard.py main()` → `build_dashboard_payload()` and noting no `redact_*` call in the path.

### Round 9 also re-verified contract bullets that don't change

- `evaluate_break_glass` raises `BypassError` if Incident ID is missing from PR body (Phase 4 contract ✅)
- Audit destinations are `audit/break-glass.jsonl` + `audit/skip.jsonl` ✅
- `alerts.py` docstring + design exclude any digest/summary aggregation ✅
- All 4 known-issues entries have `feeds_qrv2: true` + populated `verified_at`/`verified_by` ✅
- `render_codex_prompt.py` imports `load_known_issues` + `qrv2_prompt_entries` from `known_issues.py` (Phase 4 wiring ✅)

## Loop blocker count

Same 3 operator-only items as end of round 7 (no change). Tracking via [#154](https://github.com/Prekzursil/quality-zero-platform/issues/154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Redact private repo slugs in the public dashboard**

### What Changed
- The public heatmap dashboard now masks private repository slugs before the page and JSON payload are generated.
- Repo visibility is now read during dashboard build so private entries can be redacted while public entries stay visible.
- Added coverage for mixed public/private dashboards and for the default behavior when visibility data is missing.

### Impact
`✅ Fewer private repo leaks in the public dashboard`
`✅ Safer dashboard publishing`
`✅ Clearer coverage for redaction behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=B8uVRdsFgPpDpFv6fB1YufQkS7ZAb-nJ1_N1ieMXzuw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak in the public heatmap by redacting private repo slugs at payload-build time for `index.html` and `data/dashboard.json`. Re-verifies Phase 4/5 contract checks and notes unchanged operator blockers.

- **Bug Fixes**
  - Wired `redact_private_repos` into `build_admin_dashboard.py` so the heatmap masks private slugs.
  - Fetched repo `visibility` during build; defaults to `"public"` on failures to avoid accidental redaction.
  - Added tests for mixed visibility and the default behavior.

<sup>Written for commit a4b471be5c4892499127103da51a37ee11b457ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

