### PR TITLE
fix(qzp-v2 phase 3): drift-sync PRs auto-merge on green CI

### DIFF
--- a/scripts/quality/apply_drift_pr.py
+++ b/scripts/quality/apply_drift_pr.py
@@ -85,7 +85,16 @@ def _gh_pr_create(
     cwd: Path,
     runner,
 ) -> None:
-    """Invoke ``gh pr create`` with the staged branch."""
+    """Invoke ``gh pr create`` with the staged branch + enable auto-merge.
+
+    Phase 3 contract: drift-sync PRs auto-merge on green CI.
+    ``gh pr create`` itself has no auto-merge flag, so a follow-up
+    ``gh pr merge --auto --squash`` arms the merge once CI clears.
+    A failure to enable auto-merge is logged but **not fatal** — the
+    PR still exists and the operator can merge it manually. This
+    asymmetric tolerance prevents drift PRs from being orphaned by a
+    transient ``gh`` hiccup on the auto-merge step.
+    """
     runner(
         [
             "gh", "pr", "create",
@@ -99,6 +108,26 @@ def _gh_pr_create(
         capture_output=True,
         text=True,
     )
+    # gh resolves the PR by current branch — no need to parse the URL.
+    try:
+        runner(
+            ["gh", "pr", "merge", branch, "--auto", "--squash"],
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Auto-merge is best-effort. Common failure modes: repo-level
+        # auto-merge disabled, branch protection prevents squash, token
+        # lacks permission. Log and continue so the PR is still useful.
+        print(
+            f"apply_drift_pr: enabling auto-merge on {branch} failed "
+            f"(exit {exc.returncode}); PR remains open for manual merge. "
+            f"stderr: {exc.stderr}",
+            file=sys.stderr,
+            flush=True,
+        )
 
 
 def _build_body(

--- a/tests/test_apply_drift_pr.py
+++ b/tests/test_apply_drift_pr.py
@@ -150,7 +150,7 @@ class RunDriftPrTests(unittest.TestCase):
         self.assertEqual(calls, [])
 
     def test_out_of_sync_runs_full_git_and_gh_sequence(self) -> None:
-        """Drift triggers checkout+add+commit+push+gh pr create."""
+        """Drift triggers checkout+add+commit+push+gh pr create+gh pr merge --auto."""
         rc, calls = self._run(
             {
                 "entries": [
@@ -172,6 +172,68 @@ class RunDriftPrTests(unittest.TestCase):
         self.assertIn(
             "chore(drift-sync): apply template updates", commit_cmd,
         )
+        # Phase 3 contract: drift PRs auto-merge on green CI.
+        # The script issues ``gh pr merge <branch> --auto --squash`` after
+        # ``gh pr create`` so the PR squash-merges itself the moment CI
+        # turns green — without this step, drift PRs would sit open
+        # indefinitely.
+        gh_calls = [c for c in calls if c[:2] == ["gh", "pr"]]
+        gh_actions = [c[2] for c in gh_calls]
+        self.assertIn("create", gh_actions)
+        self.assertIn("merge", gh_actions)
+        merge_call = next(c for c in gh_calls if c[2] == "merge")
+        self.assertIn("--auto", merge_call)
+        self.assertIn("--squash", merge_call)
+
+    def test_auto_merge_failure_is_non_fatal(self) -> None:
+        """If ``gh pr merge --auto`` fails, the PR is still created.
+
+        Common failure modes (repo auto-merge disabled, branch
+        protection forbids squash, token lacks permission) shouldn't
+        orphan the drift PR — it stays open for manual merge. This
+        test pins that asymmetric tolerance.
+        """
+        path = _write_report({
+            "entries": [
+                {
+                    "status": "drift",
+                    "output_path": "codecov.yml",
+                    "proposed_content": "x\n",
+                }
+            ]
+        })
+        self.addCleanup(path.unlink, missing_ok=True)
+
+        merge_attempts: List[List[str]] = []
+
+        def runner(
+            cmd, cwd=None, check=False, capture_output=False, text=False
+        ) -> subprocess.CompletedProcess:
+            """Succeed on everything except gh pr merge."""
+            if cmd[:3] == ["gh", "pr", "merge"]:
+                merge_attempts.append(list(cmd))
+                raise subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=cmd,
+                    stderr="auto-merge not enabled on repo",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            args = argparse.Namespace(
+                report=str(path),
+                repo_slug="Prekzursil/test-repo",
+                default_branch="main",
+                platform_ref="main",
+                cwd=tmp,
+                runner=None,
+            )
+            rc = apr._run_drift_pr(args, runner)
+
+        # Auto-merge attempt was made — but its failure didn't propagate.
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(merge_attempts), 1)
+        self.assertIn("--auto", merge_attempts[0])
 
     def test_out_of_sync_but_no_writable_entries_returns_0(self) -> None:
         """If every entry has an empty output_path the script exits early."""


### PR DESCRIPTION
## **User description**
## Summary

**Phase 3 contract gap.** `reusable-drift-sync.yml` opens PRs when template drift is detected, but the spec says those PRs MUST "auto-merge on green CI". The original `_gh_pr_create` only invoked `gh pr create` and **never enabled auto-merge** — so drift PRs sat open indefinitely until an operator merged them by hand, defeating the whole point of the fleet-wide drift-sync sweep.

**Audit method:** `grep -rE 'auto.merge|--auto' .github/workflows/ scripts/quality/{drift_sync,apply_drift_pr}.py` → zero matches. The contract bullet was unmet.

## Fix

After `gh pr create` succeeds, follow up with:

```python
runner(
    ["gh", "pr", "merge", branch, "--auto", "--squash"],
    cwd=str(cwd), check=True, capture_output=True, text=True,
)
```

The PR squash-merges automatically once CI clears + branch protection is satisfied. The call is wrapped in `try/except` on `subprocess.CalledProcessError` — failures (repo-level auto-merge disabled, branch protection forbids squash, token lacks permission) are logged to stderr without failing the script. Asymmetric tolerance: PR still exists and an operator can merge it manually if auto-merge can't be armed.

## Test plan

- [x] Updated `test_out_of_sync_runs_full_git_and_gh_sequence` — asserts both `gh pr create` AND `gh pr merge --auto --squash` appear in the call sequence
- [x] New `test_auto_merge_failure_is_non_fatal` — pins the asymmetric tolerance: a `CalledProcessError` on the merge step doesn't propagate to a non-zero exit
- [x] 10/10 tests passing (was 9/9)
- [x] Lizard `-C 15` clean (max CCN 2.1)
- [x] Pre-push verify hook — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make drift-sync PRs auto-merge on green CI so fleet-wide template updates complete without manual intervention. `_gh_pr_create` now arms auto-merge using `gh pr merge --auto --squash` after `gh pr create`.

- **Bug Fixes**
  - Run `gh pr merge <branch> --auto --squash` right after PR creation.
  - Treat auto-merge failures as non-fatal; log to stderr and leave PR open for manual merge.
  - Tests updated to assert the merge call and verify failure tolerance.

<sup>Written for commit 26a9729ca19e2d42c2e39eb0ab7400e537acf0c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Auto-merge drift-sync PRs after they are created**

### What Changed
- Drift-sync PRs now get auto-merge enabled after creation, so they can merge themselves once CI passes.
- If auto-merge cannot be turned on, the PR still stays open and the script finishes without failing.
- Added test coverage for both the auto-merge path and the case where enabling auto-merge fails.

### Impact
`✅ Fewer drift PRs left waiting for manual merge`
`✅ Shorter cleanup after template drift is detected`
`✅ Clearer handling when auto-merge is unavailable`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=USvp_N5qNlkcLNzYf-SlXxMNr62zEFMTJxh7TNHDDFI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
