### PR TITLE
fix(profile): install defusedxml + use --cov=. for env-inspector

### DIFF
--- a/profiles/repos/env-inspector.yml
+++ b/profiles/repos/env-inspector.yml
@@ -14,9 +14,18 @@ issue_policy:
 coverage:
   command: "mkdir -p coverage\nmkdir -p .tmp\nexport TMPDIR=\"$PWD/.tmp\"\npython\
     \ -m pip install --upgrade pip\nif [ -f requirements.txt ]; then python -m pip\
-    \ install -r requirements.txt; fi\npython -m pip install pytest pytest-cov\npython\
-    \ -m pytest -q -s \\\n  --cov=env_inspector \\\n  --cov=env_inspector_core \\\n\
-    \  --cov=env_inspector_gui \\\n  --cov-branch \\\n  --cov-report=xml:coverage/python-coverage.xml\n"
+    \ install -r requirements.txt; fi\n# ``defusedxml`` is the XXE-safe XML parser\
+    \ used by\n# ``scripts/cobertura_to_sonar_generic.py`` (Semgrep\n# ``python.lang.security.use-defused-xmltree``).\
+    \  Tests for the\n# converter import it; install here so pytest collection\n#\
+    \ doesn't fail with ModuleNotFoundError.\npython -m pip install pytest pytest-cov\
+    \ defusedxml\n# ``--cov=.`` (repo root) so coverage.xml has a single\n# ``<source>``\
+    \ element. ``.coveragerc`` controls scope via\n# ``omit`` and ``[report] exclude_lines``.\
+    \ Per-package style produced\n# multiple ``<source>`` roots Sonar couldn't disambiguate.\n\
+    python -m pytest -q -s --cov=. --cov-branch \\\n  --cov-report=xml:coverage/python-coverage.xml\n\
+    # Mirror the cobertura XML to ``coverage.xml`` at the repo root so\n# the converter\
+    \ + Sonar's reportPaths defaults find it.\ncp coverage/python-coverage.xml coverage.xml\n\
+    if [ -f scripts/cobertura_to_sonar_generic.py ]; then\n  python scripts/cobertura_to_sonar_generic.py\
+    \ \\\n    --in coverage.xml \\\n    --out coverage-sonar.xml\nfi\n"
   inputs:
   - format: xml
     name: python


### PR DESCRIPTION
## **User description**
## Summary

env-inspector PR #107 ships \`scripts/cobertura_to_sonar_generic.py\` which converts pytest-cov's cobertura output to Sonar Generic Test Coverage XML. The converter uses \`defusedxml\` for XXE safety. Without the package installed in the QZP coverage gate, pytest collection fails with \`ModuleNotFoundError: No module named 'defusedxml'\`, blocking PR #107.

## Changes

1. **Install \`defusedxml\`** in the env-inspector coverage command's pip install line.
2. **Switch from per-package to \`--cov=.\`** — per-package style produced multiple \`<source>\` roots Sonar's Cobertura sensor couldn't disambiguate.
3. **Run the converter** after pytest to emit \`coverage-sonar.xml\` (gated on script presence so older consumer SHAs without the script don't fail).

## Test plan

- [x] \`python -m unittest tests.test_control_plane_profiles\` passes
- [ ] After merge, env-inspector PR #107's QZP Coverage 100 Gate flips green
- [ ] env-inspector main shows \`line_coverage=100%\` in SonarCloud

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the env-inspector coverage job by installing `defusedxml`, running coverage from the repo root, and generating Sonar-compatible output so SonarCloud reads coverage correctly. This unblocks env-inspector PR #107 and restores accurate coverage.

- **Bug Fixes**
  - Install `defusedxml` with `pytest`/`pytest-cov` to satisfy the converter and its tests.
  - Switch to `--cov=.` to produce a single coverage source; scope is controlled by `.coveragerc`.
  - Copy `coverage/python-coverage.xml` to `coverage.xml` and run `scripts/cobertura_to_sonar_generic.py` to emit `coverage-sonar.xml` (only if the script exists).

<sup>Written for commit 48cd5ac921954b74f6787cc0c055914881d1d4a2. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/173?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Fix env-inspector coverage reporting so the gate runs and Sonar can read it

### What Changed
- Installs `defusedxml` before tests so coverage collection no longer fails when the XML converter is present
- Runs coverage from the repository root so the report has one source path and Sonar can apply coverage correctly
- Copies the coverage XML to the expected root location and generates Sonar-compatible coverage output when the converter script is available

### Impact
`✅ Fewer coverage gate failures`
`✅ Accurate Sonar coverage on env-inspector`
`✅ Unblocked env-inspector PR checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=S1-m6bAUjlpzDmtTcme1QnScEyTcYJyyeWOq6mg0TYc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
