### PR TITLE
fix(sonar): _CoverageMapping alias eliminates 3x "Dict[str, Any]" S1192 smell

### DIFF
--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -14,6 +14,13 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
+# Type alias used by the three ``cast`` call sites below. Sonar's
+# python:S1192 flags the bare string form ``cast(_CoverageMapping, ...)``
+# (introduced by ruff TC006 auto-fix) as a duplicate-literal smell once
+# it appears 3+ times. Defining the alias once eliminates the repeated
+# string literal while keeping ``cast`` happy.
+_CoverageMapping = Dict[str, Any]
+
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # pragma: no cover
 
@@ -45,7 +52,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _coverage_mode(coverage: Dict[str, Any], event_name: str) -> str:
     """Handle coverage mode."""
-    assert_mode = cast("Dict[str, Any]", coverage.get("assert_mode", {}))
+    assert_mode = cast(_CoverageMapping, coverage.get("assert_mode", {}))
     if event_name in assert_mode:
         return str(assert_mode[event_name])
     return str(assert_mode.get("default", "enforce"))
@@ -370,7 +377,7 @@ def main() -> int:
         if args.platform_dir
         else Path(__file__).resolve().parents[2]
     )
-    coverage = cast("Dict[str, Any]", profile.get("coverage", {}))
+    coverage = cast(_CoverageMapping, profile.get("coverage", {}))
 
     _run_shell(
         str(coverage.get("command", "")),
@@ -390,7 +397,7 @@ def main() -> int:
             coverage, repo_dir=repo_dir, platform_dir=platform_dir
         )
         baseline_payload = _load_baseline_coverage_payload(
-            cast("Dict[str, Any]", profile)
+            cast(_CoverageMapping, profile)
         )
         return _write_non_regression_report(current_payload, baseline_payload)
 


### PR DESCRIPTION
## **User description**
## Summary

QZP main shows 1 lingering Sonar code smell after #183/#185/#186 cleared the rest:

```
[python:S1192] scripts/quality/run_coverage_gate.py:48 -
Define a constant instead of duplicating this literal "Dict[str, Any]" 3 times.
```

Origin: ruff TC006 auto-fix in PR #185 converted three `cast(Dict[str, Any], ...)` calls to the string form `cast("Dict[str, Any]", ...)` for forward-reference safety. The string then trips Sonar's duplicate-literal detector once it appears 3+ times.

## Changes

- **scripts/quality/run_coverage_gate.py**: introduce `_CoverageMapping = Dict[str, Any]` alias and replace the three `cast("Dict[str, Any]", ...)` calls with `cast(_CoverageMapping, ...)`.

## Verified locally

- 1477/1477 tests pass.

## Test plan

- [ ] Sonar main reports 0 code smells post-merge (was 1)
- [ ] All gates remain green

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Define `_CoverageMapping = Dict[str, Any]` and replace three `cast("Dict[str, Any]", ...)` calls in `scripts/quality/run_coverage_gate.py`. This removes the duplicated string literal and clears the Sonar `python:S1192` code smell while preserving type safety.

<sup>Written for commit d373197b06143e6117bdd3f6b258940f7eace1c5. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Remove a duplicate Sonar warning from the coverage gate script

### What Changed
- Replaced repeated `Dict[str, Any]` cast text with a shared alias in the coverage gate script
- Kept coverage collection and gate checks unchanged
- Cleared the Sonar duplicate-literal warning caused by the same text appearing three times

### Impact
`✅ Fewer Sonar code smells`
`✅ Cleaner coverage gate checks`
`✅ No change to coverage enforcement`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=qbomFqNeMoAs-3sBtYFYPBCRoenfvXZ5btbGKhc47ds&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
