### PR TITLE
feat(qzp): upload provider_ui .mjs coverage to Sonar + Codecov (89.4→target 100% line)

### DIFF
--- a/profiles/repos/quality-zero-platform.yml
+++ b/profiles/repos/quality-zero-platform.yml
@@ -63,20 +63,23 @@ required_contexts:
 enabled_scanners:
   deepsource_visible: true
 coverage:
-  command: 'python3 -m pip install --upgrade pip
-
-    python3 -m pip install -r requirements-dev.txt coverage
-
-    coverage run --branch -m unittest discover -s tests -p ''test_*.py''
-
-    coverage xml -o coverage/platform-coverage.xml
-
-    '
+  command: "python3 -m pip install --upgrade pip\npython3 -m pip install -r requirements-dev.txt\
+    \ coverage\ncoverage run --branch -m unittest discover -s tests -p 'test_*.py'\n\
+    coverage xml -o coverage/platform-coverage.xml\nmkdir -p coverage\n# scripts/provider_ui/*.mjs\
+    \ has its own Node test suite; emit lcov for Sonar\n# (sonar.javascript.lcov.reportPaths)\
+    \ + Codecov 'provider_ui' flag so the\n# 4 .mjs files stop sitting at 0% coverage\
+    \ in the dashboards.\nnode --test --experimental-test-coverage \\\n  --test-reporter=lcov\
+    \ \\\n  --test-reporter-destination=coverage/provider_ui-lcov.info \\\n  scripts/provider_ui/*.test.mjs\
+    \ || true\n"
   inputs:
   - format: xml
     name: platform
     path: coverage/platform-coverage.xml
     flag: platform
+  - format: lcov
+    name: provider_ui
+    path: coverage/provider_ui-lcov.info
+    flag: provider_ui
   require_sources:
   - scripts/
 vendors:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,12 @@ sonar.python.version=3.12
 # coverage.command; scripts/verify writes to coverage.xml. Both paths are
 # accepted so SonarCloud's new-code coverage gate reads whichever is present.
 sonar.python.coverage.reportPaths=coverage/platform-coverage.xml,coverage.xml
+# scripts/provider_ui/*.mjs is tested via the Node test runner, which emits
+# lcov via ``node --test --experimental-test-coverage --test-reporter=lcov``.
+# Without this declaration the .mjs files sit at 0% in the line-coverage
+# metric (sonar.sources=scripts indexes them, but no coverage data is
+# associated). The QZP self-profile coverage.command produces this file.
+sonar.javascript.lcov.reportPaths=coverage/provider_ui-lcov.info
 sonar.exclusions=generated/**,docs/admin/**
 
 # `tool.coverage.run.source` in pyproject.toml restricts coverage tracing to


### PR DESCRIPTION
## **User description**
## Summary

QZP main shows ``line_coverage = 89.4%`` even though pytest reports 100% on the curated source list (``rollup_v2`` / ``fleet_inventory`` / ``migrate_profiles_to_v2``). The 248 uncovered lines are all in ``scripts/provider_ui/*.mjs``:

\`\`\`
uncov=  96 scripts/provider_ui/provider_admin_config.mjs
uncov=  95 scripts/provider_ui/provider_admin_bootstrap.mjs
uncov=  37 scripts/provider_ui/provider_admin_config.test.mjs
uncov=  20 scripts/provider_ui/provider_admin_bootstrap.test.mjs
\`\`\`

These have their own Node test suite (``provider_admin_*.test.mjs``) but coverage was never uploaded anywhere. Sonar indexes the .mjs files via ``sonar.sources=scripts`` and reports 0% on them because no lcov was associated.

## Fix

- ``profiles/repos/quality-zero-platform.yml`` — extend ``coverage.command`` to run ``node --test --experimental-test-coverage --test-reporter=lcov`` on ``scripts/provider_ui/*.test.mjs`` and emit ``coverage/provider_ui-lcov.info``. ``|| true`` keeps a Node-side failure from blocking the main Python coverage path.
- New ``coverage.inputs[]`` row declares the lcov file with ``flag=provider_ui`` so the platform's per-flag Codecov upload picks it up.
- ``sonar-project.properties`` adds ``sonar.javascript.lcov.reportPaths=coverage/provider_ui-lcov.info`` so SonarCloud reads it.

## Verification

- [x] Local ``node --test --experimental-test-coverage --test-reporter=lcov`` produces well-formed lcov (verified ``FN/FNDA/DA`` records, ``end_of_record`` markers).
- [x] ``python -m pytest tests -q`` → 1476 passed
- [x] ``qlty smells --all`` → 0 findings
- [ ] CI: shared-codecov-analytics / Codecov Analytics uploads 2 flags (platform + provider_ui)
- [ ] CI: shared-scanner-matrix / Sonar Zero (no new findings expected)
- [ ] Sonar reanalysis: ``line_coverage`` lifts above 89.4% as the .mjs lcov lands

The .mjs tests currently cover ``provider_admin_config.mjs`` ≈85% and ``provider_admin_bootstrap.mjs`` ≈43%; this PR alone won't reach 100% — it lands the *plumbing* so missing-test backfill becomes the next concrete step instead of a coverage scope mystery.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add coverage upload for `scripts/provider_ui/*.mjs` so SonarCloud and Codecov include the Node-tested files. This removes the 0% gap on `.mjs` and lifts project line coverage above 89.4% toward 100%.

- **New Features**
  - Extend `profiles/repos/quality-zero-platform.yml` to run `node --test --experimental-test-coverage --test-reporter=lcov` for `scripts/provider_ui/*.test.mjs` and emit `coverage/provider_ui-lcov.info` (`|| true` to avoid blocking Python coverage).
  - Add `coverage.inputs` entry with `format=lcov`, `name=provider_ui`, `flag=provider_ui` for Codecov.
  - Set `sonar.javascript.lcov.reportPaths=coverage/provider_ui-lcov.info` in `sonar-project.properties` so SonarCloud reads the `.mjs` coverage.

<sup>Written for commit 33ad6a4dcd5f9bdc9ba287edb4e0a1a2d3af949a. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Add coverage reporting for the provider UI Node tests so the .mjs files count in dashboards and Sonar

### What Changed
- The provider UI Node test suite now exports coverage data alongside the existing Python coverage report
- Sonar is now pointed at that coverage file, so the four `scripts/provider_ui/*.mjs` files are no longer shown as untested
- Codecov now receives the provider UI coverage as its own flag

### Impact
`✅ Fewer false zero-coverage files in Sonar`
`✅ More complete coverage reporting for provider UI tests`
`✅ Clearer coverage dashboards for the QZP profile`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=HF_QZPvWsZ1qJPMEmaVb89CvFjnikgrOJbdVFAk7SXw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
