### PR TITLE
fix(codeql): drop `actions` from devextreme so Go autobuild works

### DIFF
--- a/profiles/repos/devextreme-filter-go-language.yml
+++ b/profiles/repos/devextreme-filter-go-language.yml
@@ -28,12 +28,21 @@ vendors:
   sonar:
     project_key: Prekzursil_DevExtreme-Filter-Go-Language
 codeql:
-  # Go REQUIRES build_mode: autobuild (or manual). CodeQL v4 errors out
-  # with "Go does not support the none build mode" if set to ``none``.
+  # Go REQUIRES build_mode: autobuild (or manual). CodeQL v4 errors with
+  # "Go does not support the none build mode" if set to ``none``.
   # See: github/codeql-action#3258 + run 24976734212 init log.
+  #
+  # actions + go in the SAME profile is incompatible because:
+  #   - actions language only supports build-mode: none
+  #   - go language only supports build-mode: autobuild|manual
+  # The reusable-codeql.yml passes one global --build-mode, so the
+  # languages must agree. Dropping ``actions`` keeps Go (the actual
+  # codebase) analyzed; the only workflow file is the auto-generated
+  # codeql.yml itself, which adds no value to scan.
+  # See: run 24978222732 init log ("GitHub Actions does not support
+  # the autobuild build mode").
   build_mode: autobuild
   languages:
-  - actions
   - go
   setup:
     go: '1.24'


### PR DESCRIPTION
## **User description**
## Summary

- Follow-up to PR #166. Drop `actions` from `devextreme-filter-go-language.yml` codeql.languages.
- Resolves run `24978222732` failure on devextreme main: "GitHub Actions does not support the autobuild build mode".

## Diagnostic root cause

PR #166 flipped `build_mode` from `none` → `autobuild` because Go errors out on `none`. That fix worked for Go, but exposed a second issue:

```
codeql database init --build-mode=autobuild --language=actions --language=go
A fatal error occurred: GitHub Actions does not support the autobuild build mode.
Please try using one of the following build modes instead: none.
```

`actions` and `go` languages have **incompatible build_mode requirements**:
- `actions` only supports `build-mode: none`
- `go` only supports `build-mode: autobuild|manual`

The platform's `reusable-codeql.yml` passes a single global `--build-mode` to `github/codeql-action/init@v4`, so all languages in the matrix must agree on a build mode. With `[actions, go]` in the same profile, no single value works.

## Fix

Drop `actions` from devextreme's languages list. The repo has only one workflow file (the auto-generated `codeql.yml`), which provides no security value to analyze. Single-language Go + autobuild works cleanly.

```diff
 codeql:
   build_mode: autobuild
   languages:
-  - actions
   - go
   setup:
     go: '1.24'
```

## Why not a platform-side fix?

A more complete fix would refactor `reusable-codeql.yml` to support a per-language build_mode matrix — e.g., spawn parallel jobs `(actions, none)` and `(go, autobuild)`. That's a platform-architecture change with broader impact (touches every profile's CodeQL config) and is out of scope for this fleet-cleanup pass. Filed as a future improvement.

## Test plan

- [ ] Pre-push hook (validates 15 profiles + scripts/verify) green ✓
- [ ] PR CI green
- [ ] After merge, trigger `gh workflow run codeql.yml --repo Prekzursil/devextreme-filter-go-language --ref main` and verify the Initialize CodeQL step succeeds with `--language=go --build-mode=autobuild`.

## Three-failures rule

This is attempt #2 on devextreme CodeQL. Attempt #1 (PR #166: flip build_mode) succeeded for Go but exposed the actions+go conflict. The diagnostic data unambiguously points to dropping `actions` as the minimum fix. If this attempt fails too, will STOP per directive and open `alert:fleet-bump-fail`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL configuration settings to optimize build process compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove Actions from the Go CodeQL profile so scanning can run**

### What Changed
- Dropped the Actions language from the DevExtreme CodeQL profile so Go scans can use autobuild successfully
- Kept Go scanning enabled for the repository’s actual source code
- Clarified why Actions and Go cannot share the same CodeQL build mode

### Impact
`✅ Fewer CodeQL scan failures`
`✅ Successful Go security scans`
`✅ Fewer broken workflow runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=F5gfd9fQ18Q1gVQgBnMPN9WE4lTZTCoeaQLULNjUMak&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
