### PR TITLE
fix(qzp): drive remaining 13 Sonar findings to zero

### DIFF
--- a/scripts/beads-fetch-conversation-history.ts
+++ b/scripts/beads-fetch-conversation-history.ts
@@ -460,7 +460,9 @@ async function main() {
   console.log("\nNext: Run '/self-reflect' to analyze with Claude Code");
 }
 
-main().catch(error => {
-  console.error("Error:", error.message);
+try {
+  await main();
+} catch (error) {
+  console.error("Error:", error instanceof Error ? error.message : error);
   process.exit(1);
-});
+}

--- a/scripts/beads-fetch-pr-comments.ts
+++ b/scripts/beads-fetch-pr-comments.ts
@@ -26,16 +26,14 @@ import { dirname } from "node:path";
 // through e.g. a PR title. Objects go through JSON.stringify so we don't
 // emit the useless "[object Object]" placeholder.
 function sanitizeForLog(value: unknown): string {
-  let stringified: string;
-  if (value === null || value === undefined) {
-    stringified = String(value);
-  } else if (typeof value === "object") {
-    stringified = JSON.stringify(value);
-  } else {
-    // Primitives: number, string, boolean, bigint, symbol all have a
-    // meaningful String() representation that is not "[object Object]".
-    stringified = String(value);
-  }
+  // Objects go through JSON.stringify so we never emit the useless
+  // "[object Object]" placeholder. Non-objects (null, undefined, and
+  // primitives) coerce via a template literal — this gives Sonar's
+  // typescript:S6551 analyser the type-narrowing it needs to prove the
+  // ``String()`` default-stringification path is unreachable.
+  const stringified = (typeof value === "object" && value !== null)
+    ? JSON.stringify(value)
+    : `${value as string | number | boolean | bigint | symbol | null | undefined}`;
   return stringified.replaceAll(/[\x00-\x1f]/g, " ");
 }
 
@@ -386,7 +384,9 @@ async function main() {
   console.log("\nNext: Run '/self-reflect' to analyze with Claude Code");
 }
 
-main().catch(error => {
-  console.error("Error:", error.message);
+try {
+  await main();
+} catch (error) {
+  console.error("Error:", error instanceof Error ? error.message : error);
   process.exit(1);
-});
+}

--- a/scripts/beads-self-reflect.ts
+++ b/scripts/beads-self-reflect.ts
@@ -29,16 +29,14 @@ import { parseArgs } from "node:util";
 // Slack API error string. Objects go through JSON.stringify so we don't
 // emit the useless "[object Object]" placeholder.
 function sanitizeForLog(value: unknown): string {
-  let stringified: string;
-  if (value === null || value === undefined) {
-    stringified = String(value);
-  } else if (typeof value === "object") {
-    stringified = JSON.stringify(value);
-  } else {
-    // Primitives: number, string, boolean, bigint, symbol all have a
-    // meaningful String() representation that is not "[object Object]".
-    stringified = String(value);
-  }
+  // Objects go through JSON.stringify so we never emit the useless
+  // "[object Object]" placeholder. Non-objects (null, undefined, and
+  // primitives) coerce via a template literal — this gives Sonar's
+  // typescript:S6551 analyser the type-narrowing it needs to prove the
+  // ``String()`` default-stringification path is unreachable.
+  const stringified = (typeof value === "object" && value !== null)
+    ? JSON.stringify(value)
+    : `${value as string | number | boolean | bigint | symbol | null | undefined}`;
   return stringified.replaceAll(/[\x00-\x1f]/g, " ");
 }
 
@@ -228,14 +226,14 @@ async function main() {
   // -------------------------------------------------------------------------
   // Step 3: Post to Slack
   // -------------------------------------------------------------------------
-  if (!NO_SLACK) {
+  if (NO_SLACK) {
+    console.log("Step 3: Skipping Slack post\n");
+  } else {
     console.log("Step 3: Posting summary to Slack...\n");
 
     const blocks = formatSlackBlocks(stats);
     await postToSlack("Weekly knowledge base report", blocks);
     console.log(`Posted to ${SLACK_CHANNEL}\n`);
-  } else {
-    console.log("Step 3: Skipping Slack post\n");
   }
 
   // -------------------------------------------------------------------------
@@ -247,7 +245,9 @@ async function main() {
   console.log("  2. Use Claude Code: /self-reflect");
 }
 
-main().catch(error => {
+try {
+  await main();
+} catch (error) {
   console.error("Fatal error:", error);
   process.exit(1);
-});
+}

--- a/scripts/quality/profile_coverage_normalization.py
+++ b/scripts/quality/profile_coverage_normalization.py
@@ -74,6 +74,42 @@ def infer_required_sources(raw_coverage: Mapping[str, Any] | None) -> List[str]:
     return dedupe_strings(inferred)
 
 
+def _add_optional_input_fields(item: Mapping[str, Any], dest: Dict[str, Any]) -> None:
+    """Copy optional ``flag``/``sources``/``min_percent`` from ``item``."""
+    if "flag" in item:
+        dest["flag"] = str(item["flag"]).strip()
+    if "sources" in item and isinstance(item["sources"], list):
+        dest["sources"] = [
+            str(s).strip() for s in item["sources"] if str(s).strip()
+        ]
+    if "min_percent" in item:
+        try:
+            dest["min_percent"] = float(item["min_percent"])
+        except (TypeError, ValueError):
+            # Drop the field on parse error so downstream consumers fall
+            # back to the schema default rather than a malformed value.
+            pass
+
+
+def _normalize_one_input(item: Any) -> Dict[str, Any] | None:
+    """Return one normalized coverage input, or ``None`` to drop the row."""
+    if not isinstance(item, dict):
+        return None
+    normalized: Dict[str, Any] = {
+        "format": str(item.get("format", "")).strip().lower(),
+        "name": str(item.get("name", "")).strip(),
+        "path": str(item.get("path", "")).strip(),
+    }
+    if (
+        normalized["format"] not in {"xml", "lcov"}
+        or not normalized["name"]
+        or not normalized["path"]
+    ):
+        return None
+    _add_optional_input_fields(item, normalized)
+    return normalized
+
+
 def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, Any]]:
     """Normalize raw coverage input mappings into the shared schema.
 
@@ -91,36 +127,11 @@ def normalize_coverage_inputs(raw_inputs: Any) -> List[Dict[str, Any]]:
     """
     if not isinstance(raw_inputs, list):
         return []
-
     normalized_items: List[Dict[str, Any]] = []
     for item in raw_inputs:
-        if not isinstance(item, dict):
-            continue
-        normalized_item: Dict[str, Any] = {
-            "format": str(item.get("format", "")).strip().lower(),
-            "name": str(item.get("name", "")).strip(),
-            "path": str(item.get("path", "")).strip(),
-        }
-        if (
-            normalized_item["format"] not in {"xml", "lcov"}
-            or not normalized_item["name"]
-            or not normalized_item["path"]
-        ):
-            continue
-        if "flag" in item:
-            normalized_item["flag"] = str(item["flag"]).strip()
-        if "sources" in item and isinstance(item["sources"], list):
-            normalized_item["sources"] = [
-                str(s).strip() for s in item["sources"] if str(s).strip()
-            ]
-        if "min_percent" in item:
-            try:
-                normalized_item["min_percent"] = float(item["min_percent"])
-            except (TypeError, ValueError):
-                # Drop the field on parse error so downstream consumers fall
-                # back to the schema default rather than a malformed value.
-                pass
-        normalized_items.append(normalized_item)
+        normalized = _normalize_one_input(item)
+        if normalized is not None:
+            normalized_items.append(normalized)
     return normalized_items
 
 

--- a/scripts/quality/rollup_v2/dedup.py
+++ b/scripts/quality/rollup_v2/dedup.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from dataclasses import replace
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, cast
 
 from scripts.quality.rollup_v2.severity import max_severity
 from scripts.quality.rollup_v2.schema.finding import (
@@ -39,12 +39,16 @@ def merge_corroborators(findings: List[Finding]) -> Finding:
     primary = _pick_primary_by_provider_priority(findings)
     severity = max_severity([f.severity for f in findings])
     all_corroborators = tuple(c for f in findings for c in f.corroborators)
-    return replace(
+    # ``dataclasses.replace`` is typed as returning ``DataclassInstance`` (a
+    # protocol covering any frozen dataclass), so Sonar python:S5886 flags
+    # the ``-> Finding`` return type as a downcast. The cast is a no-op at
+    # runtime since ``primary`` is concretely a Finding.
+    return cast(Finding, replace(
         primary,
         severity=severity,
         corroboration="multi" if len(findings) >= 2 else "single",
         corroborators=all_corroborators,
-    )
+    ))
 
 
 def _pick_primary_by_provider_priority(findings: List[Finding]) -> Finding:

--- a/scripts/quality/rollup_v2/normalizers/_base.py
+++ b/scripts/quality/rollup_v2/normalizers/_base.py
@@ -5,7 +5,7 @@ import traceback
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Tuple, final
+from typing import Any, Dict, Iterable, List, Tuple, cast, final
 
 from scripts.quality.rollup_v2.path_safety import (
     PathEscapedRootError,
@@ -154,9 +154,13 @@ class BaseNormalizer(ABC):
             )
             for c in finding.corroborators
         )
-        return replace(
+        # ``dataclasses.replace`` is typed as returning ``DataclassInstance``
+        # (a protocol covering any frozen dataclass), so Sonar python:S5886
+        # flags the ``-> Finding`` return type as a downcast. The cast is a
+        # no-op at runtime since ``finding`` is concretely a Finding.
+        return cast(Finding, replace(
             finding,
             primary_message=redact_secrets(finding.primary_message),
             context_snippet=redact_secrets(finding.context_snippet),
             corroborators=redacted_corroborators,
-        )
+        ))

--- a/scripts/quality/rollup_v2/renderer.py
+++ b/scripts/quality/rollup_v2/renderer.py
@@ -153,7 +153,7 @@ def _render_by_file_view(
             lines.append(_render_finding_body(f))
 
     if collapse_after is not None and len(grouped) > collapse_after:
-        lines.append("</details>\n")
+        lines.append(_DETAILS_CLOSE)
 
     return "\n".join(lines)
 
@@ -221,15 +221,15 @@ def _render_alternate_views(findings: Sequence[Finding]) -> str:
 
     sections.append("<details><summary>View by provider</summary>\n")
     sections.append(_render_by_provider_view(findings))
-    sections.append("</details>\n")
+    sections.append(_DETAILS_CLOSE)
 
     sections.append("<details><summary>View by severity</summary>\n")
     sections.append(_render_by_severity_view(findings))
-    sections.append("</details>\n")
+    sections.append(_DETAILS_CLOSE)
 
     sections.append("<details><summary>Autofixable only</summary>\n")
     sections.append(_render_autofixable_view(findings))
-    sections.append("</details>\n")
+    sections.append(_DETAILS_CLOSE)
 
     return "\n".join(sections)
 

--- a/scripts/quality/run_qlty_zero.py
+++ b/scripts/quality/run_qlty_zero.py
@@ -225,9 +225,12 @@ def _build_check_entry(
         has_findings = _smells_output_indicates_findings(output_tail)
     else:
         has_findings = False
-    if int(result.returncode) != 0 and name != "smells":
-        status = "fail"
-    elif name == "smells" and has_findings:
+    # Combine the two fail conditions into a single test so Sonar's
+    # python:S1871 doesn't flag the duplicate ``status = "fail"`` branches
+    # — both routes ultimately mean "this lane failed".
+    failed_check = int(result.returncode) != 0 and name != "smells"
+    failed_smells = name == "smells" and has_findings
+    if failed_check or failed_smells:
         status = "fail"
     return {
         "name": name,


### PR DESCRIPTION
## **User description**
## Summary

After PR #175 (105→28) and PR #176 (28→13), this PR drives the last 13 Sonar findings on QZP main to zero.

| Rule | Count | Fix |
|---|---|---|
| typescript:S6551 | 4 | Rewrite ``sanitizeForLog`` in ``beads-fetch-pr-comments`` and ``beads-self-reflect`` to use a template-literal coercion path with explicit ``as`` cast on the primitive types so Sonar's analyser can prove ``[object Object]`` is unreachable |
| typescript:S7785 | 3 | Switch ``main().catch(...)`` chains in all three ``scripts/beads-*.ts`` entry points to top-level ``await`` inside ``try``/``catch`` |
| typescript:S7735 | 1 | Invert the ``!NO_SLACK`` branch in ``beads-self-reflect``'s Step-3 dispatcher |
| python:S1192 | 1 | Replace remaining ``\"</details>\n\"`` inline literals in ``renderer.py`` with ``_DETAILS_CLOSE`` (constant was extracted in PR #176 but call sites still inlined due to a regex-mismatch in the migration) |
| python:S5886 | 2 | ``cast(Finding, replace(...))`` in ``dedup.merge_corroborators`` and ``BaseNormalizer._redact_finding`` so ``DataclassInstance`` narrows back to ``Finding`` |
| python:S1871 | 1 | Combine the two ``status = \"fail\"`` branches in ``run_qlty_zero._build_check_entry`` into a single ``if failed_check or failed_smells`` |
| python:S3776 | 1 | Split ``profile_coverage_normalization.normalize_coverage_inputs`` into ``_normalize_one_input`` + ``_add_optional_input_fields`` helpers to drop cognitive complexity 17 → ≤15 |

## Test plan
- [x] ``python -m pytest tests -q`` → 1476 passed, 1 skipped, 70 subtests
- [x] ``qlty check --all`` → No issues
- [x] ``qlty smells --all`` → 0 findings
- [ ] CI: shared-scanner-matrix / Sonar Zero (expected: 0 violations)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Drives the last 13 Sonar findings on QZP to zero. Cleans up TypeScript and Python code for clearer logging, safer entry points, and simpler quality tooling.

- **Refactors**
  - TypeScript: rewrote sanitizeForLog to JSON-stringify objects and use template‑literal coercion for primitives (S6551); replaced `main().catch(...)` with top‑level `await` in `try/catch` across `beads-*` scripts (S7785); inverted the `NO_SLACK` check in self‑reflect step 3 to drop a negated branch (S7735).
  - Python: used `_DETAILS_CLOSE` instead of inline `"</details>\n"` in the renderer (S1192); added `cast(Finding, replace(...))` where needed to narrow `DataclassInstance` (S5886); unified duplicate fail branches in `run_qlty_zero._build_check_entry` (S1871); split coverage input normalization into small helpers to reduce cognitive complexity (S3776).

<sup>Written for commit c15d2b85d4c58c0e3ad36faeeb7bd340bdecb51e. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reduce log noise and make report scripts exit more cleanly**

### What Changed
- Log values now keep object content readable while avoiding the plain `[object Object]` placeholder in PR comment and self-reflection scripts
- Script startup and shutdown now use a direct error-handling path, which keeps failures reporting consistently at the command line
- Coverage input cleanup now keeps valid rows while dropping invalid ones more reliably, and malformed `min_percent` values are ignored instead of being passed through
- Report output now reuses the same closing markup in all collapsible sections, and the Slack step still skips posting when Slack is disabled

### Impact
`✅ Clearer command-line error messages`
`✅ Fewer confusing log values`
`✅ More reliable report script exits`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=IOaGs2S9tUyzS6eixmmFIzZKhpXZasi103RXrSNCPqc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
