### PR TITLE
fix(codacy): refactor 2 more Lizard ccn-medium patch generators (indent_mismatch, dead_code)

### DIFF
--- a/scripts/quality/build_quality_rollup.py
+++ b/scripts/quality/build_quality_rollup.py
@@ -211,6 +211,36 @@ def _lane_statuses_from_rows(
     return statuses
 
 
+def _aggregate_rollup_status(rows: List[Dict[str, str]]) -> str:
+    """Reduce per-row statuses to a single overall verdict.
+
+    Hard-fails win; otherwise pending wins; otherwise pass.
+    """
+    overall = "pass"
+    for row in rows:
+        status = row["status"]
+        if status in {"fail", "missing"}:
+            return "fail"
+        if status == "pending" and overall == "pass":
+            overall = "pending"
+    return overall
+
+
+def _apply_severity_softening(overall: str, severity_verdict: str) -> str:
+    """If overall is ``fail`` but severity verdict is warn/pass, soften it.
+
+    Preserves the hard ``fail`` when blockers exist AND preserves
+    ``pending`` (not-yet-reported) regardless.
+    """
+    if overall != "fail":
+        return overall
+    if severity_verdict == "warn":
+        return "warn"
+    if severity_verdict == "pass":
+        return "pass"
+    return overall
+
+
 def build_rollup(
     *,
     profile: Mapping[str, Any],
@@ -228,35 +258,22 @@ def build_rollup(
     ``block`` severity (same as the existing behaviour).
     """
     required_contexts = sorted(profile.get("active_required_contexts", []))
-    rows: List[Dict[str, str]] = []
-    overall = "pass"
     reverse_map = {context: lane for lane, context in LANE_CONTEXTS.items()}
-    for context_name in required_contexts:
-        row = _build_rollup_row(
+    rows = [
+        _build_rollup_row(
             context_name=context_name,
             reverse_map=reverse_map,
             lane_payloads=lane_payloads,
             contexts=contexts,
         )
-        if row["status"] in {"fail", "missing"}:
-            overall = "fail"
-        elif row["status"] == "pending" and overall == "pass":
-            overall = "pending"
-        rows.append(row)
-
+        for context_name in required_contexts
+    ]
+    overall = _aggregate_rollup_status(rows)
     severity_verdict = classify_lanes(
         profile, _lane_statuses_from_rows(rows, reverse_map)
     )
     severity_payload = failing_lanes_to_gate_output(severity_verdict)
-    # Severity-aware overall: if the zero-rollup says ``fail`` but every
-    # failure is only ``warn``/``info`` severity, soften to ``warn`` or
-    # keep ``pass``. Preserves the hard ``fail`` when blockers exist
-    # AND preserves ``pending`` (not-yet-reported) regardless.
-    if overall == "fail":
-        if severity_verdict.verdict == "warn":
-            overall = "warn"
-        elif severity_verdict.verdict == "pass":
-            overall = "pass"
+    overall = _apply_severity_softening(overall, severity_verdict.verdict)
     return {
         "repo": profile["slug"],
         "sha": sha,

--- a/scripts/quality/rollup_v2/patches/dead_code.py
+++ b/scripts/quality/rollup_v2/patches/dead_code.py
@@ -3,12 +3,31 @@ from __future__ import absolute_import
 
 import difflib
 from pathlib import Path
+from typing import List
 
 from scripts.quality.rollup_v2.schema.finding import Finding
 from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult
 
 GENERATOR_VERSION = "dead_code/1.0.0"
 CATEGORY = "dead-code"
+
+
+def _scan_dead_block_end(lines: List[str], target_index: int, target_indent: int) -> int:
+    """Walk forward from ``target_index`` while lines are blank or indented at
+    least as deep as ``target_indent``; return the first index that breaks
+    the dead-block (i.e. the new end-exclusive boundary).
+    """
+    end_index = target_index
+    while end_index < len(lines):
+        line = lines[end_index]
+        if not line.strip():  # pragma: no cover -- blank line within dead block; tested but branch depends on exact whitespace
+            end_index += 1
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent < target_indent:
+            break
+        end_index += 1
+    return end_index
 
 
 def generate(
@@ -35,22 +54,8 @@ def generate(
             suggested_tier="skip",
         )
 
-    # Get the indent level of the target line
     target_indent = len(target_line) - len(target_line.lstrip())
-
-    # Remove consecutive unreachable lines at the same or deeper indent level
-    end_index = target_index
-    while end_index < len(lines):
-        line = lines[end_index]
-        stripped = line.strip()
-        if stripped == "":  # pragma: no cover -- blank line within dead block; tested but branch depends on exact whitespace
-            end_index += 1
-            continue
-        line_indent = len(line) - len(line.lstrip())
-        if line_indent >= target_indent:
-            end_index += 1
-        else:
-            break
+    end_index = _scan_dead_block_end(lines, target_index, target_indent)
 
     if end_index == target_index:  # pragma: no cover -- defensive; requires target line to have lower indent than itself
         return PatchDeclined(

--- a/scripts/quality/rollup_v2/patches/indent_mismatch.py
+++ b/scripts/quality/rollup_v2/patches/indent_mismatch.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import difflib
 import re
 from pathlib import Path
+from typing import List
 
 from scripts.quality.rollup_v2.schema.finding import Finding
 from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult
@@ -12,6 +13,23 @@ GENERATOR_VERSION = "indent_mismatch/1.0.0"
 CATEGORY = "indent-mismatch"
 
 _INDENT = re.compile(r"^(\s*)")
+
+
+def _infer_expected_indent(lines: List[str], target_index: int) -> str:
+    """Walk backward from ``target_index - 1`` to find the previous non-blank
+    line and derive the indent level it implies (adding one 4-space level
+    when the previous line ends with ``:``).
+    """
+    for i in range(target_index - 1, -1, -1):
+        stripped = lines[i].strip()
+        if not stripped:
+            continue
+        match = _INDENT.match(lines[i])
+        prev_indent = match.group(1) if match else ""
+        if stripped.endswith(":"):
+            prev_indent += "    "
+        return prev_indent
+    return ""
 
 
 def generate(
@@ -28,17 +46,6 @@ def generate(
             reason_text=f"line {finding.line} out of range",
             suggested_tier="skip",
         )
-    # Look for the previous non-blank line to infer expected indent
-    prev_indent = ""
-    for i in range(target_index - 1, -1, -1):
-        stripped = lines[i].strip()
-        if stripped:
-            m = _INDENT.match(lines[i])
-            prev_indent = m.group(1) if m else ""
-            # If prev line ends with ':', expect one more indent level
-            if stripped.endswith(":"):
-                prev_indent += "    "
-            break
 
     target_line = lines[target_index]
     target_stripped = target_line.strip()
@@ -49,7 +56,7 @@ def generate(
             suggested_tier="skip",
         )
 
-    new_line = prev_indent + target_stripped
+    new_line = _infer_expected_indent(lines, target_index) + target_stripped
     if target_line.endswith("\n"):
         new_line += "\n"
 


### PR DESCRIPTION
## **User description**
## Summary

Round 4 of Lizard CCN refactor — two patch generators extract their loop-with-conditions logic into helpers:

| Function | Before | After |
|---|---|---|
| `indent_mismatch.py:generate` | 10 | **5** ✅ |
| `dead_code.py:generate` | 9 | **5** ✅ |

## Changes

- **`indent_mismatch.py`**: extract `_infer_expected_indent()` to centralise the backward-walk for the previous non-blank line + ':' adjustment.
- **`dead_code.py`**: extract `_scan_dead_block_end()` to centralise the forward-walk for the dead-block end boundary (blank lines + indent comparison).

Both extract the loop-with-conditions logic that was inflating CCN.

## Verified locally

- 1477 tests pass
- `lizard -C 8` reports no findings on either file

## Test plan

- [ ] Codacy main reports ~103 issues post-merge (was 105 after #195 reanalysis)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored two patch generators to move loop-heavy logic into helpers, lowering `generate` CCN to 5 in both. Also extracted rollup helpers to simplify status aggregation and severity softening with no behavior changes.

- **Refactors**
  - Patch generators: `indent_mismatch.py` adds `_infer_expected_indent()`, `dead_code.py` adds `_scan_dead_block_end()` to encapsulate the scan loops.
  - `build_quality_rollup.py`: adds `_aggregate_rollup_status()` and `_apply_severity_softening()` and simplifies `build_rollup()` while keeping pass/pending/warn/fail semantics unchanged.

<sup>Written for commit ee2ca6458e56c14f6a31425ac9a1df43178cbdb4. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Simplify quality patch generation without changing results**

### What Changed
- Dead-code fixes now use the same block-scanning logic in one place, keeping the same unreachable-code removal behavior.
- Indent fixes now use one shared way to infer the expected indentation, keeping the same re-indent behavior.
- Quality rollup status handling was split into smaller steps, while the final rollup status rules stay the same.

### Impact
`✅ Same dead-code and indent fixes`
`✅ Same rollup verdicts`
`✅ Easier future quality rule updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=LTQvHUfGXQtLpzhzahJ7QLrCZINaLkh37P-w0PVTJEw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
