### PR TITLE
fix(codacy): refactor 2 more Lizard ccn-medium normalizers (_sarif, dependabot)

### DIFF
--- a/scripts/quality/rollup_v2/normalizers/_sarif.py
+++ b/scripts/quality/rollup_v2/normalizers/_sarif.py
@@ -79,26 +79,30 @@ def _extract_cwe(result: Dict[str, Any]) -> str | None:
     return None
 
 
+def _safe_dict(value: Any) -> Dict[str, Any]:
+    """Return ``value`` if it's a dict; otherwise an empty dict."""
+    return value if isinstance(value, dict) else {}
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce ``value`` to ``int`` only if it's not ``None``."""
+    return int(value) if value is not None else None
+
+
 def _extract_location(result: Dict[str, Any]) -> Tuple[str, int, int | None, int | None]:
     """Extract (file, line, end_line, column) from the first SARIF location."""
     locations = result.get("locations", [])
     if not locations or not isinstance(locations, list):
         return ("unknown", 1, None, None)
-    loc = locations[0]
-    phys = loc.get("physicalLocation", {}) if isinstance(loc, dict) else {}
-    artifact_loc = phys.get("artifactLocation", {}) if isinstance(phys, dict) else {}
-    uri = str(artifact_loc.get("uri", "unknown")) if isinstance(artifact_loc, dict) else "unknown"
-    region = phys.get("region", {}) if isinstance(phys, dict) else {}
-    if not isinstance(region, dict):
-        region = {}
-    line = int(region.get("startLine", 1))
-    end_line = region.get("endLine")
-    if end_line is not None:
-        end_line = int(end_line)
-    column = region.get("startColumn")
-    if column is not None:
-        column = int(column)
-    return (uri, line, end_line, column)
+    phys = _safe_dict(_safe_dict(locations[0]).get("physicalLocation"))
+    artifact_loc = _safe_dict(phys.get("artifactLocation"))
+    region = _safe_dict(phys.get("region"))
+    return (
+        str(artifact_loc.get("uri", "unknown")),
+        int(region.get("startLine", 1)),
+        _coerce_optional_int(region.get("endLine")),
+        _coerce_optional_int(region.get("startColumn")),
+    )
 
 
 def _extract_context_snippet(result: Dict[str, Any]) -> str:

--- a/scripts/quality/rollup_v2/normalizers/dependabot.py
+++ b/scripts/quality/rollup_v2/normalizers/dependabot.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 from scripts.quality.rollup_v2.normalizers._base import BaseNormalizer, FindingDraft
 from scripts.quality.rollup_v2.schema.finding import (
@@ -19,6 +19,35 @@ _SEVERITY_MAP = {
 }
 
 
+def _dependabot_finding_draft(index: int, alert: Dict[str, Any]) -> FindingDraft:
+    """Convert one Dependabot alert payload into the canonical FindingDraft."""
+    advisory = alert.get("security_advisory") or {}
+    vulnerability = alert.get("security_vulnerability") or {}
+    dependency = alert.get("dependency") or {}
+    package_info = vulnerability.get("package") or {}
+    cwes = advisory.get("cwes") or []
+    summary = str(advisory.get("summary", ""))
+    package_name = str(package_info.get("name", "unknown"))
+    cwe_id = str(cwes[0].get("cwe_id", "")) if cwes else ""
+    return FindingDraft(
+        finding_id=f"deps-{index:04d}",
+        file=str(dependency.get("manifest_path", "")),
+        line=1,
+        category="vulnerable-dependency",
+        category_group=CATEGORY_GROUP_SECURITY,
+        severity=_SEVERITY_MAP.get(
+            str(vulnerability.get("severity", "medium")).lower(),
+            "medium",
+        ),
+        primary_message=f"{package_name}: {summary}",
+        rule_id=str(advisory.get("ghsa_id", "")),
+        rule_url=None,
+        original_message=summary,
+        context_snippet="",
+        cwe=cwe_id or None,
+    )
+
+
 class DependabotNormalizer(BaseNormalizer):
     """Normalize Dependabot alert artifacts into canonical Findings.
 
@@ -29,34 +58,5 @@ class DependabotNormalizer(BaseNormalizer):
     provider = "Dependabot"
 
     def parse(self, artifact: Any, repo_root: Path) -> Iterable[Finding]:
-        alerts = (artifact or {}).get("alerts", [])
-        for index, alert in enumerate(alerts):
-            advisory = alert.get("security_advisory") or {}
-            vulnerability = alert.get("security_vulnerability") or {}
-            dependency = alert.get("dependency") or {}
-
-            summary = str(advisory.get("summary", ""))
-            raw_severity = str(vulnerability.get("severity", "medium")).lower()
-            severity = _SEVERITY_MAP.get(raw_severity, "medium")
-
-            package_info = vulnerability.get("package") or {}
-            package_name = str(package_info.get("name", "unknown"))
-
-            manifest_path = str(dependency.get("manifest_path", ""))
-            cwes = advisory.get("cwes") or []
-            cwe = str(cwes[0].get("cwe_id", "")) if cwes else None
-
-            yield self._build_finding(FindingDraft(
-                finding_id=f"deps-{index:04d}",
-                file=manifest_path,
-                line=1,
-                category="vulnerable-dependency",
-                category_group=CATEGORY_GROUP_SECURITY,
-                severity=severity,
-                primary_message=f"{package_name}: {summary}",
-                rule_id=str(advisory.get("ghsa_id", "")),
-                rule_url=None,
-                original_message=summary,
-                context_snippet="",
-                cwe=cwe if cwe else None,
-            ))
+        for index, alert in enumerate((artifact or {}).get("alerts", [])):
+            yield self._build_finding(_dependabot_finding_draft(index, alert))


### PR DESCRIPTION
## Summary

Round 3 of Lizard CCN-medium refactor — two normalizer parse paths:

| Function | Before | After |
|---|---|---|
| `_sarif.py:_extract_location` | 10 | **~6** ✅ |
| `dependabot.py:DependabotNormalizer.parse` | 10 | **2** ✅ |

## Changes

- **`_sarif.py`**: extract `_safe_dict()` + `_coerce_optional_int()` helpers. Original was a tower of `isinstance()` guards on nested SARIF structure walks; helpers concentrate the type-coercion. Main path is now a flat 5-line return tuple.

- **`dependabot.py`**: extract `_dependabot_finding_draft()` with all the `.get` drilldown (advisory/vulnerability/dependency/package/cwes). The `parse` method is now a 2-line generator that delegates to the draft builder.

## Verified locally

- All 1477 tests pass.
- `lizard -C 8` reports no findings on both files.

## Test plan

- [ ] Codacy main reports ~108 issues post-merge (was ~111)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `_sarif._extract_location` (10→~6) and `DependabotNormalizer.parse` (10→2) to lower CCN and simplify parsing. Behavior unchanged.

- **Refactors**
  - `_sarif.py`: extracted `_safe_dict()` and `_coerce_optional_int()` to centralize type coercion; main path is now a flat return tuple.
  - `dependabot.py`: extracted `_dependabot_finding_draft()` to build the draft; `parse` now yields via this helper.

<sup>Written for commit b0fc6f87fe5b0ca9154ff385a03bc70cbeb4e7f4. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

