### PR TITLE
fix(codacy): _render_prompt nloc 54→25 via input-validation helper

### DIFF
--- a/scripts/quality/render_codex_prompt.py
+++ b/scripts/quality/render_codex_prompt.py
@@ -8,7 +8,7 @@ import json
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, cast
+from typing import Any, Dict, Iterable, List, Tuple, cast
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -189,8 +189,15 @@ def _render_canonical_findings_section(findings: List[Dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def _render_prompt(*args: object, **kwargs: object) -> str:
-    """Handle render prompt."""
+def _validate_render_prompt_inputs(
+    args: tuple,
+    kwargs: Dict[str, object],
+) -> Tuple[Dict[str, Any], str, str, str, list]:
+    """Validate the (*args, **kwargs) shape for ``_render_prompt`` and unpack it.
+
+    Returns (profile, lane, event_name, failure_context, artifacts).
+    Raises ``TypeError`` for any contract violation.
+    """
     if len(args) != 1:
         raise TypeError(
             "_render_prompt expects a single profile mapping positional argument"
@@ -207,11 +214,24 @@ def _render_prompt(*args: object, **kwargs: object) -> str:
         raise TypeError(f"Missing required prompt field: {exc.args[0]}") from exc
     if not isinstance(artifacts_value, Iterable):
         raise TypeError("_render_prompt expects artifacts to be iterable")
-    artifacts = list(cast("Iterable[object]", artifacts_value))
     if kwargs:
         raise TypeError(
             f"Unexpected _render_prompt parameters: {', '.join(sorted(kwargs))}"
         )
+    return (
+        profile,
+        lane,
+        event_name,
+        failure_context,
+        list(cast("Iterable[object]", artifacts_value)),
+    )
+
+
+def _render_prompt(*args: object, **kwargs: object) -> str:
+    """Handle render prompt."""
+    profile, lane, event_name, failure_context, artifacts = (
+        _validate_render_prompt_inputs(args, kwargs)
+    )
     headline = "PR failure remediation" if lane == "remediation" else "backlog sweep"
     sections = [
         f"# Codex {headline}",


### PR DESCRIPTION
## **User description**
## Summary

`scripts/quality/render_codex_prompt.py:_render_prompt` flagged at nloc 54 (limit 50). The bulk was 18 lines of positional/kwarg validation before the actual rendering.

## Changes

- Extract `_validate_render_prompt_inputs(args, kwargs) -> Tuple[profile, lane, event_name, failure_context, artifacts]`. All TypeError contract guards live in the helper; the main function consumes the unpacked tuple.
- Used `Tuple[...]` (typing import) per project Codacy-compatibility test.

## Verified

- 1477 tests pass
- lizard -L 50 -C 8 reports 0 warnings on render_codex_prompt.py
- Output text byte-identical (separation of concerns refactor only)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduced `_render_prompt` complexity in `scripts/quality/render_codex_prompt.py` by moving input validation into `_validate_render_prompt_inputs`, dropping nloc from 54 to 25 to satisfy Codacy lizard. Output is unchanged; all tests pass; lizard now reports 0 warnings.

<sup>Written for commit f8bf9fc0193832e5bc5aeb0178a77cab923e7d3c. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/200?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Separate prompt input checks from prompt rendering**

### What Changed
- Input validation is now handled before prompt text is built, so the renderer focuses on assembling the output
- The prompt still produces the same text for valid inputs
- Invalid or missing inputs still fail with the same contract errors

### Impact
`✅ No change to generated prompt text`
`✅ Clearer invalid-input failures`
`✅ Safer prompt rendering behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=RnCfzXgaPvkh6z-EKfXRNYN8RawoXyozQKT6LYti9Mk&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
