### PR TITLE
fix(sonar): mark scripts/**/*.test.mjs as tests (closes line_coverage 89.4% → 100%)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,13 @@ sonar.projectKey=Prekzursil_quality-zero-platform
 sonar.organization=prekzursil
 sonar.sources=scripts
 sonar.tests=tests
+# Provider-UI .mjs files have a Node test runner that emits .test.mjs
+# companions in the same directory as the sources. Without explicit
+# test.inclusions, Sonar indexes the .test.mjs files as sources and
+# reports them at 0% coverage. The lcov upload (provider_ui-lcov.info)
+# only carries source-file coverage, so the indexed test files end up
+# dragging the line_coverage metric down.
+sonar.test.inclusions=scripts/**/*.test.mjs
 sonar.python.version=3.12
 # CI writes coverage to coverage/platform-coverage.xml via the profile's
 # coverage.command; scripts/verify writes to coverage.xml. Both paths are


### PR DESCRIPTION
Sonar was indexing the .test.mjs files as sources because no test.inclusions glob covered them. The lcov upload only carries source-file coverage, so the indexed test files reported 0% and dragged QZP's line_coverage down. Adding 'sonar.test.inclusions=scripts/**/*.test.mjs' classifies them correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classify `scripts/**/*.test.mjs` as tests in Sonar so they aren’t indexed as sources, fixing the false 0% coverage and restoring line coverage from 89.4% to 100%.

<sup>Written for commit 1101587f543cd655e923a2042c2f9dd1637b1b23. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/182?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

