### PR TITLE
fix(codacy): refactor 3 Lizard ccn-medium functions under threshold

### DIFF
--- a/scripts/quality/rollup_v2/normalizers/deepsource.py
+++ b/scripts/quality/rollup_v2/normalizers/deepsource.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable, Tuple
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
 from scripts.quality.rollup_v2.schema.finding import (
@@ -24,6 +24,14 @@ _SECURITY_CATEGORY_HINTS = frozenset({
 })
 
 
+def _resolve_location(issue: Dict[str, Any]) -> Tuple[str, int]:
+    """Pull ``(file_path, line_number)`` out of a DeepSource issue payload."""
+    location = issue.get("location") or {}
+    position = location.get("position") or {}
+    begin = position.get("begin") or {}
+    return str(location.get("path", "")), int(begin.get("line") or 1)
+
+
 class DeepSourceNormalizer(BaseNormalizer):
     provider = "DeepSource"
 
@@ -37,11 +45,7 @@ class DeepSourceNormalizer(BaseNormalizer):
                 if category in _SECURITY_CATEGORY_HINTS
                 else CATEGORY_GROUP_QUALITY
             )
-            location = issue.get("location") or {}
-            position = location.get("position") or {}
-            begin = position.get("begin") or {}
-            file_path = str(location.get("path", ""))
-            line = int(begin.get("line") or 1)
+            file_path, line = _resolve_location(issue)
             title = str(issue.get("title", ""))
             yield self._build_finding(FindingDraft(
                 finding_id=f"deepsource-{index:04d}",

--- a/scripts/quality/run_qlty_zero.py
+++ b/scripts/quality/run_qlty_zero.py
@@ -88,24 +88,35 @@ def _combine_output(stdout: str, stderr: str) -> str:
     return stdout_tail or stderr_tail
 
 
+def _extract_path_pattern(line: str) -> str | None:
+    """Pull the ``path = "..."`` value out of one ``[[smells.exclude]]`` line."""
+    match = re.match(r'path\s*=\s*"([^"]+)"', line)
+    return match.group(1) if match else None
+
+
+def _smells_exclude_lines(toml_path: Path) -> Iterable[str]:
+    """Yield stripped non-empty lines from qlty.toml (or empty if missing)."""
+    if not toml_path.is_file():
+        return ()
+    return (raw.strip() for raw in toml_path.read_text(encoding="utf-8").splitlines())
+
+
 def _load_smells_exclude_patterns(repo_dir: Path) -> List[str]:
     """Parse qlty.toml for smells.exclude path patterns."""
-    toml_path = repo_dir / ".qlty" / "qlty.toml"
-    if not toml_path.is_file():
-        return []
     patterns: List[str] = []
     in_smells_exclude = False
-    for line in toml_path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if stripped == "[[smells.exclude]]":
+    for line in _smells_exclude_lines(repo_dir / ".qlty" / "qlty.toml"):
+        if line == "[[smells.exclude]]":
             in_smells_exclude = True
             continue
-        if in_smells_exclude and stripped.startswith("path"):
-            match = re.match(r'path\s*=\s*"([^"]+)"', stripped)
-            if match:
-                patterns.append(match.group(1))
+        if not in_smells_exclude:
+            continue
+        if line.startswith("path"):
+            value = _extract_path_pattern(line)
+            if value is not None:
+                patterns.append(value)
             in_smells_exclude = False
-        elif stripped.startswith("[") and in_smells_exclude:
+        elif line.startswith("["):
             in_smells_exclude = False
     return patterns
 
@@ -209,6 +220,22 @@ def _run_qlty_smells(repo_dir: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _smells_lane_has_findings(
+    name: str,
+    output_tail: str,
+    smells_exclude_patterns: List[str] | None,
+) -> bool:
+    """Return whether the smells lane reports actionable findings."""
+    if name != "smells":
+        return False
+    target = (
+        _filter_smells_output(output_tail, smells_exclude_patterns)
+        if smells_exclude_patterns
+        else output_tail
+    )
+    return _smells_output_indicates_findings(target)
+
+
 def _build_check_entry(
     name: str,
     argv: List[str],
@@ -217,21 +244,13 @@ def _build_check_entry(
 ) -> Dict[str, Any]:
     """Handle build check entry."""
     output_tail = _combine_output(result.stdout or "", result.stderr or "")
-    status = "pass"
-    if name == "smells" and smells_exclude_patterns:
-        filtered = _filter_smells_output(output_tail, smells_exclude_patterns)
-        has_findings = _smells_output_indicates_findings(filtered)
-    elif name == "smells":
-        has_findings = _smells_output_indicates_findings(output_tail)
-    else:
-        has_findings = False
+    has_findings = _smells_lane_has_findings(name, output_tail, smells_exclude_patterns)
     # Combine the two fail conditions into a single test so Sonar's
     # python:S1871 doesn't flag the duplicate ``status = "fail"`` branches
     # — both routes ultimately mean "this lane failed".
     failed_check = int(result.returncode) != 0 and name != "smells"
     failed_smells = name == "smells" and has_findings
-    if failed_check or failed_smells:
-        status = "fail"
+    status = "fail" if (failed_check or failed_smells) else "pass"
     return {
         "name": name,
         "status": status,


### PR DESCRIPTION
## **User description**
## Summary

Bring three functions under qlty's CCN-medium threshold (8) via helper extraction. Real refactoring, not just config tweaks.

| Function | Before | After |
|---|---|---|
| `run_qlty_zero.py:_build_check_entry` | 10 | **7** ✅ |
| `run_qlty_zero.py:_load_smells_exclude_patterns` | 9 | **7** ✅ |
| `deepsource.py:DeepSourceNormalizer.parse` | 9 | **5** ✅ |

## Changes

- **`run_qlty_zero.py`**:
  - Extract `_smells_lane_has_findings()` from `_build_check_entry` to centralise the smells-lane detection (with/without exclude_patterns).
  - Extract `_smells_exclude_lines()` (file existence + lazy iteration) and `_extract_path_pattern()` (regex unpacking) from `_load_smells_exclude_patterns`. Main loop is now a flat state machine with single early-continue.

- **`deepsource.py`**:
  - Extract `_resolve_location()` to consolidate the `location.position.begin.line` drilldown into one helper.

## Verified locally

- All 1477 tests pass.
- `lizard -C 8` reports no findings on the modified files.

## Test plan

- [ ] Codacy main reports ~120 issues post-merge (was 123); 3 Lizard ccn-medium cleared.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored three functions to bring cyclomatic complexity under the Codacy/Lizard medium threshold (8) without changing behavior. This centralizes smells logic and simplifies parsing and location extraction.

- **Refactors**
  - `scripts/quality/run_qlty_zero.py`: Extracted `_smells_lane_has_findings()`, `_smells_exclude_lines()`, and `_extract_path_pattern()`; flattened `smells.exclude` parsing. CCN: `_build_check_entry` 10→7, `_load_smells_exclude_patterns` 9→7.
  - `scripts/quality/rollup_v2/normalizers/deepsource.py`: Extracted `_resolve_location()` and used it in `DeepSourceNormalizer.parse`. CCN: `parse` 9→5.

<sup>Written for commit e789531b90dcb7fda4539c44136794e75c226620. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Refactor DeepSource and qlty smells parsing without changing report results**

### What Changed
- Simplified how DeepSource issue locations are read, while keeping file and line output the same
- Simplified how qlty smells exclusions are read and how smells findings are checked, without changing which checks pass or fail
- Kept the same check status and output structure for existing runs

### Impact
`✅ Same scan results`
`✅ Same pass/fail behavior`
`✅ Easier maintenance for future fixes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=BlKKuemb3GDqet_daPMY_GZFihGgWryBbZ7IhDsDLVM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
