### PR TITLE
fix(qzp-gate): isolate Sonar Zero ratchet bug fix + 12-min retry budget

### DIFF
--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -20,7 +20,13 @@ from scripts.quality.common import utc_timestamp, write_report
 from scripts.security_helpers import load_json_https
 
 SONAR_API_BASE = "https://sonarcloud.io"
-SCOPED_ANALYSIS_RETRY_ATTEMPTS = 72
+# Bumped from 72 to 144 (12-minute retry budget) because the
+# SonarCloud Scan workflow + Sonar's PR-scope indexing can take up to
+# ~5 minutes combined. The previous 6-minute budget was a tight race
+# and PRs were occasionally hitting HTTP 404 from sonarcloud.io
+# /api/issues/search?pullRequest=<n> when the gate queried before
+# Sonar finished uploading + indexing the analysis. See QZP issue #169.
+SCOPED_ANALYSIS_RETRY_ATTEMPTS = 144
 
 
 def _mapping_or_empty(value: Any) -> Dict[str, Any]:

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -15,8 +15,8 @@ from typing import Any, Dict, Iterable, List, Mapping, Tuple
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from scripts.quality.common import utc_timestamp, write_report
 from scripts.quality import sonar_zero_support
+from scripts.quality.common import utc_timestamp, write_report
 from scripts.security_helpers import load_json_https
 
 SONAR_API_BASE = "https://sonarcloud.io"
@@ -40,9 +40,7 @@ def _preferred_text(*values: Any) -> str:
 def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments for the Sonar zero gate."""
     parser = argparse.ArgumentParser(
-        description=(
-            "Assert SonarCloud has zero open issues and a passing quality gate."
-        )
+        description="Assert SonarCloud has zero open issues and a passing quality gate.",
     )
     parser.add_argument("--project-key", required=True)
     parser.add_argument("--token", default="")
@@ -50,6 +48,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--sha", default="")
     parser.add_argument("--branch", default="")
     parser.add_argument("--pull-request", default="")
+    parser.add_argument(
+        "--main-branch",
+        default="main",
+        help=(
+            "Repository default branch. When --branch matches this value, "
+            "the run is treated as absolute (not scoped) so ratchet mode "
+            "doesn't bypass the open-issue check on main."
+        ),
+    )
     parser.add_argument("--out-json", default="sonar-zero/sonar.json")
     parser.add_argument("--out-md", default="sonar-zero/sonar.md")
     return parser.parse_args()
@@ -57,7 +64,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _auth_header(token: str) -> str:
     """Build the basic-auth header SonarCloud expects for token auth."""
-    return "Basic " + base64.b64encode(f"{token}:".encode("utf-8")).decode("ascii")
+    return "Basic " + base64.b64encode(f"{token}:".encode()).decode("ascii")
 
 
 def _request_json(url: str, auth_header: str) -> Dict[str, Any]:
@@ -136,8 +143,7 @@ def _load_quality_gate(args: argparse.Namespace, auth: str) -> str:
         pull_request=args.pull_request,
     )
     gate_payload = _request_json(
-        f"{SONAR_API_BASE}/api/qualitygates/project_status?"
-        f"{urllib.parse.urlencode(gate_query)}",
+        f"{SONAR_API_BASE}/api/qualitygates/project_status?{urllib.parse.urlencode(gate_query)}",
         auth,
     )
     project_status = _mapping_or_empty(gate_payload.get("projectStatus"))
@@ -152,9 +158,10 @@ def _load_sonar_findings(
     open_issues = _load_open_issues(args, auth)
     quality_gate = _load_quality_gate(args, auth)
     findings: List[str] = []
-    ratchet_scoped = getattr(
-        args, "policy_mode", "ratchet"
-    ) == "ratchet" and _is_scoped_analysis(args)
+    ratchet_scoped = (
+        getattr(args, "policy_mode", "ratchet") == "ratchet"
+        and _is_ratchet_scoped(args)
+    )
     if open_issues != 0 and not ratchet_scoped:
         findings.append(f"Sonar reports {open_issues} open issues (expected 0).")
     if quality_gate != "OK" and open_issues != 0:
@@ -163,13 +170,35 @@ def _load_sonar_findings(
 
 
 def _is_scoped_analysis(args: argparse.Namespace) -> bool:
-    """Return whether the Sonar query targets a branch or pull request."""
+    """Return whether the Sonar API call targets a branch or pull request.
+
+    This drives the API-shape branch (whether to wait for branch/PR
+    analysis to settle on the target SHA). It does NOT decide whether
+    ratchet should bypass the issue-count check — that's
+    ``_is_ratchet_scoped``.
+    """
     return bool(
         _preferred_text(
             getattr(args, "branch", ""),
             getattr(args, "pull_request", ""),
         )
     )
+
+
+def _is_ratchet_scoped(args: argparse.Namespace) -> bool:
+    """Return whether ratchet mode should bypass the open-issue check.
+
+    Ratchet mode lets PRs / feature branches keep the existing baseline
+    of issues (they only fail on NEW introductions). Main-branch runs
+    are excluded: a main run evaluates the absolute baseline state we
+    want to drive to zero. This matches
+    ``profile.issue_policy.main_behavior: absolute``.
+    """
+    if _preferred_text(getattr(args, "pull_request", "")):
+        return True
+    branch = _preferred_text(getattr(args, "branch", ""))
+    main_branch = _preferred_text(getattr(args, "main_branch", ""), "main")
+    return bool(branch) and branch != main_branch
 
 
 def _target_sha(args: argparse.Namespace) -> str:
@@ -359,10 +388,7 @@ def load_sonar_findings_with_retry(
 ) -> Tuple[int, str, List[str]]:
     """Load Sonar findings, retrying while a scoped analysis is still settling."""
     if len(args) != 2:
-        raise TypeError(
-            "load_sonar_findings_with_retry expects argparse namespace "
-            "and auth header"
-        )
+        raise TypeError("load_sonar_findings_with_retry expects argparse namespace and auth header")
     namespace, auth = args
     retry_settings = _resolve_retry_settings(kwargs)
     return sonar_zero_support.load_sonar_findings_with_retry(


### PR DESCRIPTION
## **User description**
Isolated from PR #164 (which is operator-blocked on DeepSource Python+Secrets cached failure state) so the Sonar gate fixes can land independently.

## Two fixes

1. **Sonar Zero ratchet bug**: `_is_scoped_analysis` was conflating two scoping semantics (Sonar API call vs issue-policy). Main-branch runs in `ratchet` mode were silently bypassing the open-issue check because `branch=main` made them appear scoped. event-link main showed 39 Sonar issues + 2 hotspots while the gate stayed green — exactly the loophole the maintainer just called out.
   - Split `_is_scoped_analysis` (API semantics, unchanged) from new `_is_ratchet_scoped` (issue-policy semantics, treats main as absolute).

2. **Retry budget**: bump `SCOPED_ANALYSIS_RETRY_ATTEMPTS` from 72 (6min) to 144 (12min) to absorb the SonarCloud upload + index race. Multiple fleet PRs (devextreme #18, env-inspector #104) were failing with HTTP 404 because the gate queried before SonarCloud finished indexing. See QZP issue #169.

17 existing tests still pass. No DeepSource changes — this PR is intentionally minimal so it can land without the PR #164 operator-blocked baggage.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the Sonar Zero gate so main is evaluated as absolute (not ratcheted), and extends the retry window to 12 minutes to avoid SonarCloud indexing races. Main will now fail when open issues exist, and PR 404 flakiness should drop.

- **Bug Fixes**
  - Split API scoping from ratchet policy: keep `_is_scoped_analysis` for API shape, add `_is_ratchet_scoped` so ratchet bypass applies only to PRs/feature branches, not the default branch. Added `--main-branch` arg (defaults to `main`).
  - Increased `SCOPED_ANALYSIS_RETRY_ATTEMPTS` from 72 to 144 to cover Sonar upload + indexing delays and reduce HTTP 404s (see QZP #169).

<sup>Written for commit 8a30c841f818acb9278cb53b3f0d1a51265dd901. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make Sonar gate enforce open-issue checks on main and wait longer for SonarCloud indexing**

### What Changed
- Main-branch runs are now treated as absolute checks, so ratchet mode no longer skips open Sonar issues on `main`
- Added a default main-branch setting so the gate can distinguish main from feature branches and pull requests
- Increased the retry window from 6 minutes to 12 minutes to reduce failed checks caused by SonarCloud still uploading or indexing results

### Impact
`✅ Main branch now fails when Sonar issues are still open`
`✅ Fewer false green checks on default branch`
`✅ Fewer Sonar 404 failures during new analysis uploads`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=BkdpTY7k1j9gtsFrvhSm3_c9_zf1wCUxBCz6uvC1iFQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
