### PR TITLE
fix(codacy): refactor _find_import_block CCN 11→6

### DIFF
--- a/scripts/quality/rollup_v2/patches/wrong_import_order.py
+++ b/scripts/quality/rollup_v2/patches/wrong_import_order.py
@@ -50,6 +50,13 @@ def _classify_import(line: str) -> int:
     return 2  # Assume third-party (conservative)
 
 
+def _is_continuation_line(stripped: str, *, import_started: bool) -> bool:
+    """Return whether ``stripped`` is a blank/comment line we should keep walking."""
+    if stripped == "" and import_started:
+        return True
+    return stripped.startswith("#") and not import_started  # pragma: no cover
+
+
 def _find_import_block(lines: List[str]) -> Optional[Tuple[int, int]]:
     """Find the contiguous import block at the top of the file.
 
@@ -58,16 +65,14 @@ def _find_import_block(lines: List[str]) -> Optional[Tuple[int, int]]:
     import_start = None
     import_end = None
     for i, line in enumerate(lines):
-        stripped = line.strip()
         if _IMPORT_LINE.match(line):
             if import_start is None:
                 import_start = i
             import_end = i + 1
-        elif stripped == "" and import_start is not None:
             continue
-        elif stripped.startswith("#") and import_start is None:  # pragma: no cover -- leading comments before imports
+        if _is_continuation_line(line.strip(), import_started=import_start is not None):
             continue
-        elif import_start is not None:
+        if import_start is not None:
             break
     if import_start is None or import_end is None:
         return None


### PR DESCRIPTION
## **User description**
## Summary

`scripts/quality/rollup_v2/patches/wrong_import_order.py:_find_import_block` flagged at CCN 11 (highest in the Lizard ccn-medium tail; limit 8).

The complexity came from chained `elif` branches with conjoined conditions:

```python
elif stripped == "" and import_start is not None:
    continue
elif stripped.startswith("#") and import_start is None:
    continue
elif import_start is not None:
    break
```

## Changes

Extract the 'should we walk past this non-import line?' decision into `_is_continuation_line()`. Main loop becomes a flat 3-step check (import match / continuation / break).

## Verified locally

- `lizard -C 8 wrong_import_order.py` reports no findings (CCN 11 → 6)
- 1477 tests pass

## Test plan

- [ ] Codacy main reports ~119 issues post-merge (was ~120 after #192 reanalyzed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `_find_import_block` in `scripts/quality/rollup_v2/patches/wrong_import_order.py` to reduce cyclomatic complexity and clear the Codacy/Lizard warning. Behavior is unchanged; the loop logic is simpler and easier to read.

- **Refactors**
  - Added `_is_continuation_line(stripped, *, import_started)` to handle blank/comment line continuation.
  - Flattened main loop to: import match → continuation → break, reducing CCN 11 → 6.
  - Verified: `lizard -C 8` shows no findings; all 1477 tests pass.

<sup>Written for commit a844500565e23139b1f82d60caee4921e2c4ddad. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Simplify import-block detection in the Codacy patch script

### What Changed
- Refined how the script skips blank and comment lines while looking for the top import block
- Kept the import ordering behavior the same while making the scan logic easier to follow
- Reduced the chance of future maintenance issues in this import-fixing path

### Impact
`✅ Safer Codacy import fixes`
`✅ Easier maintenance of import-order checks`
`✅ Fewer regressions in patch behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=njEQarSC16Cnb3XZRtdO_HgcJvrhN7CccwBR2_jlxQY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
