### PR TITLE
fix(codacy): refactor line_too_long.generate nloc 59→27 via helpers

### DIFF
--- a/scripts/quality/rollup_v2/patches/line_too_long.py
+++ b/scripts/quality/rollup_v2/patches/line_too_long.py
@@ -13,6 +13,40 @@ CATEGORY = "line-too-long"
 MAX_LINE_LENGTH = 100
 
 
+def _wrap_comment_line(target_line: str) -> str:
+    """Re-flow a long ``# ...`` comment within MAX_LINE_LENGTH using textwrap."""
+    stripped = target_line.strip()
+    indent = target_line[: len(target_line) - len(target_line.lstrip())]
+    comment_text = stripped[2:]  # Remove '# '
+    wrapped = textwrap.fill(
+        comment_text,
+        width=MAX_LINE_LENGTH - len(indent) - 2,
+        initial_indent=indent + "# ",
+        subsequent_indent=indent + "# ",
+    )
+    return wrapped + "\n"
+
+
+def _build_wrapped_replacement(
+    target_line: str,
+) -> str | PatchDeclined:
+    """Decide what (if anything) the long line should be replaced with."""
+    stripped = target_line.strip()
+    if stripped.startswith("#"):
+        return _wrap_comment_line(target_line)
+    if len(target_line.rstrip("\n")) <= MAX_LINE_LENGTH:
+        return PatchDeclined(
+            reason_code="ambiguous-fix",
+            reason_text="line is not actually too long",
+            suggested_tier="skip",
+        )
+    return PatchDeclined(
+        reason_code="ambiguous-fix",
+        reason_text="cannot safely wrap non-comment line",
+        suggested_tier="llm-fallback",
+    )
+
+
 def generate(
     finding: Finding,
     source_file_content: str,
@@ -28,36 +62,12 @@ def generate(
             suggested_tier="skip",
         )
 
-    target_line = lines[target_index]
-    # Only wrap comments and string literals; complex expressions decline
-    stripped = target_line.strip()
-    if stripped.startswith("#"):
-        # Wrap comment
-        indent = target_line[: len(target_line) - len(target_line.lstrip())]
-        comment_text = stripped[2:]  # Remove '# '
-        wrapped = textwrap.fill(
-            comment_text,
-            width=MAX_LINE_LENGTH - len(indent) - 2,
-            initial_indent=indent + "# ",
-            subsequent_indent=indent + "# ",
-        )
-        new_lines = wrapped + "\n"
-    elif len(target_line.rstrip("\n")) <= MAX_LINE_LENGTH:
-        return PatchDeclined(
-            reason_code="ambiguous-fix",
-            reason_text="line is not actually too long",
-            suggested_tier="skip",
-        )
-    else:
-        # For non-comments, decline to avoid breaking syntax
-        return PatchDeclined(
-            reason_code="ambiguous-fix",
-            reason_text="cannot safely wrap non-comment line",
-            suggested_tier="llm-fallback",
-        )
+    replacement = _build_wrapped_replacement(lines[target_index])
+    if isinstance(replacement, PatchDeclined):
+        return replacement
 
     patched_lines = lines.copy()
-    patched_lines[target_index] = new_lines
+    patched_lines[target_index] = replacement
     if patched_lines == lines:  # pragma: no cover -- defensive; wrap always changes long comments
         return PatchDeclined(
             reason_code="ambiguous-fix",

--- a/scripts/quality/rollup_v2/patches/mutable_default.py
+++ b/scripts/quality/rollup_v2/patches/mutable_default.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import difflib
 import re
 from pathlib import Path
+from typing import List
 
 from scripts.quality.rollup_v2.schema.finding import Finding
 from scripts.quality.rollup_v2.schema.patch import PatchDeclined, PatchResult
@@ -15,6 +16,25 @@ CATEGORY = "mutable-default"
 _MUTABLE_DEFAULT = re.compile(
     r"^(\s*def\s+\w+\s*\([^)]*?)(\w+)\s*=\s*(\[\]|\{\})\s*([,)])"
 )
+
+
+def _build_def_line_replacement(target_line: str, match: re.Match) -> str:
+    """Produce ``def f(x=None, ...)`` from the matched ``def f(x=[], ...)`` line."""
+    prefix = match.group(1)
+    param_name = match.group(2)
+    trailing = match.group(4)
+    new_def_line = f"{prefix}{param_name}=None{trailing}{target_line[match.end():]}"
+    if not new_def_line.endswith("\n"):  # pragma: no cover -- source lines always end with newline from splitlines(keepends=True)
+        new_def_line += "\n"
+    return new_def_line
+
+
+def _find_body_start(lines: List[str], target_index: int) -> int:
+    """Skip blank lines after the ``def`` to find where the body begins."""
+    body_start = target_index + 1
+    while body_start < len(lines) and lines[body_start].strip() == "":  # pragma: no cover -- blank lines between def and body are rare
+        body_start += 1
+    return body_start
 
 
 def generate(
@@ -41,29 +61,12 @@ def generate(
             suggested_tier="llm-fallback",
         )
 
-    prefix = match.group(1)
-    param_name = match.group(2)
-    mutable_literal = match.group(3)
-    trailing = match.group(4)
-
-    # Replace `x=[]` with `x=None`
-    new_def_line = f"{prefix}{param_name}=None{trailing}"
-    # Reconstruct the rest of the line after the match
-    rest_of_line = target_line[match.end():]
-    new_def_line += rest_of_line
-    if not new_def_line.endswith("\n"):  # pragma: no cover -- source lines always end with newline from splitlines(keepends=True)
-        new_def_line += "\n"
-
-    # Determine the body indent (one level deeper than function def indent)
+    new_def_line = _build_def_line_replacement(target_line, match)
     def_indent = target_line[: len(target_line) - len(target_line.lstrip())]
     body_indent = def_indent + "    "
-
-    # Find the first body line to insert the guard before it
-    body_start = target_index + 1
-    # Skip the colon line if the def line doesn't end with ':'
-    while body_start < len(lines) and lines[body_start].strip() == "":  # pragma: no cover -- blank lines between def and body are rare
-        body_start += 1
-
+    param_name = match.group(2)
+    mutable_literal = match.group(3)
+    body_start = _find_body_start(lines, target_index)
     guard_line = f"{body_indent}{param_name} = {mutable_literal} if {param_name} is None else {param_name}\n"
 
     patched_lines = lines.copy()


### PR DESCRIPTION
## **User description**
## Summary

Round 5 of Lizard refactor — line_too_long patch generator nloc reduction.

| Function | Before (nloc) | After (nloc) |
|---|---|---|
| `line_too_long.py:generate` | 59 | **27** ✅ |

## Changes

- Extract `_wrap_comment_line()` (textwrap.fill rebuild for the comment-wrap path).
- Extract `_build_wrapped_replacement()` (decision tree returning either a str replacement or PatchDeclined).
- Main `generate()` is now linear: index validation → replacement decision → diff build.

## Verified locally

- 1477 tests pass
- `lizard -L 50 -C 8 line_too_long.py` reports no findings on this file

## Test plan

- [ ] Codacy main reports ~103 issues post-merge (was 104; remaining tail is more nloc + Pylint findings)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored the line-too-long patch generator to cut NLOC from 59 to 27 and make the flow linear, improving readability and Codacy/Lizard scores without changing behavior. Also refactored the mutable-default patch generator with small helpers to clarify replacement and body insertion points.

- **Refactors**
  - Extracted `_wrap_comment_line()` and `_build_wrapped_replacement()`; `generate()` now: validate index → decide replacement → apply diff.
  - Extracted `_build_def_line_replacement()` and `_find_body_start()`; `generate()` cleanly builds `param=None` and inserts the guard at the first body line.

<sup>Written for commit afabf9e8782618e19d52fad8c6b9b566a259a216. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Simplify long-line and mutable-default patch generation**

### What Changed
- Long comment lines are still wrapped automatically, while non-comment long lines continue to be declined instead of being rewritten unsafely.
- Mutable default arguments are still converted to `None` with the matching guard inserted at the start of the function body.
- Both patch generators now follow a clearer decision path, making their results easier to keep consistent.

### Impact
`✅ More consistent patch suggestions`
`✅ Fewer unsafe automatic edits`
`✅ Clearer fixes for long comments and mutable defaults`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=jdLL-FiKGkNDAEnIE5uU6njGlRndjc9BCEQoBYitZgE&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
