### PR TITLE
fix(codacy): disable deprecated TSLint+JSHint engines, ruff --fix I001/TC006

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -59,5 +59,6 @@ exclude_paths:
   - "profiles/**"
   - "docs/**"  # QZP v2 design doc + other long-form prose; not production code
   - ".beads/**"  # Agent context state files — long-form prose, not prod code
+  - ".claude/**"  # Claude Code plugin/skill markdown — agent prose, not product code
   - ".github/workflows/control-plane-admin.yml"
   - ".github/workflows/publish-admin-dashboard.yml"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,6 +2,20 @@
 engines:
   pylint:
     enabled: false   # disabled in PR 2 per §A.7; .pylintrc deleted in PR 4
+  # TSLint was officially deprecated in 2019 in favor of @typescript-eslint.
+  # Codacy still ships "TSLint (deprecated)" and emits 74 findings on the
+  # scripts/beads-*.ts files (object-literal-sort-keys, only-arrow-functions,
+  # no-magic-numbers, trailing-comma, typedef, max-file-line-count). Those
+  # rules are either already covered by ESLint+typescript-eslint or are
+  # stylistic noise the active rule set doesn't enforce. Disable so the
+  # active ESLint engine is the single source of truth for .ts findings.
+  tslint:
+    enabled: false
+  # JSHint is also deprecated (last release 2018; superseded by ESLint).
+  # Disable so the deprecated tool's stale single finding stops showing up
+  # alongside ESLint's modern coverage of the same files.
+  jshint:
+    enabled: false
   bandit:
     enabled: true
   semgrep:

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -69,6 +69,7 @@ def _normalized_branch_min_percent(raw_value: Any) -> float | None:
 # ``from scripts.quality.assert_coverage_100 import CoverageStats``.
 from scripts.quality.coverage_types import CoverageStats  # noqa: E402, F401
 
+
 @dataclass(frozen=True)
 class CoverageEvaluationRequest:
     """Describe the thresholds and source expectations for a coverage run."""

--- a/scripts/quality/build_admin_dashboard.py
+++ b/scripts/quality/build_admin_dashboard.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import
 
 import argparse
-import shutil
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Sequence, Set

--- a/scripts/quality/build_quality_rollup.py
+++ b/scripts/quality/build_quality_rollup.py
@@ -21,12 +21,12 @@ from typing import Any, Dict, List, Mapping
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from scripts.quality.common import utc_timestamp, write_report
 from scripts.quality.check_required_checks import (
     _collect_contexts,
     _evaluate_observed_context,
     _resolve_observed_context,
 )
+from scripts.quality.common import utc_timestamp, write_report
 from scripts.quality.severity_rollup import (
     classify_lanes,
     failing_lanes_to_gate_output,

--- a/scripts/quality/check_applitools_zero.py
+++ b/scripts/quality/check_applitools_zero.py
@@ -8,12 +8,11 @@ Checks: unresolved == 0 AND failed == 0. Exits 0 on pass, 1 on fail.
 """
 from __future__ import absolute_import
 
-from typing import List, Tuple
-
 import argparse
 import json
 import sys
 from pathlib import Path
+from typing import List, Tuple
 
 
 def _check_applitools(data: dict) -> Tuple[bool, int, int, int]:

--- a/scripts/quality/check_applitools_zero.py
+++ b/scripts/quality/check_applitools_zero.py
@@ -30,8 +30,14 @@ def _check_applitools(data: dict) -> Tuple[bool, int, int, int]:
 
 
 def main(argv: List[str] | None = None) -> int:
+    """Run the Applitools zero-regression gate from CLI args."""
     parser = argparse.ArgumentParser(description="Applitools zero-regression gate")
-    parser.add_argument("--json", required=True, dest="json_file", help="Path to Applitools JSON output")
+    parser.add_argument(
+        "--json",
+        required=True,
+        dest="json_file",
+        help="Path to Applitools JSON output",
+    )
     parser.add_argument("--out-json", default=None, help="Write JSON summary")
     parser.add_argument("--out-md", default=None, help="Write Markdown summary")
     args = parser.parse_args(argv)
@@ -59,7 +65,13 @@ def main(argv: List[str] | None = None) -> int:
 
     if args.out_md:
         status = "PASS" if passed else "FAIL"
-        md = f"# Applitools Zero\n\n**Status:** {status}\n**Total:** {total}\n**Unresolved:** {unresolved}\n**Failed:** {failed}\n"
+        md = (
+            f"# Applitools Zero\n\n"
+            f"**Status:** {status}\n"
+            f"**Total:** {total}\n"
+            f"**Unresolved:** {unresolved}\n"
+            f"**Failed:** {failed}\n"
+        )
         out_md = Path(args.out_md)
         out_md.parent.mkdir(parents=True, exist_ok=True)
         out_md.write_text(md, encoding="utf-8")

--- a/scripts/quality/check_chromatic_zero.py
+++ b/scripts/quality/check_chromatic_zero.py
@@ -8,12 +8,11 @@ Checks: accepted == total AND errored == 0. Exits 0 on pass, 1 on fail.
 """
 from __future__ import absolute_import
 
-from typing import List, Tuple
-
 import argparse
 import json
 import sys
 from pathlib import Path
+from typing import List, Tuple
 
 
 def _check_chromatic(data: dict) -> Tuple[bool, int, int, int]:

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -4,7 +4,13 @@
 # skipcq: PY-W2000 - retained for Codacy compatibility.
 from __future__ import absolute_import
 
-import argparse, json, os, sys, time, urllib.error, urllib.parse
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple
@@ -12,9 +18,8 @@ from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.quality import codacy_zero_helpers, codacy_zero_support
 from scripts.quality.common import utc_timestamp, write_report
-from scripts.quality import codacy_zero_support
-from scripts.quality import codacy_zero_helpers
 from scripts.security_helpers import load_json_https
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues", "issuesCount"}

--- a/scripts/quality/check_required_checks.py
+++ b/scripts/quality/check_required_checks.py
@@ -7,9 +7,8 @@ import argparse
 import os
 import sys
 import time
-from typing import Any, Dict, List, Mapping, Tuple
-
 from pathlib import Path
+from typing import Any, Dict, List, Mapping, Tuple
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/scripts/quality/codacy_zero_support.py
+++ b/scripts/quality/codacy_zero_support.py
@@ -2,9 +2,9 @@
 
 from __future__ import absolute_import
 
+import urllib.error
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, List, Tuple
-import urllib.error
 
 CodacyCandidateFn = Callable[..., Tuple[int | None, List[str], Exception | None, bool]]
 CodacyPendingFn = Callable[[Any, str], str | None]

--- a/scripts/quality/control_plane.py
+++ b/scripts/quality/control_plane.py
@@ -15,34 +15,65 @@ import yaml  # type: ignore[import-untyped]
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.quality import profile_contract_validation
 from scripts.quality.common import (
     _deep_merge as common_deep_merge,
+)
+from scripts.quality.common import (
     dedupe_strings,
 )
 from scripts.quality.control_plane_vendors import (
     finalize_vendors,
     normalize_visual_lane,
 )
-from scripts.quality import profile_contract_validation
+from scripts.quality.profile_normalization import (
+    infer_coverage_inputs as common_infer_coverage_inputs,
+)
+from scripts.quality.profile_normalization import (
+    merge_required_contexts as common_merge_required_contexts,
+)
 from scripts.quality.profile_normalization import (
     normalize_codeql as common_normalize_codeql,
-    normalize_deps as common_normalize_deps,
-    normalize_dependabot as common_normalize_dependabot,
-    infer_coverage_inputs as common_infer_coverage_inputs,
-    merge_required_contexts as common_merge_required_contexts,
+)
+from scripts.quality.profile_normalization import (
     normalize_codex_environment as common_normalize_codex_environment,
+)
+from scripts.quality.profile_normalization import (
     normalize_coverage as common_normalize_coverage,
+)
+from scripts.quality.profile_normalization import (
     normalize_coverage_assert_mode as common_normalize_coverage_assert_mode,
+)
+from scripts.quality.profile_normalization import (
     normalize_coverage_inputs as common_normalize_coverage_inputs,
+)
+from scripts.quality.profile_normalization import (
+    normalize_dependabot as common_normalize_dependabot,
+)
+from scripts.quality.profile_normalization import (
+    normalize_deps as common_normalize_deps,
+)
+from scripts.quality.profile_normalization import (
     normalize_issue_policy as common_normalize_issue_policy,
+)
+from scripts.quality.profile_normalization import (
     normalize_java_setup as common_normalize_java_setup,
+)
+from scripts.quality.profile_normalization import (
     normalize_mode as common_normalize_mode,
+)
+from scripts.quality.profile_normalization import (
     normalize_overrides as common_normalize_overrides,
+)
+from scripts.quality.profile_normalization import (
     normalize_profile_version as common_normalize_profile_version,
+)
+from scripts.quality.profile_normalization import (
     normalize_required_contexts as common_normalize_required_contexts,
+)
+from scripts.quality.profile_normalization import (
     normalize_scanners as common_normalize_scanners,
 )
-
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_INVENTORY_PATH = ROOT / "inventory" / "repos.yml"
@@ -161,7 +192,7 @@ def _normalize_java_setup(raw_java: Any) -> Dict[str, Any]:
 def _normalize_coverage_setup(raw_setup: Any) -> Dict[str, Any]:
     """Normalize the runtime setup block used by coverage gates."""
     coverage = common_normalize_coverage({"setup": raw_setup})
-    return cast(Dict[str, Any], coverage["setup"])
+    return cast("Dict[str, Any]", coverage["setup"])
 
 
 def _normalize_coverage_assert_mode(raw_assert_mode: Any) -> Dict[str, str]:
@@ -260,7 +291,7 @@ def _apply_inventory_overrides(
     """Apply inventory metadata to one merged repo profile."""
     if not isinstance(overrides, InventoryOverrides):
         overrides = InventoryOverrides(
-            repo_entry=cast(Dict[str, Any], overrides["repo_entry"]),
+            repo_entry=cast("Dict[str, Any]", overrides["repo_entry"]),
             repo_slug=str(overrides["repo_slug"]),
             profile_id=str(overrides["profile_id"]),
             stack_id=str(overrides["stack_id"]),

--- a/scripts/quality/control_plane_admin.py
+++ b/scripts/quality/control_plane_admin.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import
 
 import argparse
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-import sys
 from typing import Any, Dict
 
 import yaml  # type: ignore[import-untyped]

--- a/scripts/quality/export_profile.py
+++ b/scripts/quality/export_profile.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 import argparse
 import json
-from pathlib import Path, PurePosixPath
 import sys
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:

--- a/scripts/quality/generate_ruleset_payload.py
+++ b/scripts/quality/generate_ruleset_payload.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 import argparse
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/scripts/quality/normalize_coverage_for_qlty.py
+++ b/scripts/quality/normalize_coverage_for_qlty.py
@@ -4,13 +4,13 @@
 from __future__ import absolute_import
 
 import argparse
-from contextlib import contextmanager
 import json
 import os
-from pathlib import Path
 import re
 import shutil
 import sys
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Dict, Iterable, List
 
 from scripts.quality.coverage_paths import (

--- a/scripts/quality/profile_coverage_normalization.py
+++ b/scripts/quality/profile_coverage_normalization.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import
 
-from copy import deepcopy
 import re
+from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Sequence, Tuple
 
 from scripts.quality.string_helpers import dedupe_strings

--- a/scripts/quality/render_codex_prompt.py
+++ b/scripts/quality/render_codex_prompt.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import
 
 import argparse
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
-import sys
 from typing import Any, Dict, Iterable, List, cast
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
@@ -19,7 +19,6 @@ from scripts.quality.control_plane import (
     load_repo_profile,
 )
 from scripts.quality.known_issues import load_known_issues, qrv2_prompt_entries
-
 
 _KNOWN_ISSUES_ROOT = Path(__file__).resolve().parents[2] / "known-issues"
 
@@ -208,7 +207,7 @@ def _render_prompt(*args: object, **kwargs: object) -> str:
         raise TypeError(f"Missing required prompt field: {exc.args[0]}") from exc
     if not isinstance(artifacts_value, Iterable):
         raise TypeError("_render_prompt expects artifacts to be iterable")
-    artifacts = list(cast(Iterable[object], artifacts_value))
+    artifacts = list(cast("Iterable[object]", artifacts_value))
     if kwargs:
         raise TypeError(
             f"Unexpected _render_prompt parameters: {', '.join(sorted(kwargs))}"

--- a/scripts/quality/render_repo_baseline.py
+++ b/scripts/quality/render_repo_baseline.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import
 
 import argparse
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 from typing import Any, Dict
 
 import yaml  # type: ignore[import-untyped]

--- a/scripts/quality/rollup_v2/__main__.py
+++ b/scripts/quality/rollup_v2/__main__.py
@@ -1,12 +1,11 @@
 """CLI entrypoint for quality rollup v2 (per design §A.8 + Phase 13)."""
 from __future__ import absolute_import
 
-from typing import Dict, Tuple
-
 import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Dict, Tuple
 
 from scripts.quality.rollup_v2.pipeline import run_pipeline
 

--- a/scripts/quality/rollup_v2/dedup.py
+++ b/scripts/quality/rollup_v2/dedup.py
@@ -4,12 +4,12 @@ from __future__ import absolute_import
 from dataclasses import replace
 from typing import Dict, Iterable, List, cast
 
-from scripts.quality.rollup_v2.severity import max_severity
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     CATEGORY_GROUP_SECURITY,
     Finding,
 )
+from scripts.quality.rollup_v2.severity import max_severity
 
 
 def dedup(findings: Iterable[Finding]) -> List[Finding]:
@@ -43,7 +43,7 @@ def merge_corroborators(findings: List[Finding]) -> Finding:
     # protocol covering any frozen dataclass), so Sonar python:S5886 flags
     # the ``-> Finding`` return type as a downcast. The cast is a no-op at
     # runtime since ``primary`` is concretely a Finding.
-    return cast(Finding, replace(
+    return cast("Finding", replace(
         primary,
         severity=severity,
         corroboration="multi" if len(findings) >= 2 else "single",

--- a/scripts/quality/rollup_v2/llm_fallback/cache_key.py
+++ b/scripts/quality/rollup_v2/llm_fallback/cache_key.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import hashlib
 
-
 _CONTEXT_WINDOW: int = 10  # lines before and after the finding line
 
 

--- a/scripts/quality/rollup_v2/normalizers/_base.py
+++ b/scripts/quality/rollup_v2/normalizers/_base.py
@@ -158,7 +158,7 @@ class BaseNormalizer(ABC):
         # (a protocol covering any frozen dataclass), so Sonar python:S5886
         # flags the ``-> Finding`` return type as a downcast. The cast is a
         # no-op at runtime since ``finding`` is concretely a Finding.
-        return cast(Finding, replace(
+        return cast("Finding", replace(
             finding,
             primary_message=redact_secrets(finding.primary_message),
             context_snippet=redact_secrets(finding.context_snippet),

--- a/scripts/quality/rollup_v2/normalizers/_sarif.py
+++ b/scripts/quality/rollup_v2/normalizers/_sarif.py
@@ -13,13 +13,13 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     CATEGORY_GROUP_SECURITY,
     CategoryGroup,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 MAX_SARIF_BYTES: int = 50 * 1024 * 1024  # 50 MB
 

--- a/scripts/quality/rollup_v2/normalizers/codacy.py
+++ b/scripts/quality/rollup_v2/normalizers/codacy.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     CATEGORY_GROUP_SECURITY,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 _SEVERITY_MAP = {
     "Error": "high",

--- a/scripts/quality/rollup_v2/normalizers/deepscan.py
+++ b/scripts/quality/rollup_v2/normalizers/deepscan.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 
 class DeepScanNormalizer(BaseNormalizer):

--- a/scripts/quality/rollup_v2/normalizers/deepsource.py
+++ b/scripts/quality/rollup_v2/normalizers/deepsource.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     CATEGORY_GROUP_SECURITY,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 _SEVERITY_MAP = {
     "CRITICAL": "high",

--- a/scripts/quality/rollup_v2/normalizers/qlty.py
+++ b/scripts/quality/rollup_v2/normalizers/qlty.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 _SEVERITY_MAP = {
     "critical": "critical",

--- a/scripts/quality/rollup_v2/normalizers/sonarcloud.py
+++ b/scripts/quality/rollup_v2/normalizers/sonarcloud.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
-from scripts.quality.rollup_v2.taxonomy import lookup
 from scripts.quality.rollup_v2.schema.finding import (
     CATEGORY_GROUP_QUALITY,
     CATEGORY_GROUP_SECURITY,
     Finding,
 )
+from scripts.quality.rollup_v2.taxonomy import lookup
 
 _SEVERITY_MAP = {
     "BLOCKER": "critical",

--- a/scripts/quality/rollup_v2/patches/__init__.py
+++ b/scripts/quality/rollup_v2/patches/__init__.py
@@ -1,13 +1,8 @@
 """Patch generator dispatcher (per design §A.1.4)."""
 from __future__ import absolute_import
 
-from typing import Dict
-
 from pathlib import Path
-
-from scripts.quality.rollup_v2.path_safety import PathEscapedRootError, validate_finding_file
-from scripts.quality.rollup_v2.schema.finding import Finding
-from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult
+from typing import Dict
 
 from scripts.quality.rollup_v2.patches import (
     assert_in_production,
@@ -42,6 +37,9 @@ from scripts.quality.rollup_v2.patches import (
     weak_crypto,
     wrong_import_order,
 )
+from scripts.quality.rollup_v2.path_safety import PathEscapedRootError, validate_finding_file
+from scripts.quality.rollup_v2.schema.finding import Finding
+from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult
 
 # Populated by Phase 9 tasks. 31 entries: 30 from §5.1 + 1 coverage-gap (Task 9.31).
 GENERATORS: Dict[str, object] = {

--- a/scripts/quality/rollup_v2/patches/wrong_import_order.py
+++ b/scripts/quality/rollup_v2/patches/wrong_import_order.py
@@ -1,10 +1,10 @@
 """Deterministic patch generator for `wrong-import-order` category."""
 from __future__ import absolute_import
-from typing import List, Optional, Tuple
 
 import difflib
 import re
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from scripts.quality.rollup_v2.schema.finding import Finding
 from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult

--- a/scripts/quality/rollup_v2/pipeline.py
+++ b/scripts/quality/rollup_v2/pipeline.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Dict, List
 
+from scripts.quality.rollup_v2 import patches as patch_dispatcher
 from scripts.quality.rollup_v2.dedup import assign_stable_ids, dedup
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, NormalizerResult
 from scripts.quality.rollup_v2.normalizers.applitools import ApplitoolsNormalizer
@@ -25,7 +26,6 @@ from scripts.quality.rollup_v2.normalizers.secrets import SecretsNormalizer
 from scripts.quality.rollup_v2.normalizers.semgrep import SemgrepNormalizer
 from scripts.quality.rollup_v2.normalizers.sentry import SentryNormalizer
 from scripts.quality.rollup_v2.normalizers.sonarcloud import SonarCloudNormalizer
-from scripts.quality.rollup_v2 import patches as patch_dispatcher
 from scripts.quality.rollup_v2.renderer import render_markdown
 from scripts.quality.rollup_v2.schema.finding import Finding
 from scripts.quality.rollup_v2.schema.patch import PatchResult

--- a/scripts/quality/rollup_v2/renderer.py
+++ b/scripts/quality/rollup_v2/renderer.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from typing import Any, Dict, List, Sequence, Tuple
 
 from scripts.quality.rollup_v2.redaction import redact_secrets
-from scripts.quality.rollup_v2.severity import SEVERITY_ORDER
 from scripts.quality.rollup_v2.schema.finding import Finding
+from scripts.quality.rollup_v2.severity import SEVERITY_ORDER
 
 # --- Truncation thresholds (§A.1.2 + §B.3.9 + §B.3.15) ---
 _MAX_VISIBLE_FILES: int = 20

--- a/scripts/quality/rollup_v2/validate_workflow_paths.py
+++ b/scripts/quality/rollup_v2/validate_workflow_paths.py
@@ -11,11 +11,10 @@ Usage:
 """
 from __future__ import absolute_import
 
-from typing import List
-
 import argparse
 import sys
 from pathlib import Path
+from typing import List
 
 from scripts.quality.rollup_v2.path_safety import PathEscapedRootError, validate_finding_file
 

--- a/scripts/quality/rollup_v2/verify_action_pins.py
+++ b/scripts/quality/rollup_v2/verify_action_pins.py
@@ -12,12 +12,11 @@ Usage:
 """
 from __future__ import absolute_import
 
-from typing import Dict, List
-
 import argparse
 import re
 import sys
 from pathlib import Path
+from typing import Dict, List
 
 # First-party / GitHub-maintained action owners exempt from SHA pinning.
 # actions/* = GitHub first-party (checkout, setup-python, upload-artifact, etc.)

--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -9,8 +9,8 @@ import os
 import subprocess  # nosec B404
 import sys
 import zipfile
-from io import BytesIO
 from contextlib import contextmanager
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
@@ -45,7 +45,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _coverage_mode(coverage: Dict[str, Any], event_name: str) -> str:
     """Handle coverage mode."""
-    assert_mode = cast(Dict[str, Any], coverage.get("assert_mode", {}))
+    assert_mode = cast("Dict[str, Any]", coverage.get("assert_mode", {}))
     if event_name in assert_mode:
         return str(assert_mode[event_name])
     return str(assert_mode.get("default", "enforce"))
@@ -113,10 +113,10 @@ def _build_assert_coverage_argv(
 ) -> List[str]:
     """Handle build assert coverage argv."""
     cmd = [str(platform_dir / "scripts" / "quality" / "assert_coverage_100.py")]
-    for item in cast(List[Dict[str, Any]], coverage.get("inputs", [])):
+    for item in cast("List[Dict[str, Any]]", coverage.get("inputs", [])):
         flag = "--xml" if item.get("format") == "xml" else "--lcov"
         cmd.extend([flag, f"{item['name']}={item['path']}"])
-    for item in cast(List[Any], coverage.get("require_sources", [])):
+    for item in cast("List[Any]", coverage.get("require_sources", [])):
         cmd.extend(["--require-source", str(item)])
     cmd.extend(["--min-percent", str(coverage.get("min_percent", 100.0))])
     if coverage.get("branch_min_percent") is not None:
@@ -370,7 +370,7 @@ def main() -> int:
         if args.platform_dir
         else Path(__file__).resolve().parents[2]
     )
-    coverage = cast(Dict[str, Any], profile.get("coverage", {}))
+    coverage = cast("Dict[str, Any]", profile.get("coverage", {}))
 
     _run_shell(
         str(coverage.get("command", "")),
@@ -390,7 +390,7 @@ def main() -> int:
             coverage, repo_dir=repo_dir, platform_dir=platform_dir
         )
         baseline_payload = _load_baseline_coverage_payload(
-            cast(Dict[str, Any], profile)
+            cast("Dict[str, Any]", profile)
         )
         return _write_non_regression_report(current_payload, baseline_payload)
 

--- a/scripts/quality/run_quality_zero_gate.py
+++ b/scripts/quality/run_quality_zero_gate.py
@@ -134,7 +134,7 @@ def main() -> int:
         else Path(__file__).resolve().parents[2]
     )
     argv = _build_argv(
-        cast(Dict[str, Any], profile),
+        cast("Dict[str, Any]", profile),
         sha,
         platform_dir=platform_dir,
         out_json=args.out_json,

--- a/scripts/quality/validate_control_plane.py
+++ b/scripts/quality/validate_control_plane.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 import argparse
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import List
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -2,12 +2,12 @@
 
 from __future__ import absolute_import
 
-from dataclasses import dataclass
-from http.client import HTTPConnection, HTTPS_PORT
 import ipaddress
 import json
 import ssl
-from typing import Any, cast, Dict, List, Mapping, Set, Tuple
+from dataclasses import dataclass
+from http.client import HTTPS_PORT, HTTPConnection
+from typing import Any, Dict, List, Mapping, Set, Tuple, cast
 from urllib.error import HTTPError
 from urllib.parse import ParseResult, urlparse, urlunparse
 
@@ -168,7 +168,7 @@ def _require_request_hostname(parsed: ParseResult) -> str:
     """Handle require request hostname."""
     if not parsed.hostname:
         raise ValueError(f"Request URL is missing a hostname: {urlunparse(parsed)!r}")
-    return cast(str, parsed.hostname)
+    return cast("str", parsed.hostname)
 
 
 def _build_tls_context() -> ssl.SSLContext:


### PR DESCRIPTION
## **User description**
## Summary

Codacy main reports 608 open issues. This PR clears ~123 of them via two deprecated-tool disables and a Ruff auto-fix pass.

| Tool | Issue type | Count | Action |
|---|---|---|---|
| TSLint (deprecated) | object-literal-sort-keys, only-arrow-functions, no-magic-numbers, trailing-comma, typedef, max-file-line-count | 74 | Disable engine — TSLint deprecated 2019, replaced by @typescript-eslint |
| JSHint (deprecated) | stale single finding | 1 | Disable engine — superseded by ESLint |
| Ruff I001 | unsorted-imports | 36 | `ruff check scripts/ --select I001 --fix` |
| Ruff TC006 | runtime-cast-value | 12 | `ruff check scripts/ --select TC006 --fix` |

## Changes

- **`.codacy.yaml`**: `tslint: enabled: false` and `jshint: enabled: false` block lines added with rationale.
- **scripts/**\: 35 files re-sorted imports + typing.cast string-form fixups, no behavioral changes.

## Verified locally

- `python -m unittest discover` — 1477/1477 pass, 1 skip.

## Remaining (after this PR merges)

Estimated ~485 issues left, breaking down roughly as:

- 35x markdownlint MD032 (lists need blank lines)
- 16x markdownlint MD036 (italics for emphasis)
- 24x ESLint8 es-x_no-block-scoped-variables
- 14x Lizard ccn-medium / 10x nloc-medium (real complexity)
- Smaller Pylint, Prospector, ShellCheck, Bandit, Checkov tails

## Test plan

- [ ] All 1477 tests pass
- [ ] Codacy reports ~485 issues post-merge (down from 608)
- [ ] No new findings introduced by the import re-sorts

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable deprecated Codacy `tslint` and `jshint` engines, exclude `.claude/**` from analysis, and apply `ruff` autofixes (I001, TC006) to remove ~123 noisy findings with no behavior changes.

- **Bug Fixes**
  - `.codacy.yaml`: disabled `tslint` and `jshint`; excluded `.claude/**` to avoid markdownlint noise on plugin prose.
  - Ran `ruff check scripts/ --select I001,TC006 --fix` to sort imports and switch `typing.cast` to string-literal types across `scripts/quality/*` and `scripts/security_helpers.py`.
  - `scripts/quality/check_applitools_zero.py`: added `main()` docstring and wrapped a long Markdown f-string to satisfy DeepSource.

<sup>Written for commit 512f234c89bf541aa66df82c1f234fd64cc6cea3. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reduce Codacy noise from deprecated engines and agent prose**

### What Changed
- Codacy no longer reports findings from the deprecated TSLint and JSHint engines, removing stale issues that were already covered elsewhere or no longer relevant.
- Files under `.claude/**` are excluded from analysis, so agent-generated markdown does not create extra review noise.
- Several quality scripts were cleaned up to keep their imports and type handling consistent; this does not change their output.

### Impact
`✅ Fewer false-positive Codacy issues`
`✅ Cleaner quality reports`
`✅ Less review noise from generated prose`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=fJmQX_w85eOkMZyjTvnZiKe8IOa_37JB13I9ykuvPBg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
