### PR TITLE
test(provider_ui): drive .mjs coverage 43%/86% → 100% line (closes the 89.4% gap)

### DIFF
--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -35,18 +35,19 @@ export function ensureManagedStatePath(targetPath, stateRoot) {
  * Load Playwright from the managed external runner directory.
  * @returns {Promise<import('playwright').BrowserType>}
  */
-async function loadPlaywrightChromium() {
-  const runnerDir = process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR;
-  if (!runnerDir) {
+export async function loadPlaywrightChromium(deps = {}) {
+  const runnerDirEnv = deps.runnerDir ?? process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR;
+  if (!runnerDirEnv) {
     throw new Error(
       'QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR is required so the bootstrap can ' +
       'load Playwright from the external runner directory.'
     );
   }
-
-  const runnerRequire = createRequire(path.join(runnerDir, 'package.json'));
+  const _createRequire = deps.createRequire ?? createRequire;
+  const _importModule = deps.importModule ?? ((href) => import(href));
+  const runnerRequire = _createRequire(path.join(runnerDirEnv, 'package.json'));
   const playwrightEntry = runnerRequire.resolve('playwright');
-  const playwrightModule = await import(pathToFileURL(playwrightEntry).href);
+  const playwrightModule = await _importModule(pathToFileURL(playwrightEntry).href);
   return resolvePlaywrightChromium(playwrightModule);
 }
 
@@ -84,13 +85,20 @@ export function isCliEntrypoint(importMetaUrl, argv = process.argv) {
  * @param {string} profileDir
  * @returns {Promise<void>}
  */
-async function promptForManualLogin(target, profileDir) {
-  const rl = readline.createInterface({ input, output });
+export async function promptForManualLogin(target, profileDir, deps = {}) {
+  const readlineModule = deps.readline ?? readline;
+  const inputStream = deps.input ?? input;
+  const outputStream = deps.output ?? output;
+  return _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream);
+}
+
+async function _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream) {
+  const rl = readlineModule.createInterface({ input: inputStream, output: outputStream });
   try {
-    output.write(`\nManual login handoff for ${target.label}\n`);
-    output.write(`Target URL: ${target.targetUrl}\n`);
-    output.write(`Persistent profile: ${profileDir}\n`);
-    output.write(`${target.loginHint}\n`);
+    outputStream.write(`\nManual login handoff for ${target.label}\n`);
+    outputStream.write(`Target URL: ${target.targetUrl}\n`);
+    outputStream.write(`Persistent profile: ${profileDir}\n`);
+    outputStream.write(`${target.loginHint}\n`);
     await rl.question(
       'Complete sign-in or provider checks in the opened browser, then ' +
       'press Enter to continue... '
@@ -107,14 +115,14 @@ async function promptForManualLogin(target, profileDir) {
  * @param {import('playwright').LaunchPersistentContextOptions} options
  * @returns {Promise<import('playwright').BrowserContext>}
  */
-async function launchContextWithFallback(chromium, profileDir, options) {
+export async function launchContextWithFallback(chromium, profileDir, options, platform = process.platform) {
   try {
     return await chromium.launchPersistentContext(profileDir, {
-      channel: process.platform === 'win32' ? 'msedge' : undefined,
+      channel: platform === 'win32' ? 'msedge' : undefined,
       ...options
     });
   } catch (error) {
-    if (process.platform !== 'win32') {
+    if (platform !== 'win32') {
       throw error;
     }
 
@@ -135,7 +143,10 @@ async function launchContextWithFallback(chromium, profileDir, options) {
  *   headless: boolean
  * }>}
  */
-async function launchPersistentContext(args, { headlessDefault, includeManualPrompt }) {
+export async function launchPersistentContext(args, { headlessDefault, includeManualPrompt }, deps = {}) {
+  const loadChromium = deps.loadPlaywrightChromium ?? loadPlaywrightChromium;
+  const launchCtx = deps.launchContextWithFallback ?? launchContextWithFallback;
+  const promptLogin = deps.promptForManualLogin ?? promptForManualLogin;
   const target = resolveProviderTarget(args.provider, {
     repo: args.repo,
     owner: args.owner
@@ -143,8 +154,8 @@ async function launchPersistentContext(args, { headlessDefault, includeManualPro
   const profileDir = ensureManagedStatePath(args.profileDir, args.stateRoot);
 
   const headless = args.headless ?? headlessDefault;
-  const chromium = await loadPlaywrightChromium();
-  const context = await launchContextWithFallback(chromium, profileDir, {
+  const chromium = await loadChromium();
+  const context = await launchCtx(chromium, profileDir, {
     headless,
     slowMo: args.slowMoMs,
     viewport: { width: 1440, height: 960 }
@@ -158,7 +169,7 @@ async function launchPersistentContext(args, { headlessDefault, includeManualPro
   });
 
   if (includeManualPrompt) {
-    await promptForManualLogin(target, profileDir);
+    await promptLogin(target, profileDir);
   }
 
   const title = await page.title();
@@ -178,7 +189,7 @@ async function launchPersistentContext(args, { headlessDefault, includeManualPro
  * }} result
  * @returns {void}
  */
-function printResult(prefix, result) {
+export function printResult(prefix, result, log = console.log) {
   const metadata = {
     provider: result.target.key,
     label: result.target.label,
@@ -190,7 +201,7 @@ function printResult(prefix, result) {
   };
 
   // skipcq: JS-0002 - this Node CLI intentionally emits structured JSON for automation.
-  console.log(`${prefix}: ${JSON.stringify(metadata, null, 2)}`);
+  log(`${prefix}: ${JSON.stringify(metadata, null, 2)}`);
 }
 
 /**
@@ -198,7 +209,7 @@ function printResult(prefix, result) {
  * @param {{stateRoot: string, profileDir: string}} args
  * @returns {void}
  */
-function listProviders(args) {
+export function listProviders(args, log = console.log) {
   const rows = PROVIDER_KEYS.map((key) => {
     const target = resolveProviderTarget(key, {});
     return {
@@ -210,7 +221,7 @@ function listProviders(args) {
   });
 
   // skipcq: JS-0002 - this Node CLI intentionally emits structured JSON for automation.
-  console.log(
+  log(
     JSON.stringify(
       {
         providers: rows,
@@ -229,21 +240,21 @@ function listProviders(args) {
  * @param {import('playwright').BrowserContext} context
  * @returns {Promise<void>}
  */
-function waitForKeepOpenExit(context) {
+export function waitForKeepOpenExit(context, processObj = process) {
   return new Promise((resolve) => {
     /**
      * Detach signal handlers and resolve the keep-open wait.
      * @returns {void}
      */
     function finish() {
-      process.off('SIGINT', finish);
-      process.off('SIGTERM', finish);
+      processObj.off('SIGINT', finish);
+      processObj.off('SIGTERM', finish);
       context.off('close', finish);
       resolve();
     }
 
-    process.once('SIGINT', finish);
-    process.once('SIGTERM', finish);
+    processObj.once('SIGINT', finish);
+    processObj.once('SIGTERM', finish);
     context.once('close', finish);
   });
 }
@@ -253,15 +264,18 @@ function waitForKeepOpenExit(context) {
  * @param {ReturnType<typeof parseArgs>} args
  * @returns {Promise<void>}
  */
-async function bootstrap(args) {
-  const result = await launchPersistentContext(args, {
+export async function bootstrap(args, deps = {}) {
+  const launchCtx = deps.launchPersistentContext ?? launchPersistentContext;
+  const printRes = deps.printResult ?? printResult;
+  const waitExit = deps.waitForKeepOpenExit ?? waitForKeepOpenExit;
+  const result = await launchCtx(args, {
     headlessDefault: false,
     includeManualPrompt: true
   });
   try {
-    printResult('bootstrap_complete', result);
+    printRes('bootstrap_complete', result);
     if (args.keepOpen) {
-      await waitForKeepOpenExit(result.context);
+      await waitExit(result.context);
     }
   } finally {
     if (!args.keepOpen) {
@@ -276,15 +290,18 @@ async function bootstrap(args) {
  * @param {{inspectOnly: boolean}} options
  * @returns {Promise<void>}
  */
-async function openOrInspect(args, { inspectOnly }) {
-  const result = await launchPersistentContext(args, {
+export async function openOrInspect(args, { inspectOnly }, deps = {}) {
+  const launchCtx = deps.launchPersistentContext ?? launchPersistentContext;
+  const printRes = deps.printResult ?? printResult;
+  const waitExit = deps.waitForKeepOpenExit ?? waitForKeepOpenExit;
+  const result = await launchCtx(args, {
     headlessDefault: true,
     includeManualPrompt: false
   });
   try {
-    printResult(inspectOnly ? 'inspect_complete' : 'open_complete', result);
+    printRes(inspectOnly ? 'inspect_complete' : 'open_complete', result);
     if (args.keepOpen) {
-      await waitForKeepOpenExit(result.context);
+      await waitExit(result.context);
     }
   } finally {
     if (!args.keepOpen) {
@@ -335,9 +352,11 @@ export async function runCommand(args, hooks = {}) {
  * Parse CLI arguments and run the requested provider command.
  * @returns {Promise<void>}
  */
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
-  await runCommand(args);
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const parse = deps.parseArgs ?? parseArgs;
+  const run = deps.runCommand ?? runCommand;
+  const args = parse(argv);
+  await run(args);
 }
 
 /**
@@ -345,16 +364,34 @@ async function main() {
  * @param {unknown} error
  * @returns {void}
  */
-function reportCliError(error) {
+export function reportCliError(error, errLog = console.error, processObj = process) {
   // skipcq: JS-0002 - this Node CLI writes failures to stderr for callers and CI logs.
-  console.error(error instanceof Error ? error.stack ?? error.message : error);
-  process.exitCode = 1;
+  errLog(error instanceof Error ? error.stack ?? error.message : error);
+  processObj.exitCode = 1;
 }
 
-if (isCliEntrypoint(import.meta.url)) {
-  try {
-    await main();
-  } catch (error) {
-    reportCliError(error);
+/**
+ * Entry-point guard extracted so tests can drive both branches without
+ * spawning a child process. ``runCliIfEntrypoint`` is no-op when the
+ * module is imported by tests; runs ``main()`` and forwards any throw
+ * through ``reportCliError`` when invoked as the CLI script.
+ * @param {string} importMetaUrl - the calling module's ``import.meta.url``.
+ * @param {object} [deps]
+ * @returns {Promise<boolean>} ``true`` if the CLI ran, ``false`` otherwise.
+ */
+export async function runCliIfEntrypoint(importMetaUrl, deps = {}) {
+  const isEntrypoint = deps.isCliEntrypoint ?? isCliEntrypoint;
+  const runMain = deps.main ?? main;
+  const reportErr = deps.reportCliError ?? reportCliError;
+  if (!isEntrypoint(importMetaUrl)) {
+    return false;
   }
+  try {
+    await runMain();
+  } catch (error) {
+    reportErr(error);
+  }
+  return true;
 }
+
+await runCliIfEntrypoint(import.meta.url);

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -1,62 +1,634 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { runCommand } from './provider_admin_bootstrap.mjs';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  bootstrap,
+  ensureManagedStatePath,
+  isCliEntrypoint,
+  launchContextWithFallback,
+  launchPersistentContext,
+  listProviders,
+  loadPlaywrightChromium,
+  main,
+  openOrInspect,
+  printResult,
+  promptForManualLogin,
+  reportCliError,
+  resolvePlaywrightChromium,
+  runCliIfEntrypoint,
+  runCommand,
+  waitForKeepOpenExit
+} from './provider_admin_bootstrap.mjs';
 
-test('runCommand dispatches bootstrap requests through provider normalization', async () => {
+// =============================================================================
+// ensureManagedStatePath
+// =============================================================================
+
+test('ensureManagedStatePath returns absolute path under the state root', () => {
+  const root = path.resolve('/tmp/state');
+  const target = path.join(root, 'profile');
+  const got = ensureManagedStatePath(target, root);
+  assert.equal(got, path.resolve(target));
+});
+
+test('ensureManagedStatePath rejects sibling escape', () => {
+  const root = path.resolve('/tmp/state');
+  assert.throws(() => ensureManagedStatePath('/tmp/elsewhere', root), /managed state root/);
+});
+
+test('ensureManagedStatePath rejects parent traversal', () => {
+  const root = path.resolve('/tmp/state');
+  assert.throws(
+    () => ensureManagedStatePath(path.join(root, '..', 'evil'), root),
+    /managed state root/
+  );
+});
+
+// =============================================================================
+// resolvePlaywrightChromium
+// =============================================================================
+
+test('resolvePlaywrightChromium picks up the named export first', () => {
+  const stub = { chromium: { tag: 'top-level' } };
+  assert.equal(resolvePlaywrightChromium(stub), stub.chromium);
+});
+
+test('resolvePlaywrightChromium falls back to default export', () => {
+  const stub = { default: { chromium: { tag: 'default' } } };
+  assert.equal(resolvePlaywrightChromium(stub), stub.default.chromium);
+});
+
+test('resolvePlaywrightChromium throws when no chromium export is present', () => {
+  assert.throws(() => resolvePlaywrightChromium({}), /does not expose chromium/);
+});
+
+test('resolvePlaywrightChromium throws on null module', () => {
+  assert.throws(() => resolvePlaywrightChromium(null), /does not expose chromium/);
+});
+
+// =============================================================================
+// loadPlaywrightChromium
+// =============================================================================
+
+test('loadPlaywrightChromium throws when QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR is unset', async () => {
+  const original = process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR;
+  delete process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR;
+  try {
+    await assert.rejects(loadPlaywrightChromium(), /QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR/);
+  } finally {
+    if (original !== undefined) {
+      process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR = original;
+    }
+  }
+});
+
+// =============================================================================
+// isCliEntrypoint
+// =============================================================================
+
+test('isCliEntrypoint matches when argv[1] resolves to the import URL', () => {
+  const target = path.resolve('/tmp/some-script.mjs');
+  const url = pathToFileURL(target).href;
+  assert.equal(isCliEntrypoint(url, ['node', target]), true);
+});
+
+test('isCliEntrypoint rejects when argv[1] is a different file', () => {
+  const target = path.resolve('/tmp/script.mjs');
+  const otherUrl = pathToFileURL(path.resolve('/tmp/other.mjs')).href;
+  assert.equal(isCliEntrypoint(otherUrl, ['node', target]), false);
+});
+
+test('isCliEntrypoint returns false when argv[1] is missing', () => {
+  const url = pathToFileURL(path.resolve('/tmp/script.mjs')).href;
+  assert.equal(isCliEntrypoint(url, ['node']), false);
+});
+
+// =============================================================================
+// promptForManualLogin
+// =============================================================================
+
+test('promptForManualLogin writes guidance and waits for Enter', async () => {
+  const writes = [];
+  const outputStream = { write: (line) => writes.push(line) };
+  const inputStream = {};
+  let questionAsked = '';
+  let closed = false;
+  const readlineModule = {
+    createInterface: () => ({
+      question: async (prompt) => { questionAsked = prompt; return ''; },
+      close: () => { closed = true; }
+    })
+  };
+
+  await promptForManualLogin(
+    { label: 'Codecov', targetUrl: 'https://example.com', loginHint: 'Press something.' },
+    '/tmp/profile',
+    { readline: readlineModule, input: inputStream, output: outputStream }
+  );
+
+  assert.equal(closed, true);
+  assert.match(writes.join(''), /Manual login handoff for Codecov/);
+  assert.match(writes.join(''), /https:\/\/example\.com/);
+  assert.match(writes.join(''), /\/tmp\/profile/);
+  assert.match(writes.join(''), /Press something/);
+  assert.match(questionAsked, /press Enter to continue/);
+});
+
+// =============================================================================
+// launchContextWithFallback
+// =============================================================================
+
+test('launchContextWithFallback uses msedge channel on win32', async () => {
+  const calls = [];
+  const chromium = {
+    launchPersistentContext: async (dir, options) => {
+      calls.push({ dir, options });
+      return { ctx: 'edge' };
+    }
+  };
+  const ctx = await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'win32');
+  assert.deepEqual(ctx, { ctx: 'edge' });
+  assert.equal(calls[0].options.channel, 'msedge');
+  assert.equal(calls[0].options.headless, true);
+});
+
+test('launchContextWithFallback skips channel on non-win32', async () => {
+  const calls = [];
+  const chromium = {
+    launchPersistentContext: async (dir, options) => {
+      calls.push({ dir, options });
+      return { ctx: 'chromium' };
+    }
+  };
+  await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'linux');
+  assert.equal(calls[0].options.channel, undefined);
+});
+
+test('launchContextWithFallback retries without channel on win32 launch failure', async () => {
+  const calls = [];
+  const chromium = {
+    launchPersistentContext: async (dir, options) => {
+      calls.push({ options });
+      if (options.channel === 'msedge') {
+        throw new Error('edge missing');
+      }
+      return { ctx: 'fallback-chromium' };
+    }
+  };
+  const ctx = await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'win32');
+  assert.deepEqual(ctx, { ctx: 'fallback-chromium' });
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].options.channel, 'msedge');
+  assert.equal(calls[1].options.channel, undefined);
+});
+
+test('launchContextWithFallback re-throws on non-win32 launch failure', async () => {
+  const chromium = {
+    launchPersistentContext: async () => { throw new Error('boom'); }
+  };
+  await assert.rejects(
+    launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'linux'),
+    /boom/
+  );
+});
+
+// =============================================================================
+// launchPersistentContext
+// =============================================================================
+
+function _stubArgs() {
+  return {
+    provider: 'chromatic',
+    repo: 'org/repo',
+    owner: 'org',
+    profileDir: path.resolve('/tmp/state/profile'),
+    stateRoot: path.resolve('/tmp/state'),
+    headless: undefined,
+    slowMoMs: 0,
+    timeoutMs: 1000
+  };
+}
+
+function _stubBrowserContext() {
+  const page = {
+    setDefaultTimeout: () => {},
+    goto: async () => {},
+    title: async () => 'Test Title',
+    url: () => 'https://final.example.com'
+  };
+  return {
+    pages: () => [page],
+    newPage: async () => page,
+    on: () => {},
+    once: () => {},
+    off: () => {},
+    close: async () => {}
+  };
+}
+
+test('launchPersistentContext walks the launch path and skips manual prompt when configured', async () => {
+  const calls = [];
+  const ctx = _stubBrowserContext();
+  const result = await launchPersistentContext(
+    _stubArgs(),
+    { headlessDefault: true, includeManualPrompt: false },
+    {
+      loadPlaywrightChromium: async () => ({ tag: 'chromium' }),
+      launchContextWithFallback: async (chromium, dir, opts) => {
+        calls.push({ dir, headless: opts.headless });
+        return ctx;
+      },
+      promptForManualLogin: async () => { calls.push('prompt'); }
+    }
+  );
+  assert.equal(result.headless, true);
+  assert.equal(result.title, 'Test Title');
+  assert.equal(result.finalUrl, 'https://final.example.com');
+  assert.deepEqual(calls.map((c) => c.dir ?? c), [path.resolve('/tmp/state/profile')]);
+});
+
+test('launchPersistentContext invokes manual prompt when requested', async () => {
+  const ctx = _stubBrowserContext();
+  let prompted = false;
+  await launchPersistentContext(
+    _stubArgs(),
+    { headlessDefault: false, includeManualPrompt: true },
+    {
+      loadPlaywrightChromium: async () => ({}),
+      launchContextWithFallback: async () => ctx,
+      promptForManualLogin: async () => { prompted = true; }
+    }
+  );
+  assert.equal(prompted, true);
+});
+
+test('launchPersistentContext creates a new page when context.pages() is empty', async () => {
+  const page = {
+    setDefaultTimeout: () => {},
+    goto: async () => {},
+    title: async () => 'New Page',
+    url: () => 'https://new.example.com'
+  };
+  const ctx = {
+    pages: () => [],
+    newPage: async () => page,
+    on: () => {}, once: () => {}, off: () => {}, close: async () => {}
+  };
+  const result = await launchPersistentContext(
+    _stubArgs(),
+    { headlessDefault: false, includeManualPrompt: false },
+    {
+      loadPlaywrightChromium: async () => ({}),
+      launchContextWithFallback: async () => ctx,
+      promptForManualLogin: async () => {}
+    }
+  );
+  assert.equal(result.title, 'New Page');
+});
+
+// =============================================================================
+// printResult / listProviders
+// =============================================================================
+
+test('printResult emits prefixed JSON via injected logger', () => {
+  const logged = [];
+  printResult(
+    'bootstrap_complete',
+    {
+      target: { key: 'codecov', label: 'Codecov', repoSlug: 'org/repo', targetUrl: 'https://x' },
+      finalUrl: 'https://final',
+      title: 'Title',
+      headless: true
+    },
+    (msg) => logged.push(msg)
+  );
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /^bootstrap_complete: \{/);
+  assert.match(logged[0], /"provider": "codecov"/);
+});
+
+test('listProviders enumerates known providers via injected logger', () => {
+  const logged = [];
+  listProviders(
+    { stateRoot: '/state', profileDir: '/state/profile' },
+    (msg) => logged.push(msg)
+  );
+  assert.equal(logged.length, 1);
+  const payload = JSON.parse(logged[0]);
+  assert.ok(Array.isArray(payload.providers));
+  assert.ok(payload.providers.length >= 1);
+  assert.equal(payload.defaultStateRoot, '/state');
+});
+
+// =============================================================================
+// waitForKeepOpenExit
+// =============================================================================
+
+test('waitForKeepOpenExit resolves when context closes', async () => {
+  const ctx = new EventEmitter();
+  ctx.off = ctx.removeListener.bind(ctx);
+  const processObj = new EventEmitter();
+  processObj.off = processObj.removeListener.bind(processObj);
+  const done = waitForKeepOpenExit(ctx, processObj);
+  ctx.emit('close');
+  await done;
+});
+
+test('waitForKeepOpenExit resolves on SIGINT', async () => {
+  const ctx = new EventEmitter();
+  ctx.off = ctx.removeListener.bind(ctx);
+  const processObj = new EventEmitter();
+  processObj.off = processObj.removeListener.bind(processObj);
+  const done = waitForKeepOpenExit(ctx, processObj);
+  processObj.emit('SIGINT');
+  await done;
+});
+
+test('waitForKeepOpenExit resolves on SIGTERM', async () => {
+  const ctx = new EventEmitter();
+  ctx.off = ctx.removeListener.bind(ctx);
+  const processObj = new EventEmitter();
+  processObj.off = processObj.removeListener.bind(processObj);
+  const done = waitForKeepOpenExit(ctx, processObj);
+  processObj.emit('SIGTERM');
+  await done;
+});
+
+// =============================================================================
+// bootstrap / openOrInspect
+// =============================================================================
+
+function _bootstrapStubResult(close = async () => {}) {
+  return {
+    target: { key: 'codecov', label: 'Codecov', repoSlug: 'org/repo', targetUrl: 'https://x' },
+    finalUrl: 'https://final',
+    title: 'Title',
+    headless: false,
+    context: { close }
+  };
+}
+
+test('bootstrap closes the context when keepOpen is false', async () => {
+  let closed = 0;
+  await bootstrap(
+    { keepOpen: false },
+    {
+      launchPersistentContext: async () => _bootstrapStubResult(async () => { closed += 1; }),
+      printResult: () => {},
+      waitForKeepOpenExit: async () => {}
+    }
+  );
+  assert.equal(closed, 1);
+});
+
+test('bootstrap waits for keep-open exit when requested', async () => {
+  let waited = false;
+  let closed = 0;
+  await bootstrap(
+    { keepOpen: true },
+    {
+      launchPersistentContext: async () => _bootstrapStubResult(async () => { closed += 1; }),
+      printResult: () => {},
+      waitForKeepOpenExit: async () => { waited = true; }
+    }
+  );
+  assert.equal(waited, true);
+  assert.equal(closed, 0);
+});
+
+test('openOrInspect uses inspect_complete prefix in inspect mode', async () => {
+  const prefixes = [];
+  await openOrInspect(
+    { keepOpen: false },
+    { inspectOnly: true },
+    {
+      launchPersistentContext: async () => _bootstrapStubResult(),
+      printResult: (prefix) => prefixes.push(prefix),
+      waitForKeepOpenExit: async () => {}
+    }
+  );
+  assert.deepEqual(prefixes, ['inspect_complete']);
+});
+
+test('openOrInspect uses open_complete prefix when not inspect-only', async () => {
+  const prefixes = [];
+  await openOrInspect(
+    { keepOpen: false },
+    { inspectOnly: false },
+    {
+      launchPersistentContext: async () => _bootstrapStubResult(),
+      printResult: (prefix) => prefixes.push(prefix),
+      waitForKeepOpenExit: async () => {}
+    }
+  );
+  assert.deepEqual(prefixes, ['open_complete']);
+});
+
+test('openOrInspect waits for keep-open exit when requested', async () => {
+  let waited = false;
+  await openOrInspect(
+    { keepOpen: true },
+    { inspectOnly: false },
+    {
+      launchPersistentContext: async () => _bootstrapStubResult(),
+      printResult: () => {},
+      waitForKeepOpenExit: async () => { waited = true; }
+    }
+  );
+  assert.equal(waited, true);
+});
+
+// =============================================================================
+// runCommand exhaustive cases
+// =============================================================================
+
+test('runCommand dispatches list to listProviders hook', async () => {
   const calls = [];
   await runCommand(
-    { command: 'bootstrap', provider: 'Chromatic' },
+    { command: 'list' },
     {
-      normalizeProvider(provider) {
-        calls.push(['normalize', provider]);
-        return 'chromatic';
-      },
-      bootstrap(args) {
-        calls.push(['bootstrap', args.provider]);
-      },
-      listProviders() {
-        calls.push(['list']);
-      },
-      openOrInspect() {
-        calls.push(['openOrInspect']);
-      },
-      log: () => {
-        calls.push(['log']);
-      },
+      listProviders: (args) => { calls.push(['list', args]); },
+      normalizeProvider: () => {},
+      bootstrap: () => {},
+      openOrInspect: () => {},
+      log: () => {},
       renderHelp: () => 'help'
     }
   );
-
-  assert.deepEqual(calls, [
-    ['normalize', 'Chromatic'],
-    ['bootstrap', 'Chromatic']
-  ]);
+  assert.deepEqual(calls.map((c) => c[0]), ['list']);
 });
 
-test('runCommand prints help for default commands without provider normalization', async () => {
+test('runCommand dispatches open to openOrInspect with inspectOnly=false', async () => {
   const calls = [];
   await runCommand(
-    { command: 'help' },
+    { command: 'open', provider: 'Sonar' },
     {
-      normalizeProvider: (provider) => {
-        calls.push(['normalize', provider]);
-        return provider;
-      },
-      bootstrap() {
-        calls.push(['bootstrap']);
-      },
-      listProviders() {
-        calls.push(['list']);
-      },
-      openOrInspect() {
-        calls.push(['openOrInspect']);
-      },
-      log: (message) => {
-        calls.push(['log', message]);
-      },
-      renderHelp: () => 'provider help'
+      listProviders: () => {},
+      normalizeProvider: (p) => { calls.push(['normalize', p]); return p.toLowerCase(); },
+      bootstrap: () => { calls.push(['bootstrap']); },
+      openOrInspect: (_args, opts) => { calls.push(['open', opts.inspectOnly]); },
+      log: () => {},
+      renderHelp: () => 'help'
     }
   );
+  assert.deepEqual(calls, [['normalize', 'Sonar'], ['open', false]]);
+});
 
-  assert.deepEqual(calls, [['log', 'provider help']]);
+test('runCommand dispatches inspect to openOrInspect with inspectOnly=true', async () => {
+  const calls = [];
+  await runCommand(
+    { command: 'inspect', provider: 'Codacy' },
+    {
+      listProviders: () => {},
+      normalizeProvider: (p) => p.toLowerCase(),
+      bootstrap: () => {},
+      openOrInspect: (_args, opts) => { calls.push(['inspect', opts.inspectOnly]); },
+      log: () => {},
+      renderHelp: () => 'help'
+    }
+  );
+  assert.deepEqual(calls, [['inspect', true]]);
+});
+
+test('runCommand prints help for unrecognised commands', async () => {
+  const messages = [];
+  await runCommand(
+    { command: 'unknown-command-name' },
+    {
+      listProviders: () => {},
+      normalizeProvider: () => {},
+      bootstrap: () => {},
+      openOrInspect: () => {},
+      log: (m) => messages.push(m),
+      renderHelp: () => 'help text'
+    }
+  );
+  assert.deepEqual(messages, ['help text']);
+});
+
+// =============================================================================
+// main / reportCliError
+// =============================================================================
+
+test('main parses argv and forwards to runCommand', async () => {
+  const calls = [];
+  await main(
+    ['list'],
+    {
+      parseArgs: (argv) => { calls.push(['parse', argv]); return { command: 'list' }; },
+      runCommand: async (args) => { calls.push(['run', args]); }
+    }
+  );
+  assert.deepEqual(calls, [['parse', ['list']], ['run', { command: 'list' }]]);
+});
+
+test('reportCliError prints stack for Error and sets exitCode=1', () => {
+  const messages = [];
+  const fakeProcess = {};
+  reportCliError(new Error('boom'), (m) => messages.push(m), fakeProcess);
+  assert.equal(fakeProcess.exitCode, 1);
+  assert.match(messages[0], /Error: boom/);
+});
+
+test('reportCliError prints raw value for non-Error inputs', () => {
+  const messages = [];
+  const fakeProcess = {};
+  reportCliError({ kind: 'opaque' }, (m) => messages.push(m), fakeProcess);
+  assert.deepEqual(messages, [{ kind: 'opaque' }]);
+});
+
+test('reportCliError falls back to stack=undefined Error string', () => {
+  const messages = [];
+  const fakeProcess = {};
+  const err = new Error('without stack');
+  // Force stack to undefined so the ?? fallback to message is exercised.
+  Object.defineProperty(err, 'stack', { value: undefined });
+  reportCliError(err, (m) => messages.push(m), fakeProcess);
+  assert.deepEqual(messages, ['without stack']);
+});
+
+// =============================================================================
+// runCliIfEntrypoint
+// =============================================================================
+
+test('runCliIfEntrypoint short-circuits when not the CLI entrypoint', async () => {
+  let mainCalled = false;
+  const ran = await runCliIfEntrypoint('file:///not-the-script.mjs', {
+    isCliEntrypoint: () => false,
+    main: async () => { mainCalled = true; },
+    reportCliError: () => {}
+  });
+  assert.equal(ran, false);
+  assert.equal(mainCalled, false);
+});
+
+test('runCliIfEntrypoint runs main when called as CLI', async () => {
+  let mainCalled = false;
+  const ran = await runCliIfEntrypoint('file:///cli.mjs', {
+    isCliEntrypoint: () => true,
+    main: async () => { mainCalled = true; },
+    reportCliError: () => {}
+  });
+  assert.equal(ran, true);
+  assert.equal(mainCalled, true);
+});
+
+test('runCliIfEntrypoint forwards errors to reportCliError', async () => {
+  const errors = [];
+  const ran = await runCliIfEntrypoint('file:///cli.mjs', {
+    isCliEntrypoint: () => true,
+    main: async () => { throw new Error('boom from main'); },
+    reportCliError: (e) => errors.push(e.message)
+  });
+  assert.equal(ran, true);
+  assert.deepEqual(errors, ['boom from main']);
+});
+
+// =============================================================================
+// loadPlaywrightChromium - happy path with a stubbed runner dir
+// =============================================================================
+
+test('loadPlaywrightChromium reads runner dir env and resolves chromium via injected deps', async () => {
+  const stubChromium = { tag: 'stub-chromium' };
+  const stubPlaywright = { chromium: stubChromium };
+  const got = await loadPlaywrightChromium({
+    runnerDir: '/tmp/runner',
+    createRequire: () => ({
+      resolve: (id) => {
+        assert.equal(id, 'playwright');
+        return '/tmp/runner/node_modules/playwright/index.js';
+      }
+    }),
+    importModule: async (href) => {
+      assert.match(href, /\/tmp\/runner\/node_modules\/playwright\/index\.js$/);
+      return stubPlaywright;
+    }
+  });
+  assert.equal(got, stubChromium);
+});
+
+test('loadPlaywrightChromium throws when runnerDir is empty', async () => {
+  await assert.rejects(loadPlaywrightChromium({ runnerDir: '' }), /QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR/);
+});
+
+// =============================================================================
+// runCommand bootstrap branch (lines 333-335 explicit re-cover)
+// =============================================================================
+
+test('runCommand bootstrap branch invokes normalize then bootstrap hooks in order', async () => {
+  const order = [];
+  await runCommand(
+    { command: 'bootstrap', provider: 'codecov' },
+    {
+      listProviders: () => order.push('list'),
+      normalizeProvider: (p) => { order.push(`normalize:${p}`); return p; },
+      bootstrap: async (a) => { order.push(`bootstrap:${a.provider}`); },
+      openOrInspect: () => order.push('openOrInspect'),
+      log: () => {},
+      renderHelp: () => 'help'
+    }
+  );
+  assert.deepEqual(order, ['normalize:codecov', 'bootstrap:codecov']);
 });

--- a/scripts/provider_ui/provider_admin_config.mjs
+++ b/scripts/provider_ui/provider_admin_config.mjs
@@ -65,7 +65,7 @@ export const PROVIDER_KEYS = Object.freeze(Object.keys(PROVIDERS));
 /**
  * Handle build repo target url.
  */
-function buildRepoTargetUrl(providerKey, repoSlug) {
+export function buildRepoTargetUrl(providerKey, repoSlug) {
   switch (providerKey) {
     case 'codecov':
       return `https://app.codecov.io/gh/${repoSlug}`;

--- a/scripts/provider_ui/provider_admin_config.test.mjs
+++ b/scripts/provider_ui/provider_admin_config.test.mjs
@@ -3,11 +3,14 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import {
   PROVIDER_KEYS,
+  buildRepoTargetUrl,
   getDefaultProfileDir,
   getDefaultRunnerDir,
   getDefaultStateRoot,
+  normalizeProvider,
   normalizeRepoSlug,
   parseArgs,
+  renderHelp,
   resolveProviderTarget
 } from './provider_admin_config.mjs';
 
@@ -72,4 +75,134 @@ test('argument parsing accepts short aliases without changing command semantics'
   assert.equal(args.provider, 'codacy');
   assert.equal(args.repo, 'quality-zero-platform');
   assert.equal(args.headless, null);
+});
+
+test('getDefaultStateRoot honours QUALITY_ZERO_PROVIDER_UI_HOME override', () => {
+  const env = { QUALITY_ZERO_PROVIDER_UI_HOME: '/custom/home' };
+  const root = getDefaultStateRoot(env);
+  assert.equal(root, path.resolve('/custom/home'));
+  assert.equal(getDefaultProfileDir(env), path.join(path.resolve('/custom/home'), 'chromium-profile'));
+  assert.equal(getDefaultRunnerDir(env), path.join(path.resolve('/custom/home'), 'pw-runner'));
+});
+
+test('getDefaultStateRoot falls back to homedir when LOCALAPPDATA is missing', () => {
+  const root = getDefaultStateRoot({});
+  // Should land under either the home directory or a non-empty path
+  assert.ok(root.length > 0);
+  assert.ok(root.endsWith('provider-ui'));
+});
+
+test('normalizeProvider rejects empty input', () => {
+  assert.throws(() => normalizeProvider(''), /Provider is required/);
+});
+
+test('normalizeProvider rejects unknown providers', () => {
+  assert.throws(() => normalizeProvider('not-a-provider'), /Unknown provider/);
+});
+
+test('normalizeProvider trims and lowercases recognised providers', () => {
+  assert.equal(normalizeProvider('  Codecov  '), 'codecov');
+  assert.equal(normalizeProvider('Sentry'), 'sentry');
+});
+
+test('resolveProviderTarget defaults to provider home when no repo is supplied', () => {
+  const target = resolveProviderTarget('codecov');
+  assert.equal(target.repoSlug, null);
+  // Codecov home page when no repo is supplied
+  assert.match(target.targetUrl, /codecov\.io/);
+});
+
+test('resolveProviderTarget rejects an unknown provider key', () => {
+  assert.throws(() => resolveProviderTarget('totally-unknown'), /Unknown provider/);
+});
+
+test('parseArgs throws on an unknown long flag', () => {
+  assert.throws(() => parseArgs(['list', '--bogus-flag']), /Unknown argument/);
+});
+
+test('parseArgs --headless toggle flips the headless option', () => {
+  const headless = parseArgs(['open', '-p', 'codecov', '--headless']);
+  assert.equal(headless.headless, true);
+  const headed = parseArgs(['open', '-p', 'codecov', '--headed']);
+  assert.equal(headed.headless, false);
+});
+
+test('parseArgs --keep-open turns on keepOpen', () => {
+  const args = parseArgs(['inspect', '-p', 'codecov', '--keep-open']);
+  assert.equal(args.keepOpen, true);
+});
+
+test('parseArgs --slow-mo-ms applies as numeric', () => {
+  const args = parseArgs(['open', '-p', 'codecov', '--slow-mo-ms', '50']);
+  assert.equal(args.slowMoMs, 50);
+});
+
+test('parseArgs --state-root + --profile-dir resolve to absolute paths', () => {
+  const args = parseArgs([
+    'open',
+    '-p',
+    'codecov',
+    '--state-root',
+    '/tmp/state',
+    '--profile-dir',
+    '/tmp/profile'
+  ]);
+  assert.equal(args.stateRoot, path.resolve('/tmp/state'));
+  assert.equal(args.profileDir, path.resolve('/tmp/profile'));
+});
+
+test('parseArgs rejects non-positive --timeout-ms', () => {
+  assert.throws(() => parseArgs(['inspect', '-p', 'codecov', '--timeout-ms', '0']), /Invalid --timeout-ms/);
+});
+
+test('parseArgs rejects negative --slow-mo-ms', () => {
+  assert.throws(() => parseArgs(['inspect', '-p', 'codecov', '--slow-mo-ms', '-5']), /Invalid --slow-mo-ms/);
+});
+
+test('parseArgs requires a value for --provider', () => {
+  assert.throws(() => parseArgs(['bootstrap', '--provider']), /Missing value for/);
+});
+
+test('parseArgs --owner overrides default owner', () => {
+  const args = parseArgs(['inspect', '-p', 'codecov', '--owner', 'someone-else']);
+  assert.equal(args.owner, 'someone-else');
+});
+
+test('renderHelp returns a help string with Commands / Options sections', () => {
+  const help = renderHelp();
+  assert.match(help, /Commands:/);
+  assert.match(help, /Options:/);
+  assert.match(help, /Examples:/);
+  assert.match(help, /list\s+List supported providers/);
+});
+
+test('normalizeRepoSlug handles slug-only with a fallback owner', () => {
+  assert.equal(normalizeRepoSlug('repo-only', 'fallback-owner'), 'fallback-owner/repo-only');
+  assert.equal(normalizeRepoSlug(null, 'fallback'), null);
+  assert.equal(normalizeRepoSlug(undefined, 'fallback'), null);
+});
+
+test('normalizeRepoSlug returns null when input trims to empty', () => {
+  assert.equal(normalizeRepoSlug('   ', 'fallback'), null);
+});
+
+test('resolveProviderTarget with repo on a provider that does not support repo URLs falls back to home', () => {
+  // chromatic does not derive a per-repo URL — the buildRepoTargetUrl
+  // default branch (return null) routes back to the provider home page.
+  const target = resolveProviderTarget('chromatic', { repo: 'momentstudio' });
+  assert.equal(target.targetUrl, 'https://www.chromatic.com/start');
+  assert.equal(target.repoSlug, 'Prekzursil/momentstudio');
+});
+
+test('buildRepoTargetUrl returns codecov / qlty URLs and null otherwise', () => {
+  assert.equal(
+    buildRepoTargetUrl('codecov', 'Prekzursil/quality-zero-platform'),
+    'https://app.codecov.io/gh/Prekzursil/quality-zero-platform'
+  );
+  assert.equal(
+    buildRepoTargetUrl('qlty', 'Prekzursil/quality-zero-platform'),
+    'https://qlty.sh/gh/Prekzursil/projects/quality-zero-platform'
+  );
+  // Unknown provider key — covers the default: return null branch
+  assert.equal(buildRepoTargetUrl('unknown-future-provider', 'org/repo'), null);
 });


### PR DESCRIPTION
## **User description**
## Summary

After PR #178 wired Node test runner lcov → SonarCloud + Codecov, QZP main's line coverage rose from 89.4% → 90.99% but still failed the 100% gate because ``provider_admin_bootstrap.mjs`` had only 43% line coverage. This PR brings both ``.mjs`` files to 100% line coverage by making them fully testable and adding 30+ new tests.

## Changes

### Module refactoring (no behavior changes)
- ``provider_admin_bootstrap.mjs`` exports every previously-private function (``loadPlaywrightChromium``, ``promptForManualLogin``, ``launchContextWithFallback``, ``launchPersistentContext``, ``printResult``, ``listProviders``, ``waitForKeepOpenExit``, ``bootstrap``, ``openOrInspect``, ``main``, ``reportCliError``).
- Each accepts a ``deps`` object with optional dependency-injection seams (``loadPlaywrightChromium``, ``createRequire``, ``importModule``, ``readline``, ``input``, ``output``, ``platform``, ``processObj``, ``log``, ``errLog``) so playwright / readline / node-internal calls can be mocked.
- ``provider_admin_config.buildRepoTargetUrl`` now exported so its ``default: return null`` branch is unit-testable.
- The CLI entry-point guard is extracted into ``runCliIfEntrypoint(importMetaUrl, deps)`` so both the entrypoint and non-entrypoint paths are testable without spawning a child process.

### New tests
30+ tests covering every exported function path:
- ``ensureManagedStatePath`` happy path + sibling escape + parent traversal
- ``resolvePlaywrightChromium`` named-export, default-export, missing, null variants
- ``loadPlaywrightChromium`` with both runner-dir-missing and runner-dir-set + injected createRequire/importModule
- ``isCliEntrypoint`` matching, mismatching, and empty-argv cases
- ``promptForManualLogin`` with mocked readline/input/output streams
- ``launchContextWithFallback`` win32 channel selection, non-win32 path, win32 fallback after edge failure, non-win32 re-throw
- ``launchPersistentContext`` skip/include manual prompt, empty pages list (newPage path)
- ``printResult`` / ``listProviders`` with injected logger
- ``waitForKeepOpenExit`` close / SIGINT / SIGTERM resolution
- ``bootstrap`` / ``openOrInspect`` with keepOpen=true/false, inspectOnly=true/false
- ``runCommand`` list / open / inspect / unknown-command paths
- ``main`` argv forwarding
- ``reportCliError`` Error-with-stack, non-Error, Error-without-stack
- ``runCliIfEntrypoint`` non-entrypoint short-circuit, entrypoint happy path, entrypoint error forwarding
- ``buildRepoTargetUrl`` codecov / qlty / unknown-provider null branch
- ``parseArgs`` 14 new tests covering --headless, --headed, --keep-open, --slow-mo-ms, --state-root, --profile-dir, --owner, --timeout-ms, --bogus-flag, --provider missing-value, etc.
- ``normalizeProvider`` empty / unknown / valid-with-trim
- ``resolveProviderTarget`` no-repo, unknown-provider, repo-on-non-supporting-provider
- ``getDefaultStateRoot`` QUALITY_ZERO_PROVIDER_UI_HOME override, missing-LOCALAPPDATA fallback
- ``renderHelp`` content shape

## Coverage results
\`\`\`
provider_admin_bootstrap.mjs | 100% line | 77.78% branch | 95.24% funcs
provider_admin_config.mjs    | 100% line | 100%   branch | 100%   funcs
all files                    | 100% line | 88.08% branch | 97.62% funcs
\`\`\`

Branch coverage gap (88%) is entirely on the optional-dep-injection fallbacks (``?? defaultFn`` where the test passes both branches but each expression has 2 branch points). These are low-risk and not enforced by the platform's coverage gate which only checks line coverage minimum at 100%.

## Test plan
- [x] ``node --test scripts/provider_ui/*.test.mjs`` → 76 pass, 0 fail
- [x] ``python -m pytest tests -q`` → 1476 pass (unchanged)
- [x] ``qlty smells`` → 0 findings
- [ ] CI: shared-scanner-matrix / Coverage 100 Gate (expects 100% line on QZP main)
- [ ] Sonar reanalysis: line_coverage lifts from 89.4% to 100%

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Brings `scripts/provider_ui` `.mjs` files to 100% line coverage by making the CLI fully testable and adding 30+ focused Node tests. This closes the 89.4% → 100% line coverage gap and unblocks the coverage gate.

- **Refactors**
  - Exported previously private functions from `provider_admin_bootstrap.mjs` (e.g., `loadPlaywrightChromium`, `promptForManualLogin`, `launchContextWithFallback`, `launchPersistentContext`, `printResult`, `listProviders`, `waitForKeepOpenExit`, `bootstrap`, `openOrInspect`, `main`, `reportCliError`).
  - Added dependency-injection seams (`createRequire`, `importModule`, `readline`, `input`/`output` streams, `process`, `log`/`errLog`) to enable fast, isolated tests.
  - Extracted CLI entry-point guard into `runCliIfEntrypoint(importMetaUrl, deps)` and invoked it at module end.
  - Exported `buildRepoTargetUrl` from `provider_admin_config.mjs` to make the default `null` branch testable.

- **Coverage**
  - Added 30+ Node tests covering all exported paths and CLI flows (entrypoint detection, prompts, launch fallbacks, keep-open signals, printing, commands, arg parsing, config helpers).
  - Coverage results: `provider_admin_bootstrap.mjs` 100% line (77.78% branch), `provider_admin_config.mjs` 100% line/branch; overall 100% line.
  - Remaining branch gaps come from optional DI fallbacks and are not required by the line-coverage gate.
  - Test plan: `node --test scripts/provider_ui/*.test.mjs` → 76 pass; `pytest` unchanged.

<sup>Written for commit f362d4d7f4a503f57d1ab101aa6cc9aa9ddabb09. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for provider UI administration scripts, including Playwright integration, CLI parsing, and browser context management scenarios.

* **Chores**
  * Refactored internal provider UI modules to improve code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Cover the provider UI CLI paths with tests and make its helpers testable

### What Changed
- Added tests for provider lookup, argument parsing, help text, URL selection, and CLI command routing
- Added tests for browser launch, manual login prompt, keep-open handling, result logging, and error reporting
- Exposed a few helper paths so the existing CLI behavior can be exercised directly in tests without changing how the tool runs

### Impact
`✅ Full test coverage for provider UI CLI flows`
`✅ Fewer untested CLI edge cases`
`✅ Safer provider UI changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=PtKL7uHTeiakVngmIpJejmAxltwEYKO1wbcYATNOK-o&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
