### PR TITLE
fix(codacy): ruff --fix batch 2 (UP017 datetime-timezone-utc + TC006)

### DIFF
--- a/scripts/quality/alert_dispatch.py
+++ b/scripts/quality/alert_dispatch.py
@@ -132,7 +132,7 @@ def build_triggers_from_fleet_state(
 ) -> List[at.AlertTrigger]:
     """Run every detector over the aggregated fleet state."""
     today: dt.date = state.get("today", dt.date.today())
-    now: dt.datetime = state.get("now", dt.datetime.now(dt.timezone.utc))
+    now: dt.datetime = state.get("now", dt.datetime.now(dt.UTC))
 
     triggers: List[at.AlertTrigger] = []
     for profile_entry in state.get("profiles", []):

--- a/scripts/quality/bypass_labels.py
+++ b/scripts/quality/bypass_labels.py
@@ -23,7 +23,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -88,7 +88,7 @@ def extract_incident_id(pr_body: str) -> Optional[str]:
 def _utc_iso_now() -> str:
     """Current UTC timestamp in ISO-8601 with ``Z`` suffix."""
     return (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z")

--- a/scripts/quality/common.py
+++ b/scripts/quality/common.py
@@ -6,7 +6,7 @@ import json
 import sys
 from copy import deepcopy
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping
 
@@ -32,7 +32,7 @@ class ReportSpec:
 
 def utc_timestamp() -> str:
     """Handle utc timestamp."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def github_commit_status_payload(repo: str, sha: str, token: str) -> Dict[str, Any]:

--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -52,7 +52,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _coverage_mode(coverage: Dict[str, Any], event_name: str) -> str:
     """Handle coverage mode."""
-    assert_mode = cast(_CoverageMapping, coverage.get("assert_mode", {}))
+    assert_mode = cast("_CoverageMapping", coverage.get("assert_mode", {}))
     if event_name in assert_mode:
         return str(assert_mode[event_name])
     return str(assert_mode.get("default", "enforce"))
@@ -377,7 +377,7 @@ def main() -> int:
         if args.platform_dir
         else Path(__file__).resolve().parents[2]
     )
-    coverage = cast(_CoverageMapping, profile.get("coverage", {}))
+    coverage = cast("_CoverageMapping", profile.get("coverage", {}))
 
     _run_shell(
         str(coverage.get("command", "")),
@@ -397,7 +397,7 @@ def main() -> int:
             coverage, repo_dir=repo_dir, platform_dir=platform_dir
         )
         baseline_payload = _load_baseline_coverage_payload(
-            cast(_CoverageMapping, profile)
+            cast("_CoverageMapping", profile)
         )
         return _write_non_regression_report(current_payload, baseline_payload)
 

--- a/scripts/quality/secrets_sync.py
+++ b/scripts/quality/secrets_sync.py
@@ -44,7 +44,7 @@ SecretSetter = Callable[[str, str], "subprocess.CompletedProcess[str]"]
 
 def _utc_now_iso() -> str:
     """Return the current UTC time as ``YYYY-MM-DDTHH:MM:SSZ``."""
-    return dt.datetime.now(tz=dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.datetime.now(tz=dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def make_gh_secret_setter(


### PR DESCRIPTION
## **User description**
## Summary

After QZP Codacy reanalysis from #188 dropped the count from 348 → 124, the remaining tail surfaced. Round 2 of `ruff --fix` auto-fixes:

- **UP017** (4): `datetime.timezone.utc` → `datetime.UTC` (Python 3.11+ idiom)
- **TC006** (3): `cast()` string-form fixups

7 of 29 auto-fixable issues resolved. The remaining 22 (E402, E501, E702) need case-by-case manual review:
- E402 (8): module-import-not-at-top — usually `sys.path` insertion before imports
- E501 (5): line-too-long
- E702 (9): multiple-statements-on-one-line — mostly inline conditionals

Other rule families left are real refactoring tasks: Lizard ccn/nloc-medium (20), Pylint R0914/R0902 (8).

## Verified locally

- All 1477 tests pass.

## Test plan

- [ ] Codacy main reports ~117 issues post-merge (was 124)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Second batch of `ruff` auto-fixes to standardize UTC handling and clean up `typing.cast` usage in quality scripts, reducing Codacy warnings and aligning with Python 3.11 conventions.

- **Refactors**
  - Replaced `datetime.timezone.utc` with `datetime.UTC` in `scripts/quality/alert_dispatch.py`, `scripts/quality/bypass_labels.py`, `scripts/quality/common.py`, and `scripts/quality/secrets_sync.py`.
  - Switched to string-form `cast("_CoverageMapping", ...)` in three spots in `scripts/quality/run_coverage_gate.py`.

<sup>Written for commit 23f0c5f4d996e869dbfad76add223f7c38354568. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Use Python 3.11 UTC handling in quality scripts and clean up cast warnings**

### What Changed
- Quality scripts now use the modern UTC timezone helper when generating timestamps
- Coverage gate checks now use string-form type casts in a few places
- These updates keep the quality tools aligned with current Python conventions and reduce remaining Codacy warnings

### Impact
`✅ Fewer Codacy warnings`
`✅ Cleaner audit and coverage timestamps`
`✅ Less lint noise in quality scripts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=3aAXLIor3uZbtbEEQDIEP7_DYx_0iM3yaPhLm_0sxz8&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
