### PR TITLE
fix(codacy): _parse_args nloc 55→8 via collection/alert arg helpers

### DIFF
--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -19,37 +19,19 @@ from scripts.quality.common import dedupe_strings, utc_timestamp, write_report
 NONE_BULLET = "- None"
 
 
-def _parse_args() -> argparse.Namespace:
-    """Handle parse args."""
-    parser = argparse.ArgumentParser(
-        description="Validate required quality-gate secrets and variables."
-    )
-    parser.add_argument(
-        "--required-secret",
-        action="append",
-        default=[],
-        help="Required secret env var name",
-    )
-    parser.add_argument(
-        "--conditional-secret",
-        action="append",
-        default=[],
-        help="Conditional secret env var name",
-    )
-    parser.add_argument(
-        "--required-var",
-        action="append",
-        default=[],
-        help="Required variable env var name",
-    )
-    parser.add_argument(
-        "--conditional-var",
-        action="append",
-        default=[],
-        help="Conditional variable env var name",
-    )
-    parser.add_argument("--out-json", default="quality-secrets/secrets.json")
-    parser.add_argument("--out-md", default="quality-secrets/secrets.md")
+def _add_collection_args(parser: argparse.ArgumentParser) -> None:
+    """Add the four ``--required-secret`` / ``--conditional-*`` collectors."""
+    for flag, label in (
+        ("--required-secret", "Required secret env var name"),
+        ("--conditional-secret", "Conditional secret env var name"),
+        ("--required-var", "Required variable env var name"),
+        ("--conditional-var", "Conditional variable env var name"),
+    ):
+        parser.add_argument(flag, action="append", default=[], help=label)
+
+
+def _add_alert_args(parser: argparse.ArgumentParser) -> None:
+    """Add the ``--open-alerts`` / ``--dry-run-alerts`` / slug pair."""
     parser.add_argument(
         "--open-alerts",
         action="store_true",
@@ -73,6 +55,17 @@ def _parse_args() -> argparse.Namespace:
         help="Repo the secrets are missing on (subject of the alert). "
         "Defaults to --platform-slug when empty.",
     )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Handle parse args."""
+    parser = argparse.ArgumentParser(
+        description="Validate required quality-gate secrets and variables."
+    )
+    _add_collection_args(parser)
+    parser.add_argument("--out-json", default="quality-secrets/secrets.json")
+    parser.add_argument("--out-md", default="quality-secrets/secrets.md")
+    _add_alert_args(parser)
     return parser.parse_args()
 
 


### PR DESCRIPTION
## **User description**
## Summary

`scripts/quality/check_quality_secrets.py:_parse_args` flagged at nloc 55 (limit 50). Pure argparse builder with two repetitive arg groups.

## Changes

- Extract `_add_collection_args()` — iterates `(flag, label)` table for the 4 `--required-secret` / `--conditional-*` collectors.
- Extract `_add_alert_args()` — the 4 alert/slug flags.
- Main `_parse_args()` is now a 7-line composition.

## Verified

- 1477 tests pass
- lizard -L 50 -C 8 reports no findings on this file

## Test plan

- [ ] Codacy main reports 1 fewer Lizard nloc-medium post-merge

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored `scripts/quality/check_quality_secrets.py` to reduce `_parse_args` NLOC from 55 to 8, eliminating duplication and satisfying Codacy/Lizard rules.

- **Refactors**
  - Added `_add_collection_args()` to register the four `--required/conditional` secret/var collectors via a small (flag, label) table.
  - Added `_add_alert_args()` to add the four alert/slug flags.
  - `_parse_args()` now composes the parser with these helpers; behavior unchanged.

<sup>Written for commit 33591a9e14ac5aab20579bfcc3d2148a6a04124a. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Simplify the quality-secrets checker setup without changing its command-line behavior**

### What Changed
- The script now builds its secret, variable, and alert options in smaller sections instead of one long setup block
- The same flags, defaults, and output paths remain available
- The checker’s behavior stays the same while the command-line setup is easier to follow and maintain

### Impact
`✅ Same command-line behavior`
`✅ Same output files and defaults`
`✅ Easier maintenance for the secrets checker`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bjNvqB73f43BQTFKTvca39wY7fcOd-hDquqYxj9fk2c&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
