### PR TITLE
fix(codacy): refactor check_quality_secrets.main CCN 10→3

### DIFF
--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -180,19 +180,32 @@ def open_secret_missing_alerts(
     return results
 
 
+def _build_payload_from_args(args: argparse.Namespace) -> Dict[str, Any]:
+    """Dedupe each *_secret/*_var argv list and build the report payload."""
+    return _build_payload(
+        required_secrets=dedupe_strings(args.required_secret or []),
+        conditional_secrets=dedupe_strings(args.conditional_secret or []),
+        required_vars=dedupe_strings(args.required_var or []),
+        conditional_vars=dedupe_strings(args.conditional_var or []),
+    )
+
+
+def _maybe_open_missing_alerts(args: argparse.Namespace, payload: Dict[str, Any]) -> None:
+    """Fire alert:secret-missing for each missing secret if --open-alerts is set."""
+    if not (args.open_alerts and payload["missing_secrets"]):
+        return
+    open_secret_missing_alerts(
+        platform_slug=args.platform_slug,
+        target_repo_slug=args.target_repo_slug or args.platform_slug,
+        missing_secrets=payload["missing_secrets"],
+        dry_run=args.dry_run_alerts,
+    )
+
+
 def main() -> int:
     """Handle main."""
     args = _parse_args()
-    required_secrets = dedupe_strings(args.required_secret or [])
-    conditional_secrets = dedupe_strings(args.conditional_secret or [])
-    required_vars = dedupe_strings(args.required_var or [])
-    conditional_vars = dedupe_strings(args.conditional_var or [])
-    payload = _build_payload(
-        required_secrets=required_secrets,
-        conditional_secrets=conditional_secrets,
-        required_vars=required_vars,
-        conditional_vars=conditional_vars,
-    )
+    payload = _build_payload_from_args(args)
     return_code = write_report(
         payload,
         out_json=args.out_json,
@@ -203,13 +216,7 @@ def main() -> int:
     )
     if return_code != 0:
         return return_code
-    if args.open_alerts and payload["missing_secrets"]:
-        open_secret_missing_alerts(
-            platform_slug=args.platform_slug,
-            target_repo_slug=args.target_repo_slug or args.platform_slug,
-            missing_secrets=payload["missing_secrets"],
-            dry_run=args.dry_run_alerts,
-        )
+    _maybe_open_missing_alerts(args, payload)
     return 0 if payload["status"] == "pass" else 1
 
 


### PR DESCRIPTION
## **User description**
## Summary

`scripts/quality/check_quality_secrets.py:main` flagged at CCN 10 (limit 8). Linear top-level CLI with 4 dedupe_strings calls + write_report + conditional alert fire + status-based return.

## Changes

- Extract `_build_payload_from_args()` (4 dedupe_strings calls + _build_payload assembly)
- Extract `_maybe_open_missing_alerts()` (the `if args.open_alerts and missing_secrets` block)

`main` is now linear: parse args → build payload → write report → maybe-fire-alerts → status-based return.

## Verified locally

- `lizard -C 8 check_quality_secrets.py` reports no findings (was 1 at main CCN 10).
- All 1477 tests pass.

## Test plan

- [ ] Codacy main reports ~107 issues post-merge (was ~108 after #194)


___

## **CodeAnt-AI Description**
**Simplify secret quality report handling without changing results**

### What Changed
- The script now prepares the secrets report in one step from the CLI inputs before writing it
- Missing-secret alerts are only sent when alerting is enabled and missing secrets exist
- Report output, alert behavior, and exit status stay the same

### Impact
`✅ Same secrets report output`
`✅ Same missing-secret alert behavior`
`✅ No change to CLI results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=yoB28xH0KJ4fSWUtvyTWWjwdajSMtayt8T6ozDgMlxg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
