### PR TITLE
fix(codeql): Go requires build_mode autobuild, not none

### DIFF
--- a/profiles/repos/devextreme-filter-go-language.yml
+++ b/profiles/repos/devextreme-filter-go-language.yml
@@ -28,7 +28,10 @@ vendors:
   sonar:
     project_key: Prekzursil_DevExtreme-Filter-Go-Language
 codeql:
-  build_mode: none
+  # Go REQUIRES build_mode: autobuild (or manual). CodeQL v4 errors out
+  # with "Go does not support the none build mode" if set to ``none``.
+  # See: github/codeql-action#3258 + run 24976734212 init log.
+  build_mode: autobuild
   languages:
   - actions
   - go


### PR DESCRIPTION
## **User description**
## Summary

- Flip `codeql.build_mode` on `profiles/repos/devextreme-filter-go-language.yml` from `none` to `autobuild`.
- Resolves long-standing `codeql / CodeQL` failures on devextreme-filter-go-language main (4 weekly schedule failures since 2026-03-30 push; most recent run `24976734212`).

## Diagnostic root cause

CodeQL v4's `database init` step fails for any Go-language target when `build-mode` is `none`:

```
Encountered a fatal error while running ``codeql database init --build-mode=none``:
A fatal error occurred: Go does not support the none build mode. Please try using
one of the following build modes instead: autobuild, manual.
```

The `actions` language tolerates `build-mode: none` (no build needed), but Go does not. Go always needs either `autobuild` (which runs `go build ./...` automatically) or `manual` (consumer supplies the build).

`profiles/repos/devextreme-filter-go-language.yml` had `build_mode: none` but listed `[actions, go]` as languages — the moment Go entered the language matrix, init failed.

## Fix

```diff
 codeql:
-  build_mode: none
+  # Go REQUIRES build_mode: autobuild (or manual). CodeQL v4 errors out
+  # with "Go does not support the none build mode" if set to ``none``.
+  build_mode: autobuild
   languages:
   - actions
   - go
```

The platform's `reusable-codeql.yml` already handles `autobuild` via `github/codeql-action/autobuild@v4` when the profile says so, so no platform-side change is needed.

## Why other profiles are unaffected

`build_mode: none` is correct and currently in use for any profile whose only languages are non-build-required (actions, javascript, python, etc.). This change touches one profile only.

## Test plan

- [ ] Pre-push hook (already validated 15 repo profiles + ran `scripts/verify`) green ✓
- [ ] PR CI green on platform side
- [ ] After merge, devextreme-filter-go-language CodeQL workflow runs green on next schedule (or workflow_dispatch).
- [ ] Verify via `gh run view --repo Prekzursil/devextreme-filter-go-language <run_id>` that the CodeQL job's "Initialize CodeQL" step now succeeds.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch CodeQL `build_mode` from `none` to `autobuild` in `profiles/repos/devextreme-filter-go-language.yml` to satisfy Go’s requirement. This fixes the CodeQL v4 Go init error and restores passing runs via `github/codeql-action/autobuild@v4`.

<sup>Written for commit 376eba62df8b1f724ed5fdbd910601c0673726fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix CodeQL scans for the Go repo profile**

### What Changed
- Changed the Go repo profile to use automatic building during CodeQL scans, which stops scan setup from failing
- This fixes the recurring CodeQL failure for the `actions` + `go` profile on main and scheduled runs

### Impact
`✅ Fewer CodeQL scan failures`
`✅ Reliable Go security scans`
`✅ Fewer broken scheduled checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=fODZf53d8TiEM4EXO1t_XLyth6InON3M4N6TDf1qPSY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
