### PR TITLE
fix(codacy): exclude *.test.mjs from Lizard + nosec B105 on alert:secret-missing label

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -79,3 +79,10 @@ exclude_paths:
   - "scripts/beads-fetch-conversation-history.ts"
   - "scripts/beads-fetch-pr-comments.ts"
   - "scripts/beads-self-reflect.ts"
+  # Test files colocated with source. The QZP self-profile already marks
+  # these via sonar.test.inclusions, but Codacy uses its own test-pattern
+  # detection. Excluding here mirrors the convention from tests/** above
+  # and keeps Lizard's 500-line nloc threshold off legitimate test
+  # fixtures (the *.test.mjs files run every test and naturally grow as
+  # source is refactored).
+  - "scripts/**/*.test.mjs"

--- a/scripts/quality/alerts.py
+++ b/scripts/quality/alerts.py
@@ -75,7 +75,7 @@ class AlertType(enum.Enum):
     FLEET_BUMP_FAIL = "alert:fleet-bump-fail"
     REPO_NOT_PROFILED = "alert:repo-not-profiled"
     FLAG_MISSING = "alert:flag-missing"
-    SECRET_MISSING = "alert:secret-missing"
+    SECRET_MISSING = "alert:secret-missing"  # nosec B105 — issue label, not a credential
 
     @property
     def label(self) -> str:


### PR DESCRIPTION
## **User description**
## Summary

Post-#189 Codacy reanalysis surfaced two false positives:

1. **Lizard file-nloc-medium** on `scripts/provider_ui/provider_admin_bootstrap.test.mjs` (531 lines crossed the 500 threshold). Test files growing past 500 lines is normal as source is refactored.

2. **Bandit B105** (hardcoded password) on `alerts.py:78` SECRET_MISSING enum — string contains 'secret' so Bandit triggers, but it's actually a GitHub issue label name (`alert:secret-missing`), not a credential.

## Changes

- **`.codacy.yaml`**: add `scripts/**/*.test.mjs` to top-level `exclude_paths`. Mirrors the existing `tests/**` pattern. Sonar already classifies these via `sonar.test.inclusions`; Codacy/Lizard need the explicit exclusion.
- **`scripts/quality/alerts.py:78`**: inline `# nosec B105` with explanation comment on SECRET_MISSING enum.

## Test plan

- [ ] All 1477 tests pass
- [ ] Codacy main reports ~117 → ~116 issues post-merge

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Silences two Codacy false positives by excluding `*.test.mjs` from Lizard NLOC and adding `# nosec B105` for the `alert:secret-missing` label. This keeps CI quality checks focused on real issues.

- **Bug Fixes**
  - `.codacy.yaml`: add `scripts/**/*.test.mjs` to `exclude_paths` so Lizard ignores colocated test files over 500 lines.
  - `scripts/quality/alerts.py`: add `# nosec B105` to `SECRET_MISSING` enum to suppress Bandit’s hardcoded password false positive on the label `alert:secret-missing`.

<sup>Written for commit 3c60e754f23f29795afad0fbaf80557afbcd9a04. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Suppress two Codacy false positives in quality checks**

### What Changed
- Codacy now ignores `scripts/**/*.test.mjs` test files, so long test fixtures no longer trigger the 500-line warning
- The `alert:secret-missing` label is now exempted from a password scan false alarm, since it is a label name and not a secret
- These changes keep CI warnings focused on real code issues instead of test files and label text

### Impact
`✅ Fewer false Codacy alerts`
`✅ Cleaner quality reports`
`✅ Less noise from long test files`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=u0N8pXUD5WqotOiLgdfvIhFvDhDXjjd3yLQcYTQPEvM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
