### PR TITLE
fix(codacy): suppress Bandit/Ruff subprocess findings on git apply (~13 issues)

### DIFF
--- a/scripts/quality/rollup_v2/apply_deterministic_patches.py
+++ b/scripts/quality/rollup_v2/apply_deterministic_patches.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 import argparse
 import json
 import os
-import subprocess
+import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
@@ -64,12 +64,16 @@ def apply_single_patch(diff: str, repo_dir: Path) -> Dict[str, Any]:
         tmp_path = Path(tmp.name)
 
     try:
-        # Dry-run first
-        check_result = subprocess.run(
+        # Dry-run first.
+        # Safe by construction: shell=False (list argv), git is a trusted
+        # tool on PATH, args derived from the validated tmp_path. nosec/noqa
+        # silence Bandit B603/B607 + Ruff S603/S607 on this site.
+        check_result = subprocess.run(  # noqa: S603,S607  # nosec B603,B607
             ["git", "apply", "--check", str(tmp_path)],
             cwd=repo_dir,
             capture_output=True,
             text=True,
+            check=False,
         )
         if check_result.returncode != 0:
             return {
@@ -78,12 +82,13 @@ def apply_single_patch(diff: str, repo_dir: Path) -> Dict[str, Any]:
                 "reason": check_result.stderr.strip() or "git apply --check failed",
             }
 
-        # Apply for real
-        apply_result = subprocess.run(
+        # Apply for real (same safety analysis as the dry-run above).
+        apply_result = subprocess.run(  # noqa: S603,S607  # nosec B603,B607
             ["git", "apply", str(tmp_path)],
             cwd=repo_dir,
             capture_output=True,
             text=True,
+            check=False,
         )
         if apply_result.returncode != 0:
             return {


### PR DESCRIPTION
## **User description**
## Summary

Of QZP's 123 remaining Codacy issues, 13 are concentrated on the two `subprocess.run()` calls in `apply_deterministic_patches.py` (`git apply --check` + `git apply`). Each call trips 6 separate rules from 4 tools:
- Bandit B603 (subprocess without shell=True) + B607 (partial path)
- Ruff S603 (same) + S607 (same)
- Prospector pylint + PyLintPython3 W1510 (subprocess.run audit)

## Safety analysis

These calls are safe by construction:
- `shell=False` (default when first arg is a list)
- `git` is a trusted tool on PATH (every developer + CI runner has it)
- Args are derived from a validated `tmp_path` we just wrote
- The patches themselves came from validated `canonical.json` produced by rollup_v2

Per-line `# nosec B603,B607  # noqa: S603,S607` suppressions with a comment explaining the analysis. Module-level B404 nosec on the `import subprocess` line.

Also added explicit `check=False` (the rules' implicit ask).

## Verified locally

- All 1477 tests pass.

## Test plan

- [ ] Codacy main reports ~110 issues post-merge (was 123)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Suppresses Codacy Bandit/Ruff subprocess findings on `git apply` calls in `apply_deterministic_patches.py` (~13 issues). No functional changes.

- **Bug Fixes**
  - Added module-level `# nosec B404` on `import subprocess`.
  - Added per-call `# nosec B603,B607` and `# noqa: S603,S607` for safe `subprocess.run()` of `git apply` (shell=False, trusted `git`, validated temp path).
  - Set `check=False` on both calls to make intent explicit.
  - Expected Codacy count reduction: ~13 (from 123 to ~110).

<sup>Written for commit 16d97e34a320fe9c52ef55629be115af0d85c387. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Suppress false security warnings on safe `git apply` checks**

### What Changed
- Marked the `subprocess` import and both `git apply` calls as safe so Codacy no longer flags them.
- Added explicit `check=False` to both `git apply` runs to match the intended behavior.
- Kept the existing patch-apply flow unchanged: validate the patch first, then apply it, and skip it with a clear reason if either step fails.

### Impact
`✅ Fewer false security alerts`
`✅ Cleaner Codacy reports`
`✅ No change to patch application behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=FiVaOZkX6S3a9Ax3cr2vcTPfRd54SCTBnqNugAwmucg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
