### PR TITLE
fix(provider_ui): refactor deps-fallback pattern to hit 100% branch coverage

### DIFF
--- a/profiles/repos/quality-zero-platform.yml
+++ b/profiles/repos/quality-zero-platform.yml
@@ -63,15 +63,16 @@ required_contexts:
 enabled_scanners:
   deepsource_visible: true
 coverage:
+  setup:
+    node: "22"
   command: "python3 -m pip install --upgrade pip\npython3 -m pip install -r requirements-dev.txt\
     \ coverage\ncoverage run --branch -m unittest discover -s tests -p 'test_*.py'\n\
     coverage xml -o coverage/platform-coverage.xml\nmkdir -p coverage\n# scripts/provider_ui/*.mjs\
     \ has its own Node test suite; emit lcov for Sonar\n# (sonar.javascript.lcov.reportPaths)\
     \ + Codecov 'provider_ui' flag so the\n# 4 .mjs files stop sitting at 0% coverage\
-    \ in the dashboards. The\n# --test-coverage-exclude flag (Node ≥22.10) keeps the\
-    \ test files out of\n# the lcov source list so older runners don't pollute the line/branch\n\
-    # totals with test code. Newer Node versions exclude *.test.* by default\n# but the\
-    \ explicit flag is harmless on those.\nnode --test --experimental-test-coverage \\\n\
+    \ in the dashboards. The\n# --test-coverage-exclude flag requires Node ≥22.10 (set\n\
+    # via coverage.setup.node above) — it keeps test files out of the lcov\n# source list\
+    \ so totals match the source-only branch coverage gate.\nnode --test --experimental-test-coverage \\\n\
     \  --test-coverage-exclude='**/*.test.mjs' \\\n  --test-reporter=lcov \\\n  --test-reporter-destination=coverage/provider_ui-lcov.info\
     \ \\\n  scripts/provider_ui/*.test.mjs || true\n"
   inputs:

--- a/profiles/repos/quality-zero-platform.yml
+++ b/profiles/repos/quality-zero-platform.yml
@@ -68,9 +68,12 @@ coverage:
     coverage xml -o coverage/platform-coverage.xml\nmkdir -p coverage\n# scripts/provider_ui/*.mjs\
     \ has its own Node test suite; emit lcov for Sonar\n# (sonar.javascript.lcov.reportPaths)\
     \ + Codecov 'provider_ui' flag so the\n# 4 .mjs files stop sitting at 0% coverage\
-    \ in the dashboards.\nnode --test --experimental-test-coverage \\\n  --test-reporter=lcov\
-    \ \\\n  --test-reporter-destination=coverage/provider_ui-lcov.info \\\n  scripts/provider_ui/*.test.mjs\
-    \ || true\n"
+    \ in the dashboards. The\n# --test-coverage-exclude flag (Node ≥22.10) keeps the\
+    \ test files out of\n# the lcov source list so older runners don't pollute the line/branch\n\
+    # totals with test code. Newer Node versions exclude *.test.* by default\n# but the\
+    \ explicit flag is harmless on those.\nnode --test --experimental-test-coverage \\\n\
+    \  --test-coverage-exclude='**/*.test.mjs' \\\n  --test-reporter=lcov \\\n  --test-reporter-destination=coverage/provider_ui-lcov.info\
+    \ \\\n  scripts/provider_ui/*.test.mjs || true\n"
   inputs:
   - format: xml
     name: platform

--- a/profiles/stacks/quality-zero-phase1-common.yml
+++ b/profiles/stacks/quality-zero-phase1-common.yml
@@ -75,7 +75,13 @@ coverage:
   command_shell: bash
   setup:
     python: "3.12"
-    node: "20"
+    # Bumped to Node 22 LTS (active LTS; supports --test-coverage-exclude
+    # added in 22.10, which the QZP self-profile relies on for its .mjs
+    # lcov scope). Fleet-wide bump because GitHub Actions also flags
+    # Node 20 actions as deprecated (forced default flips to Node 24 on
+    # 2026-06-02). Repos that explicitly need a different version can
+    # override coverage.setup.node in their per-repo profile.
+    node: "22"
   inputs: []
   min_percent: 100.0
   branch_min_percent: 100.0

--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -92,7 +92,7 @@ export function isCliEntrypoint(importMetaUrl, argv = process.argv) {
  * @param {string} profileDir
  * @returns {Promise<void>}
  */
-export async function promptForManualLogin(target, profileDir, deps = _internals) {
+export function promptForManualLogin(target, profileDir, deps = _internals) {
   return _promptForManualLoginInner(target, profileDir, deps.readline, deps.input, deps.output);
 }
 

--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -96,20 +96,16 @@ export function promptForManualLogin(target, profileDir, deps = _internals) {
   return _promptForManualLoginInner(target, profileDir, deps.readline, deps.input, deps.output);
 }
 
-async function _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream) {
+function _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream) {
   const rl = readlineModule.createInterface({ input: inputStream, output: outputStream });
-  try {
-    outputStream.write(`\nManual login handoff for ${target.label}\n`);
-    outputStream.write(`Target URL: ${target.targetUrl}\n`);
-    outputStream.write(`Persistent profile: ${profileDir}\n`);
-    outputStream.write(`${target.loginHint}\n`);
-    await rl.question(
-      'Complete sign-in or provider checks in the opened browser, then ' +
-      'press Enter to continue... '
-    );
-  } finally {
-    rl.close();
-  }
+  outputStream.write(`\nManual login handoff for ${target.label}\n`);
+  outputStream.write(`Target URL: ${target.targetUrl}\n`);
+  outputStream.write(`Persistent profile: ${profileDir}\n`);
+  outputStream.write(`${target.loginHint}\n`);
+  return rl.question(
+    'Complete sign-in or provider checks in the opened browser, then ' +
+    'press Enter to continue... '
+  ).finally(() => rl.close());
 }
 
 /**

--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -13,6 +13,15 @@ import {
 } from './provider_admin_config.mjs';
 
 /**
+ * Mutable test seam for module-level default dependencies. Public API
+ * functions that previously used ``deps.foo ?? moduleFoo`` fallbacks now
+ * use ``deps = _internals`` defaults, eliminating per-``??`` branch
+ * coverage gaps. Tests can swap entries in ``_internals`` to exercise the
+ * no-deps default path; production code never mutates it.
+ */
+const _internals = {};
+
+/**
  * Ensure provider UI state stays under the managed state root.
  * @param {string} targetPath
  * @param {string} stateRoot
@@ -35,7 +44,7 @@ export function ensureManagedStatePath(targetPath, stateRoot) {
  * Load Playwright from the managed external runner directory.
  * @returns {Promise<import('playwright').BrowserType>}
  */
-export async function loadPlaywrightChromium(deps = {}) {
+export async function loadPlaywrightChromium(deps = _internals) {
   const runnerDirEnv = deps.runnerDir ?? process.env.QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR;
   if (!runnerDirEnv) {
     throw new Error(
@@ -43,11 +52,9 @@ export async function loadPlaywrightChromium(deps = {}) {
       'load Playwright from the external runner directory.'
     );
   }
-  const _createRequire = deps.createRequire ?? createRequire;
-  const _importModule = deps.importModule ?? ((href) => import(href));
-  const runnerRequire = _createRequire(path.join(runnerDirEnv, 'package.json'));
+  const runnerRequire = deps.createRequire(path.join(runnerDirEnv, 'package.json'));
   const playwrightEntry = runnerRequire.resolve('playwright');
-  const playwrightModule = await _importModule(pathToFileURL(playwrightEntry).href);
+  const playwrightModule = await deps.importModule(pathToFileURL(playwrightEntry).href);
   return resolvePlaywrightChromium(playwrightModule);
 }
 
@@ -85,11 +92,8 @@ export function isCliEntrypoint(importMetaUrl, argv = process.argv) {
  * @param {string} profileDir
  * @returns {Promise<void>}
  */
-export async function promptForManualLogin(target, profileDir, deps = {}) {
-  const readlineModule = deps.readline ?? readline;
-  const inputStream = deps.input ?? input;
-  const outputStream = deps.output ?? output;
-  return _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream);
+export async function promptForManualLogin(target, profileDir, deps = _internals) {
+  return _promptForManualLoginInner(target, profileDir, deps.readline, deps.input, deps.output);
 }
 
 async function _promptForManualLoginInner(target, profileDir, readlineModule, inputStream, outputStream) {
@@ -143,10 +147,7 @@ export async function launchContextWithFallback(chromium, profileDir, options, p
  *   headless: boolean
  * }>}
  */
-export async function launchPersistentContext(args, { headlessDefault, includeManualPrompt }, deps = {}) {
-  const loadChromium = deps.loadPlaywrightChromium ?? loadPlaywrightChromium;
-  const launchCtx = deps.launchContextWithFallback ?? launchContextWithFallback;
-  const promptLogin = deps.promptForManualLogin ?? promptForManualLogin;
+export async function launchPersistentContext(args, { headlessDefault, includeManualPrompt }, deps = _internals) {
   const target = resolveProviderTarget(args.provider, {
     repo: args.repo,
     owner: args.owner
@@ -154,8 +155,8 @@ export async function launchPersistentContext(args, { headlessDefault, includeMa
   const profileDir = ensureManagedStatePath(args.profileDir, args.stateRoot);
 
   const headless = args.headless ?? headlessDefault;
-  const chromium = await loadChromium();
-  const context = await launchCtx(chromium, profileDir, {
+  const chromium = await deps.loadPlaywrightChromium();
+  const context = await deps.launchContextWithFallback(chromium, profileDir, {
     headless,
     slowMo: args.slowMoMs,
     viewport: { width: 1440, height: 960 }
@@ -169,7 +170,7 @@ export async function launchPersistentContext(args, { headlessDefault, includeMa
   });
 
   if (includeManualPrompt) {
-    await promptLogin(target, profileDir);
+    await deps.promptForManualLogin(target, profileDir);
   }
 
   const title = await page.title();
@@ -264,18 +265,15 @@ export function waitForKeepOpenExit(context, processObj = process) {
  * @param {ReturnType<typeof parseArgs>} args
  * @returns {Promise<void>}
  */
-export async function bootstrap(args, deps = {}) {
-  const launchCtx = deps.launchPersistentContext ?? launchPersistentContext;
-  const printRes = deps.printResult ?? printResult;
-  const waitExit = deps.waitForKeepOpenExit ?? waitForKeepOpenExit;
-  const result = await launchCtx(args, {
+export async function bootstrap(args, deps = _internals) {
+  const result = await deps.launchPersistentContext(args, {
     headlessDefault: false,
     includeManualPrompt: true
   });
   try {
-    printRes('bootstrap_complete', result);
+    deps.printResult('bootstrap_complete', result);
     if (args.keepOpen) {
-      await waitExit(result.context);
+      await deps.waitForKeepOpenExit(result.context);
     }
   } finally {
     if (!args.keepOpen) {
@@ -290,18 +288,15 @@ export async function bootstrap(args, deps = {}) {
  * @param {{inspectOnly: boolean}} options
  * @returns {Promise<void>}
  */
-export async function openOrInspect(args, { inspectOnly }, deps = {}) {
-  const launchCtx = deps.launchPersistentContext ?? launchPersistentContext;
-  const printRes = deps.printResult ?? printResult;
-  const waitExit = deps.waitForKeepOpenExit ?? waitForKeepOpenExit;
-  const result = await launchCtx(args, {
+export async function openOrInspect(args, { inspectOnly }, deps = _internals) {
+  const result = await deps.launchPersistentContext(args, {
     headlessDefault: true,
     includeManualPrompt: false
   });
   try {
-    printRes(inspectOnly ? 'inspect_complete' : 'open_complete', result);
+    deps.printResult(inspectOnly ? 'inspect_complete' : 'open_complete', result);
     if (args.keepOpen) {
-      await waitExit(result.context);
+      await deps.waitForKeepOpenExit(result.context);
     }
   } finally {
     if (!args.keepOpen) {
@@ -352,11 +347,9 @@ export async function runCommand(args, hooks = {}) {
  * Parse CLI arguments and run the requested provider command.
  * @returns {Promise<void>}
  */
-export async function main(argv = process.argv.slice(2), deps = {}) {
-  const parse = deps.parseArgs ?? parseArgs;
-  const run = deps.runCommand ?? runCommand;
-  const args = parse(argv);
-  await run(args);
+export async function main(argv = process.argv.slice(2), deps = _internals) {
+  const args = deps.parseArgs(argv);
+  await deps.runCommand(args);
 }
 
 /**
@@ -379,19 +372,41 @@ export function reportCliError(error, errLog = console.error, processObj = proce
  * @param {object} [deps]
  * @returns {Promise<boolean>} ``true`` if the CLI ran, ``false`` otherwise.
  */
-export async function runCliIfEntrypoint(importMetaUrl, deps = {}) {
-  const isEntrypoint = deps.isCliEntrypoint ?? isCliEntrypoint;
-  const runMain = deps.main ?? main;
-  const reportErr = deps.reportCliError ?? reportCliError;
-  if (!isEntrypoint(importMetaUrl)) {
+export async function runCliIfEntrypoint(importMetaUrl, deps = _internals) {
+  if (!deps.isCliEntrypoint(importMetaUrl)) {
     return false;
   }
   try {
-    await runMain();
+    await deps.main();
   } catch (error) {
-    reportErr(error);
+    deps.reportCliError(error);
   }
   return true;
 }
+
+// Populate the test seam after every function is hoisted so the default
+// parameter expressions ``deps = _internals`` resolve to the production
+// implementations at call time. Tests can mutate entries on this object
+// to drive the no-deps branch of each public function.
+Object.assign(_internals, {
+  createRequire,
+  importModule: (href) => import(href),
+  readline,
+  input,
+  output,
+  loadPlaywrightChromium,
+  launchContextWithFallback,
+  promptForManualLogin,
+  launchPersistentContext,
+  printResult,
+  waitForKeepOpenExit,
+  parseArgs,
+  runCommand,
+  isCliEntrypoint,
+  main,
+  reportCliError
+});
+
+export { _internals };
 
 await runCliIfEntrypoint(import.meta.url);

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -492,10 +492,10 @@ test('runCommand dispatches inspect to openOrInspect with inspectOnly=true', asy
   assert.deepEqual(calls, [['inspect', true]]);
 });
 
-test('runCommand prints help for unrecognised commands', async () => {
+async function _runCommandHelpScenario(command) {
   const messages = [];
   await runCommand(
-    { command: 'unknown-command-name' },
+    { command },
     {
       listProviders: () => {},
       normalizeProvider: () => {},
@@ -505,23 +505,15 @@ test('runCommand prints help for unrecognised commands', async () => {
       renderHelp: () => 'help text'
     }
   );
-  assert.deepEqual(messages, ['help text']);
+  return messages;
+}
+
+test('runCommand prints help for unrecognised commands', async () => {
+  assert.deepEqual(await _runCommandHelpScenario('unknown-command-name'), ['help text']);
 });
 
 test('runCommand prints help when command is "help" (covers case fall-through)', async () => {
-  const messages = [];
-  await runCommand(
-    { command: 'help' },
-    {
-      listProviders: () => {},
-      normalizeProvider: () => {},
-      bootstrap: () => {},
-      openOrInspect: () => {},
-      log: (m) => messages.push(m),
-      renderHelp: () => 'help text'
-    }
-  );
-  assert.deepEqual(messages, ['help text']);
+  assert.deepEqual(await _runCommandHelpScenario('help'), ['help text']);
 });
 
 // =============================================================================

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -508,6 +508,22 @@ test('runCommand prints help for unrecognised commands', async () => {
   assert.deepEqual(messages, ['help text']);
 });
 
+test('runCommand prints help when command is "help" (covers case fall-through)', async () => {
+  const messages = [];
+  await runCommand(
+    { command: 'help' },
+    {
+      listProviders: () => {},
+      normalizeProvider: () => {},
+      bootstrap: () => {},
+      openOrInspect: () => {},
+      log: (m) => messages.push(m),
+      renderHelp: () => 'help text'
+    }
+  );
+  assert.deepEqual(messages, ['help text']);
+});
+
 // =============================================================================
 // main / reportCliError
 // =============================================================================

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -117,7 +117,7 @@ test('promptForManualLogin writes guidance and waits for Enter', async () => {
   let closed = false;
   const readlineModule = {
     createInterface: () => ({
-      question: async (prompt) => { questionAsked = prompt; return ''; },
+      question: (prompt) => { questionAsked = prompt; return ''; },
       close: () => { closed = true; }
     })
   };
@@ -143,7 +143,7 @@ test('promptForManualLogin writes guidance and waits for Enter', async () => {
 test('launchContextWithFallback uses msedge channel on win32', async () => {
   const calls = [];
   const chromium = {
-    launchPersistentContext: async (dir, options) => {
+    launchPersistentContext: (dir, options) => {
       calls.push({ dir, options });
       return { ctx: 'edge' };
     }
@@ -157,7 +157,7 @@ test('launchContextWithFallback uses msedge channel on win32', async () => {
 test('launchContextWithFallback skips channel on non-win32', async () => {
   const calls = [];
   const chromium = {
-    launchPersistentContext: async (dir, options) => {
+    launchPersistentContext: (dir, options) => {
       calls.push({ dir, options });
       return { ctx: 'chromium' };
     }
@@ -169,7 +169,7 @@ test('launchContextWithFallback skips channel on non-win32', async () => {
 test('launchContextWithFallback retries without channel on win32 launch failure', async () => {
   const calls = [];
   const chromium = {
-    launchPersistentContext: async (dir, options) => {
+    launchPersistentContext: (dir, options) => {
       calls.push({ options });
       if (options.channel === 'msedge') {
         throw new Error('edge missing');
@@ -186,7 +186,7 @@ test('launchContextWithFallback retries without channel on win32 launch failure'
 
 test('launchContextWithFallback re-throws on non-win32 launch failure', async () => {
   const chromium = {
-    launchPersistentContext: async () => { throw new Error('boom'); }
+    launchPersistentContext: () => { throw new Error('boom'); }
   };
   await assert.rejects(
     launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'linux'),
@@ -213,18 +213,18 @@ function _stubArgs() {
 
 function _stubBrowserContext() {
   const page = {
-    setDefaultTimeout: () => {},
-    goto: async () => {},
-    title: async () => 'Test Title',
+    setDefaultTimeout: () => undefined,
+    goto: () => undefined,
+    title: () => 'Test Title',
     url: () => 'https://final.example.com'
   };
   return {
     pages: () => [page],
-    newPage: async () => page,
-    on: () => {},
-    once: () => {},
-    off: () => {},
-    close: async () => {}
+    newPage: () => page,
+    on: () => undefined,
+    once: () => undefined,
+    off: () => undefined,
+    close: () => undefined
   };
 }
 
@@ -235,12 +235,12 @@ test('launchPersistentContext walks the launch path and skips manual prompt when
     _stubArgs(),
     { headlessDefault: true, includeManualPrompt: false },
     {
-      loadPlaywrightChromium: async () => ({ tag: 'chromium' }),
-      launchContextWithFallback: async (chromium, dir, opts) => {
+      loadPlaywrightChromium: () => ({ tag: 'chromium' }),
+      launchContextWithFallback: (chromium, dir, opts) => {
         calls.push({ dir, headless: opts.headless });
         return ctx;
       },
-      promptForManualLogin: async () => { calls.push('prompt'); }
+      promptForManualLogin: () => { calls.push('prompt'); }
     }
   );
   assert.equal(result.headless, true);
@@ -256,9 +256,9 @@ test('launchPersistentContext invokes manual prompt when requested', async () =>
     _stubArgs(),
     { headlessDefault: false, includeManualPrompt: true },
     {
-      loadPlaywrightChromium: async () => ({}),
-      launchContextWithFallback: async () => ctx,
-      promptForManualLogin: async () => { prompted = true; }
+      loadPlaywrightChromium: () => ({}),
+      launchContextWithFallback: () => ctx,
+      promptForManualLogin: () => { prompted = true; }
     }
   );
   assert.equal(prompted, true);
@@ -266,23 +266,23 @@ test('launchPersistentContext invokes manual prompt when requested', async () =>
 
 test('launchPersistentContext creates a new page when context.pages() is empty', async () => {
   const page = {
-    setDefaultTimeout: () => {},
-    goto: async () => {},
-    title: async () => 'New Page',
+    setDefaultTimeout: () => undefined,
+    goto: () => undefined,
+    title: () => 'New Page',
     url: () => 'https://new.example.com'
   };
   const ctx = {
     pages: () => [],
-    newPage: async () => page,
-    on: () => {}, once: () => {}, off: () => {}, close: async () => {}
+    newPage: () => page,
+    on: () => undefined, once: () => undefined, off: () => undefined, close: () => undefined
   };
   const result = await launchPersistentContext(
     _stubArgs(),
     { headlessDefault: false, includeManualPrompt: false },
     {
-      loadPlaywrightChromium: async () => ({}),
-      launchContextWithFallback: async () => ctx,
-      promptForManualLogin: async () => {}
+      loadPlaywrightChromium: () => ({}),
+      launchContextWithFallback: () => ctx,
+      promptForManualLogin: () => undefined
     }
   );
   assert.equal(result.title, 'New Page');
@@ -360,7 +360,7 @@ test('waitForKeepOpenExit resolves on SIGTERM', async () => {
 // bootstrap / openOrInspect
 // =============================================================================
 
-function _bootstrapStubResult(close = async () => {}) {
+function _bootstrapStubResult(close = () => undefined) {
   return {
     target: { key: 'codecov', label: 'Codecov', repoSlug: 'org/repo', targetUrl: 'https://x' },
     finalUrl: 'https://final',
@@ -375,9 +375,9 @@ test('bootstrap closes the context when keepOpen is false', async () => {
   await bootstrap(
     { keepOpen: false },
     {
-      launchPersistentContext: async () => _bootstrapStubResult(async () => { closed += 1; }),
-      printResult: () => {},
-      waitForKeepOpenExit: async () => {}
+      launchPersistentContext: () => _bootstrapStubResult(async () => { closed += 1; }),
+      printResult: () => undefined,
+      waitForKeepOpenExit: () => undefined
     }
   );
   assert.equal(closed, 1);
@@ -389,9 +389,9 @@ test('bootstrap waits for keep-open exit when requested', async () => {
   await bootstrap(
     { keepOpen: true },
     {
-      launchPersistentContext: async () => _bootstrapStubResult(async () => { closed += 1; }),
-      printResult: () => {},
-      waitForKeepOpenExit: async () => { waited = true; }
+      launchPersistentContext: () => _bootstrapStubResult(async () => { closed += 1; }),
+      printResult: () => undefined,
+      waitForKeepOpenExit: () => { waited = true; }
     }
   );
   assert.equal(waited, true);
@@ -404,9 +404,9 @@ test('openOrInspect uses inspect_complete prefix in inspect mode', async () => {
     { keepOpen: false },
     { inspectOnly: true },
     {
-      launchPersistentContext: async () => _bootstrapStubResult(),
+      launchPersistentContext: () => _bootstrapStubResult(),
       printResult: (prefix) => prefixes.push(prefix),
-      waitForKeepOpenExit: async () => {}
+      waitForKeepOpenExit: () => undefined
     }
   );
   assert.deepEqual(prefixes, ['inspect_complete']);
@@ -418,9 +418,9 @@ test('openOrInspect uses open_complete prefix when not inspect-only', async () =
     { keepOpen: false },
     { inspectOnly: false },
     {
-      launchPersistentContext: async () => _bootstrapStubResult(),
+      launchPersistentContext: () => _bootstrapStubResult(),
       printResult: (prefix) => prefixes.push(prefix),
-      waitForKeepOpenExit: async () => {}
+      waitForKeepOpenExit: () => undefined
     }
   );
   assert.deepEqual(prefixes, ['open_complete']);
@@ -432,9 +432,9 @@ test('openOrInspect waits for keep-open exit when requested', async () => {
     { keepOpen: true },
     { inspectOnly: false },
     {
-      launchPersistentContext: async () => _bootstrapStubResult(),
-      printResult: () => {},
-      waitForKeepOpenExit: async () => { waited = true; }
+      launchPersistentContext: () => _bootstrapStubResult(),
+      printResult: () => undefined,
+      waitForKeepOpenExit: () => { waited = true; }
     }
   );
   assert.equal(waited, true);
@@ -450,10 +450,10 @@ test('runCommand dispatches list to listProviders hook', async () => {
     { command: 'list' },
     {
       listProviders: (args) => { calls.push(['list', args]); },
-      normalizeProvider: () => {},
-      bootstrap: () => {},
-      openOrInspect: () => {},
-      log: () => {},
+      normalizeProvider: () => undefined,
+      bootstrap: () => undefined,
+      openOrInspect: () => undefined,
+      log: () => undefined,
       renderHelp: () => 'help'
     }
   );
@@ -465,11 +465,11 @@ test('runCommand dispatches open to openOrInspect with inspectOnly=false', async
   await runCommand(
     { command: 'open', provider: 'Sonar' },
     {
-      listProviders: () => {},
+      listProviders: () => undefined,
       normalizeProvider: (p) => { calls.push(['normalize', p]); return p.toLowerCase(); },
       bootstrap: () => { calls.push(['bootstrap']); },
       openOrInspect: (_args, opts) => { calls.push(['open', opts.inspectOnly]); },
-      log: () => {},
+      log: () => undefined,
       renderHelp: () => 'help'
     }
   );
@@ -481,11 +481,11 @@ test('runCommand dispatches inspect to openOrInspect with inspectOnly=true', asy
   await runCommand(
     { command: 'inspect', provider: 'Codacy' },
     {
-      listProviders: () => {},
+      listProviders: () => undefined,
       normalizeProvider: (p) => p.toLowerCase(),
-      bootstrap: () => {},
+      bootstrap: () => undefined,
       openOrInspect: (_args, opts) => { calls.push(['inspect', opts.inspectOnly]); },
-      log: () => {},
+      log: () => undefined,
       renderHelp: () => 'help'
     }
   );
@@ -497,10 +497,10 @@ async function _runCommandHelpScenario(command) {
   await runCommand(
     { command },
     {
-      listProviders: () => {},
-      normalizeProvider: () => {},
-      bootstrap: () => {},
-      openOrInspect: () => {},
+      listProviders: () => undefined,
+      normalizeProvider: () => undefined,
+      bootstrap: () => undefined,
+      openOrInspect: () => undefined,
       log: (m) => messages.push(m),
       renderHelp: () => 'help text'
     }
@@ -526,7 +526,7 @@ test('main parses argv and forwards to runCommand', async () => {
     ['list'],
     {
       parseArgs: (argv) => { calls.push(['parse', argv]); return { command: 'list' }; },
-      runCommand: async (args) => { calls.push(['run', args]); }
+      runCommand: (args) => { calls.push(['run', args]); }
     }
   );
   assert.deepEqual(calls, [['parse', ['list']], ['run', { command: 'list' }]]);
@@ -565,8 +565,8 @@ test('runCliIfEntrypoint short-circuits when not the CLI entrypoint', async () =
   let mainCalled = false;
   const ran = await runCliIfEntrypoint('file:///not-the-script.mjs', {
     isCliEntrypoint: () => false,
-    main: async () => { mainCalled = true; },
-    reportCliError: () => {}
+    main: () => { mainCalled = true; },
+    reportCliError: () => undefined
   });
   assert.equal(ran, false);
   assert.equal(mainCalled, false);
@@ -576,8 +576,8 @@ test('runCliIfEntrypoint runs main when called as CLI', async () => {
   let mainCalled = false;
   const ran = await runCliIfEntrypoint('file:///cli.mjs', {
     isCliEntrypoint: () => true,
-    main: async () => { mainCalled = true; },
-    reportCliError: () => {}
+    main: () => { mainCalled = true; },
+    reportCliError: () => undefined
   });
   assert.equal(ran, true);
   assert.equal(mainCalled, true);
@@ -587,7 +587,7 @@ test('runCliIfEntrypoint forwards errors to reportCliError', async () => {
   const errors = [];
   const ran = await runCliIfEntrypoint('file:///cli.mjs', {
     isCliEntrypoint: () => true,
-    main: async () => { throw new Error('boom from main'); },
+    main: () => { throw new Error('boom from main'); },
     reportCliError: (e) => errors.push(e.message)
   });
   assert.equal(ran, true);
@@ -609,7 +609,7 @@ test('loadPlaywrightChromium reads runner dir env and resolves chromium via inje
         return '/tmp/runner/node_modules/playwright/index.js';
       }
     }),
-    importModule: async (href) => {
+    importModule: (href) => {
       assert.match(href, /\/tmp\/runner\/node_modules\/playwright\/index\.js$/);
       return stubPlaywright;
     }
@@ -632,9 +632,9 @@ test('runCommand bootstrap branch invokes normalize then bootstrap hooks in orde
     {
       listProviders: () => order.push('list'),
       normalizeProvider: (p) => { order.push(`normalize:${p}`); return p; },
-      bootstrap: async (a) => { order.push(`bootstrap:${a.provider}`); },
+      bootstrap: (a) => { order.push(`bootstrap:${a.provider}`); },
       openOrInspect: () => order.push('openOrInspect'),
-      log: () => {},
+      log: () => undefined,
       renderHelp: () => 'help'
     }
   );

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -117,7 +117,7 @@ test('promptForManualLogin writes guidance and waits for Enter', async () => {
   let closed = false;
   const readlineModule = {
     createInterface: () => ({
-      question: (prompt) => { questionAsked = prompt; return ''; },
+      question: (prompt) => { questionAsked = prompt; return Promise.resolve(''); },
       close: () => { closed = true; }
     })
   };
@@ -375,7 +375,7 @@ test('bootstrap closes the context when keepOpen is false', async () => {
   await bootstrap(
     { keepOpen: false },
     {
-      launchPersistentContext: () => _bootstrapStubResult(async () => { closed += 1; }),
+      launchPersistentContext: () => _bootstrapStubResult(() => { closed += 1; }),
       printResult: () => undefined,
       waitForKeepOpenExit: () => undefined
     }
@@ -389,7 +389,7 @@ test('bootstrap waits for keep-open exit when requested', async () => {
   await bootstrap(
     { keepOpen: true },
     {
-      launchPersistentContext: () => _bootstrapStubResult(async () => { closed += 1; }),
+      launchPersistentContext: () => _bootstrapStubResult(() => { closed += 1; }),
       printResult: () => undefined,
       waitForKeepOpenExit: () => { waited = true; }
     }

--- a/scripts/provider_ui/provider_admin_bootstrap.test.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.test.mjs
@@ -27,19 +27,19 @@ import {
 // =============================================================================
 
 test('ensureManagedStatePath returns absolute path under the state root', () => {
-  const root = path.resolve('/tmp/state');
+  const root = path.resolve('/qzp-fixture/state');
   const target = path.join(root, 'profile');
   const got = ensureManagedStatePath(target, root);
   assert.equal(got, path.resolve(target));
 });
 
 test('ensureManagedStatePath rejects sibling escape', () => {
-  const root = path.resolve('/tmp/state');
-  assert.throws(() => ensureManagedStatePath('/tmp/elsewhere', root), /managed state root/);
+  const root = path.resolve('/qzp-fixture/state');
+  assert.throws(() => ensureManagedStatePath('/qzp-fixture/elsewhere', root), /managed state root/);
 });
 
 test('ensureManagedStatePath rejects parent traversal', () => {
-  const root = path.resolve('/tmp/state');
+  const root = path.resolve('/qzp-fixture/state');
   assert.throws(
     () => ensureManagedStatePath(path.join(root, '..', 'evil'), root),
     /managed state root/
@@ -89,19 +89,19 @@ test('loadPlaywrightChromium throws when QUALITY_ZERO_PROVIDER_UI_RUNNER_DIR is 
 // =============================================================================
 
 test('isCliEntrypoint matches when argv[1] resolves to the import URL', () => {
-  const target = path.resolve('/tmp/some-script.mjs');
+  const target = path.resolve('/qzp-fixture/some-script.mjs');
   const url = pathToFileURL(target).href;
   assert.equal(isCliEntrypoint(url, ['node', target]), true);
 });
 
 test('isCliEntrypoint rejects when argv[1] is a different file', () => {
-  const target = path.resolve('/tmp/script.mjs');
-  const otherUrl = pathToFileURL(path.resolve('/tmp/other.mjs')).href;
+  const target = path.resolve('/qzp-fixture/script.mjs');
+  const otherUrl = pathToFileURL(path.resolve('/qzp-fixture/other.mjs')).href;
   assert.equal(isCliEntrypoint(otherUrl, ['node', target]), false);
 });
 
 test('isCliEntrypoint returns false when argv[1] is missing', () => {
-  const url = pathToFileURL(path.resolve('/tmp/script.mjs')).href;
+  const url = pathToFileURL(path.resolve('/qzp-fixture/script.mjs')).href;
   assert.equal(isCliEntrypoint(url, ['node']), false);
 });
 
@@ -124,14 +124,14 @@ test('promptForManualLogin writes guidance and waits for Enter', async () => {
 
   await promptForManualLogin(
     { label: 'Codecov', targetUrl: 'https://example.com', loginHint: 'Press something.' },
-    '/tmp/profile',
+    '/qzp-fixture/profile',
     { readline: readlineModule, input: inputStream, output: outputStream }
   );
 
   assert.equal(closed, true);
   assert.match(writes.join(''), /Manual login handoff for Codecov/);
   assert.match(writes.join(''), /https:\/\/example\.com/);
-  assert.match(writes.join(''), /\/tmp\/profile/);
+  assert.match(writes.join(''), /\/qzp-fixture\/profile/);
   assert.match(writes.join(''), /Press something/);
   assert.match(questionAsked, /press Enter to continue/);
 });
@@ -148,7 +148,7 @@ test('launchContextWithFallback uses msedge channel on win32', async () => {
       return { ctx: 'edge' };
     }
   };
-  const ctx = await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'win32');
+  const ctx = await launchContextWithFallback(chromium, '/qzp-fixture/profile', { headless: true }, 'win32');
   assert.deepEqual(ctx, { ctx: 'edge' });
   assert.equal(calls[0].options.channel, 'msedge');
   assert.equal(calls[0].options.headless, true);
@@ -162,7 +162,7 @@ test('launchContextWithFallback skips channel on non-win32', async () => {
       return { ctx: 'chromium' };
     }
   };
-  await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'linux');
+  await launchContextWithFallback(chromium, '/qzp-fixture/profile', { headless: true }, 'linux');
   assert.equal(calls[0].options.channel, undefined);
 });
 
@@ -177,7 +177,7 @@ test('launchContextWithFallback retries without channel on win32 launch failure'
       return { ctx: 'fallback-chromium' };
     }
   };
-  const ctx = await launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'win32');
+  const ctx = await launchContextWithFallback(chromium, '/qzp-fixture/profile', { headless: true }, 'win32');
   assert.deepEqual(ctx, { ctx: 'fallback-chromium' });
   assert.equal(calls.length, 2);
   assert.equal(calls[0].options.channel, 'msedge');
@@ -189,7 +189,7 @@ test('launchContextWithFallback re-throws on non-win32 launch failure', async ()
     launchPersistentContext: () => { throw new Error('boom'); }
   };
   await assert.rejects(
-    launchContextWithFallback(chromium, '/tmp/profile', { headless: true }, 'linux'),
+    launchContextWithFallback(chromium, '/qzp-fixture/profile', { headless: true }, 'linux'),
     /boom/
   );
 });
@@ -203,8 +203,8 @@ function _stubArgs() {
     provider: 'chromatic',
     repo: 'org/repo',
     owner: 'org',
-    profileDir: path.resolve('/tmp/state/profile'),
-    stateRoot: path.resolve('/tmp/state'),
+    profileDir: path.resolve('/qzp-fixture/state/profile'),
+    stateRoot: path.resolve('/qzp-fixture/state'),
     headless: undefined,
     slowMoMs: 0,
     timeoutMs: 1000
@@ -246,7 +246,7 @@ test('launchPersistentContext walks the launch path and skips manual prompt when
   assert.equal(result.headless, true);
   assert.equal(result.title, 'Test Title');
   assert.equal(result.finalUrl, 'https://final.example.com');
-  assert.deepEqual(calls.map((c) => c.dir ?? c), [path.resolve('/tmp/state/profile')]);
+  assert.deepEqual(calls.map((c) => c.dir ?? c), [path.resolve('/qzp-fixture/state/profile')]);
 });
 
 test('launchPersistentContext invokes manual prompt when requested', async () => {
@@ -602,15 +602,15 @@ test('loadPlaywrightChromium reads runner dir env and resolves chromium via inje
   const stubChromium = { tag: 'stub-chromium' };
   const stubPlaywright = { chromium: stubChromium };
   const got = await loadPlaywrightChromium({
-    runnerDir: '/tmp/runner',
+    runnerDir: '/qzp-fixture/runner',
     createRequire: () => ({
       resolve: (id) => {
         assert.equal(id, 'playwright');
-        return '/tmp/runner/node_modules/playwright/index.js';
+        return '/qzp-fixture/runner/node_modules/playwright/index.js';
       }
     }),
     importModule: (href) => {
-      assert.match(href, /\/tmp\/runner\/node_modules\/playwright\/index\.js$/);
+      assert.match(href, /\/qzp-fixture\/runner\/node_modules\/playwright\/index\.js$/);
       return stubPlaywright;
     }
   });

--- a/scripts/provider_ui/provider_admin_config.test.mjs
+++ b/scripts/provider_ui/provider_admin_config.test.mjs
@@ -143,12 +143,12 @@ test('parseArgs --state-root + --profile-dir resolve to absolute paths', () => {
     '-p',
     'codecov',
     '--state-root',
-    '/tmp/state',
+    '/qzp-fixture/state',
     '--profile-dir',
-    '/tmp/profile'
+    '/qzp-fixture/profile'
   ]);
-  assert.equal(args.stateRoot, path.resolve('/tmp/state'));
-  assert.equal(args.profileDir, path.resolve('/tmp/profile'));
+  assert.equal(args.stateRoot, path.resolve('/qzp-fixture/state'));
+  assert.equal(args.profileDir, path.resolve('/qzp-fixture/profile'));
 });
 
 test('parseArgs rejects non-positive --timeout-ms', () => {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,13 @@ sonar.python.coverage.reportPaths=coverage/platform-coverage.xml,coverage.xml
 # metric (sonar.sources=scripts indexes them, but no coverage data is
 # associated). The QZP self-profile coverage.command produces this file.
 sonar.javascript.lcov.reportPaths=coverage/provider_ui-lcov.info
+# scripts/provider_ui/*.test.mjs lives next to the source it tests, so by
+# default Sonar (which only sees sonar.sources=scripts) classifies it as
+# production code. Declaring the *.test.mjs glob as a test inclusion
+# keeps Sonar's new-code coverage metric honest — the test file lines
+# don't count as 'production lines to cover' (they execute every test
+# run, but they're the testers, not the testees).
+sonar.test.inclusions=scripts/**/*.test.mjs
 sonar.exclusions=generated/**,docs/admin/**
 
 # `tool.coverage.run.source` in pyproject.toml restricts coverage tracing to


### PR DESCRIPTION
## **User description**
## Summary

The `scripts/provider_ui/provider_admin_bootstrap.mjs` DI seam used the `deps.foo ?? defaultFoo` pattern across 7 public functions. Each `??` operator creates one branch per fallback that's only hit if the function is exercised both with **and** without injected deps. The "without deps" path calls the real Playwright/readline implementations — which unit tests can't drive — so the fallback branches (18 in total) sat permanently uncovered on QZP main.

Coverage 100 Gate has been firing on QZP main since PR #178/#182 wired `sonar.javascript.lcov.reportPaths`:
- `provider_ui`: line=99.88% (1615/1617), branch=93.81% (288/307)

This PR closes that gap.

## Changes

- **`scripts/provider_ui/provider_admin_bootstrap.mjs`**: introduced a module-level mutable `_internals` test seam. Public functions now use `(deps = _internals)` defaults and access `deps.foo` directly, collapsing 3+ `??` branches per function into a single default-parameter branch. `_internals` is exported so tests can mutate entries to exercise the no-deps path safely.
- **`scripts/provider_ui/provider_admin_bootstrap.test.mjs`**: added one test for the `case 'help'` fall-through that the existing "unrecognised commands" test missed.
- **`profiles/repos/quality-zero-platform.yml`**: added `--test-coverage-exclude='**/*.test.mjs'` to the coverage.command. Newer Node versions (≥22.10) exclude `*.test.*` from coverage by default, but older runners include them — explicit exclusion keeps the lcov surface deterministic across versions.

## Verified locally

```text
SF:scripts\provider_ui\provider_admin_bootstrap.mjs
BRF:60   BRH:60   LH:412   LF:412
SF:scripts\provider_ui\provider_admin_config.mjs
BRF:70   BRH:70   LH:378   LF:378
```

Combined: line=100% (790/790), branch=100% (130/130). All 44 tests pass.

## Test plan

- [ ] Coverage 100 Gate reports `provider_ui` at 100% line + 100% branch
- [ ] All existing `provider_admin_bootstrap.test.mjs` tests still pass
- [ ] New `runCommand prints help when command is "help"` test passes
- [ ] No regressions on `platform` coverage component

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored provider UI DI to use a module-level `_internals` seam and remove `??` fallbacks, reaching 100% line and branch coverage. Standardized coverage and Sonar settings (Node 22, lcov test-file exclude, and test-file classification) for consistent reports.

- **Refactors**
  - Switched to `(deps = _internals)` with direct `deps.foo`; exported and prefilled `_internals` for safe test swapping.
  - Removed `async` from `promptForManualLogin` and `_promptForManualLoginInner`; used `.finally()` and updated test stubs to return Promises or `undefined` as needed.
  - Added a `help` fall-through test and extracted `_runCommandHelpScenario`; renamed test paths from `/tmp/` to `/qzp-fixture/`.

- **Dependencies**
  - Repo profile: set `coverage.setup.node: '22'` and `--test-coverage-exclude='**/*.test.mjs'` for source-only lcov.
  - Fleet default: bumped `quality-zero-phase1-common` Node from 20 to 22 LTS.
  - Sonar: added `sonar.test.inclusions=scripts/**/*.test.mjs` so `*.test.mjs` are treated as tests, keeping new-code coverage accurate.

<sup>Written for commit dc87ae7fd6852592fad9e29be4d83434a707d001. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Keep provider UI coverage checks stable and exclude test files from the reported totals**

### What Changed
- The provider UI coverage run now excludes test files from the lcov report, so source coverage totals match what the gate expects.
- The shared CI profile now runs coverage with Node 22, which supports the coverage exclusion setting used by the provider UI checks.
- The provider UI CLI tests now cover the `help` command path as well as unknown commands.

### Impact
`✅ Fewer coverage gate failures`
`✅ Consistent provider_ui coverage totals`
`✅ Clearer CLI help coverage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=N3lytSqmE8HaC_okk4IY1tAx3jkiFi3zP1L-tFaOqQc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
