### PR TITLE
fix(codacy): move beads-*.ts exclusion to top-level exclude_paths (engines.eslint.exclude_paths is silently ignored)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -16,21 +16,13 @@ engines:
   # alongside ESLint's modern coverage of the same files.
   jshint:
     enabled: false
-  # Codacy's default ESLint config bundles eslint-plugin-es-x rules
-  # (es-x_no-block-scoped-variables, es-x_no-trailing-commas,
-  # es-x_no-keyword-properties, es-x_no-arrow-functions) that flag every
-  # `let`/`const`/arrow function as if the target runtime is ES5. The
-  # scripts/beads-*.ts files run via tsx on Node 22+ and legitimately
-  # use modern syntax (~150 ESLint findings on those 3 files alone).
-  # Pin ESLint to a modern config that targets ES2022+ so the es-x
-  # backwards-compat plugin stops generating noise; @typescript-eslint
-  # remains active for real TS code-quality issues.
+  # ESLint stays enabled with default config; the scripts/beads-*.ts
+  # exclusion moved to the top-level exclude_paths below (the
+  # engines.eslint.exclude_paths key isn't honored by Codacy's analyzer
+  # in practice — top-level scope is the only reliable mechanism for
+  # this).
   eslint:
     enabled: true
-    exclude_paths:
-      - "scripts/beads-fetch-conversation-history.ts"
-      - "scripts/beads-fetch-pr-comments.ts"
-      - "scripts/beads-self-reflect.ts"
   bandit:
     enabled: true
   semgrep:
@@ -77,3 +69,13 @@ exclude_paths:
   - ".claude/**"  # Claude Code plugin/skill markdown — agent prose, not product code
   - ".github/workflows/control-plane-admin.yml"
   - ".github/workflows/publish-admin-dashboard.yml"
+  # scripts/beads-*.ts run via tsx on Node 22+ and legitimately use ES2022+
+  # syntax (let/const/arrow functions/etc.). Codacy's default ESLint config
+  # bundles eslint-plugin-es-x rules that flag those constructs as ES5
+  # incompatible — generating ~150 noise findings on these 3 files. Plus
+  # the deprecated TSLint engine emits its own duplicate findings.
+  # Top-level exclude is the only reliable scope mechanism (the per-engine
+  # exclude_paths key under engines.eslint isn't honored in practice).
+  - "scripts/beads-fetch-conversation-history.ts"
+  - "scripts/beads-fetch-pr-comments.ts"
+  - "scripts/beads-self-reflect.ts"


### PR DESCRIPTION
## **User description**
## Summary

PR #186 added the 3 `scripts/beads-*.ts` files to `engines.eslint.exclude_paths` expecting Codacy's ESLint engine to skip them. **It didn't.**

Verified live on QZP main commit `1f8fbbe5` (post-#187): Codacy analyzed at 11:34:17 with the new config in place and still emitted ~150 ESLint findings in `beads-self-reflect.ts` (es-x_no-modules, @lwc_no-async-await, prefer-nullish-coalescing) plus 73 cached TSLint findings.

The per-engine `exclude_paths` key works for the `metric` engine (verified on Phase 1 modules) but apparently doesn't for ESLint. Top-level `exclude_paths` is the only reliable scope mechanism — same one already used for generated/, tests/, .beads/, .claude/, etc.

## Changes

- **`.codacy.yaml`**: move the 3 `scripts/beads-*.ts` files from `engines.eslint.exclude_paths` to top-level `exclude_paths`. Comment documents why per-engine exclude was abandoned.

## Expected impact

- QZP Codacy: **348 → ~180** (eliminates ~150 ESLint + ~18 TSLint/JSHint cached findings on the 3 beads-*.ts files)
- All 5 ALL ENGINES skip the 3 files; tradeoff is acceptable since they're plugin scripts vendored from the metaswarm plugin (not actively maintained QZP product code).

## Test plan

- [ ] Codacy reanalyzes post-merge and reports ~180 issues
- [ ] No source code change; existing tests + builds still pass

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make Codacy reliably skip `scripts/beads-*.ts` by moving their exclusion to top-level `exclude_paths`, since the ESLint engine’s per-engine exclude was ignored. This reduces noisy lint findings and keeps reports focused on product code.

- **Bug Fixes**
  - Update `.codacy.yaml` to exclude the three `scripts/beads-*.ts` files at the top level, with a note explaining why.
  - Applies to all engines; expected issue count drops from ~348 to ~180 after reanalysis.

<sup>Written for commit fb152d8150ca1b3897b6e82ed1078a1266b05bcb. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration to optimize how linting rules are applied across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Stop Codacy from reporting lint issues on the beads helper scripts**

### What Changed
- The three `scripts/beads-*.ts` files are now excluded at the top level, so Codacy skips them reliably.
- These files no longer depend on the ESLint-specific exclusion setting, which was not taking effect.
- Codacy reports should no longer include the large block of lint findings from these helper scripts.

### Impact
`✅ Fewer false lint findings`
`✅ Cleaner Codacy reports`
`✅ Less noise on helper scripts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=IZdKg4lxwFDaMXpYjfYAvtjyWJ6QdSphGlLFcxWbzaE&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
