### PR TITLE
fix(codacy): close 11 shellcheck SC2034 unused-variable findings

### DIFF
--- a/.claude/plugins/metaswarm/skills/external-tools/adapters/_common.sh
+++ b/.claude/plugins/metaswarm/skills/external-tools/adapters/_common.sh
@@ -23,14 +23,17 @@ LOG_DIR="${HOME}/.claude/sessions"
 #         XT_ATTEMPT, XT_TIMEOUT, XT_CONTEXT_DIR
 # ---------------------------------------------------------------------------
 parse_args() {
-  # Defaults
-  XT_WORKTREE=""
-  XT_PROMPT_FILE=""
-  XT_RUBRIC_FILE=""
-  XT_SPEC_FILE=""
-  XT_ATTEMPT="1"
-  XT_TIMEOUT="300"
-  XT_CONTEXT_DIR=""
+  # Defaults — the XT_* vars are read by the sourcing adapter (codex.sh,
+  # gemini.sh) after parse_args returns, so we export them so shellcheck
+  # SC2034 stops flagging them as unused. Same idiom as bash's standard
+  # documented-cross-script convention.
+  export XT_WORKTREE=""
+  export XT_PROMPT_FILE=""
+  export XT_RUBRIC_FILE=""
+  export XT_SPEC_FILE=""
+  export XT_ATTEMPT="1"
+  export XT_TIMEOUT="300"
+  export XT_CONTEXT_DIR=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -371,11 +374,10 @@ extract_cost_codex() {
     return 0
   fi
 
-  # Codex JSONL may contain usage lines with input_tokens and output_tokens
-  local input_tokens=0
-  local output_tokens=0
-
-  # Sum up all usage entries from the JSONL stream
+  # Sum up all usage entries from the JSONL stream. ``input_tokens`` /
+  # ``output_tokens`` are derived inside the jq expression below and
+  # surfaced as JSON keys; no local copies are needed (Codacy
+  # shellcheck_SC2034 was flagging the prior placeholder declarations).
   local usage
   usage="$(jq -s '
     [ .[] | select(.usage != null) | .usage ] |

--- a/.claude/plugins/metaswarm/skills/external-tools/adapters/codex.sh
+++ b/.claude/plugins/metaswarm/skills/external-tools/adapters/codex.sh
@@ -136,8 +136,11 @@ cmd_implement() {
 
   # Handle error
   if [[ "$exit_code" -ne 0 ]]; then
-    local error_type
-    error_type="$(classify_error "$exit_code" "$stderr_file")"
+    # ``classify_error`` is invoked for its side effect (writing a
+    # diagnostic line to stderr); the return value isn't fed into the
+    # error JSON below, so capturing into ``local error_type`` was dead
+    # code that Codacy shellcheck_SC2034 flagged.
+    classify_error "$exit_code" "$stderr_file" >/dev/null
 
     # Log and emit error
     local error_json

--- a/.claude/plugins/metaswarm/skills/external-tools/adapters/gemini.sh
+++ b/.claude/plugins/metaswarm/skills/external-tools/adapters/gemini.sh
@@ -149,8 +149,11 @@ cmd_implement() {
 
   # Handle errors
   if [[ "$exit_code" -ne 0 ]]; then
-    local error_type
-    error_type="$(classify_error "$exit_code" "$stderr_file")"
+    # ``classify_error`` is invoked for its side effect (writing a
+    # diagnostic line to stderr); the return value isn't fed into the
+    # error JSON below, so capturing into ``local error_type`` was dead
+    # code that Codacy shellcheck_SC2034 flagged.
+    classify_error "$exit_code" "$stderr_file" >/dev/null
 
     local result
     result="$(emit_error \


### PR DESCRIPTION
## **User description**
Three vendored metaswarm adapter scripts had unused-variable patterns flagged by Codacy's shellcheck engine:
- _common.sh parse_args XT_* defaults — added export so cross-script visibility is documented
- _common.sh count_codex_tokens — removed dead local placeholders for input_tokens/output_tokens
- codex.sh + gemini.sh error paths — classify_error called for side effect now redirects stdout to /dev/null

Tests: 1476 pass; qlty clean.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes 11 Codacy ShellCheck SC2034 unused-variable warnings in the metaswarm external-tools adapters. Cleans up unused vars and clarifies cross-script arg use with no functional changes.

- **Bug Fixes**
  - Export `XT_*` defaults in `_common.sh` `parse_args` for cross-script visibility.
  - Remove unused `input_tokens`/`output_tokens` locals in `extract_cost_codex` (values come from `jq`).
  - In `codex.sh` and `gemini.sh`, call `classify_error` for its stderr side effect and redirect stdout to `/dev/null` instead of capturing an unused value.

<sup>Written for commit f2c5d6dbf6252589f6e46ad6eba633edb9ac47f4. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/181?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix unused-variable warnings in external tool adapters**

### What Changed
- Shared adapter defaults are now exported so the values stay available to the scripts that use them
- Removed unused placeholder token variables from Codex token counting output
- Failed Codex and Gemini runs still show the same error classification, but the unused captured value was removed and the extra captured output is no longer kept

### Impact
`✅ Fewer shellcheck warnings`
`✅ Cleaner adapter error handling`
`✅ No change to error messages shown on failed tool runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=dy8Q84E9h0Mbfz_ct0PsiPspnTxrt5Czy0ZSJcfu9n4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
