### PR TITLE
fix(codacy): parse_sarif nloc 70→17 via _iter + _build_draft helpers

### DIFF
--- a/scripts/quality/rollup_v2/normalizers/_sarif.py
+++ b/scripts/quality/rollup_v2/normalizers/_sarif.py
@@ -165,81 +165,73 @@ def check_sarif_size(data: bytes | str) -> None:
         )
 
 
+def _build_sarif_finding_draft(
+    *,
+    result: Dict[str, Any],
+    rule_meta: Dict[str, Any],
+    provider: str,
+    index: int,
+) -> FindingDraft:
+    """Translate one SARIF ``result`` into a normaliser-ready FindingDraft."""
+    rule_id = str(result.get("ruleId", "unknown"))
+    message = _extract_message(result)
+    level = str(result.get("level", "warning")).lower()
+    file_path, line, end_line, column = _extract_location(result)
+    category = lookup(provider, rule_id) or rule_id
+    tags = _extract_tags(result)
+    return FindingDraft(
+        finding_id=f"{provider.lower()}-{index:04d}",
+        file=file_path,
+        line=line,
+        end_line=end_line,
+        column=column,
+        category=category,
+        category_group=_classify_category_group(category, tags),
+        severity=_SARIF_LEVEL_TO_SEVERITY.get(level, "medium"),
+        primary_message=message,
+        rule_id=rule_id,
+        rule_url=_extract_rule_url(rule_meta),
+        original_message=message,
+        context_snippet=_extract_context_snippet(result),
+        cwe=_extract_cwe(result),
+    )
+
+
+def _iter_sarif_results(runs: List[Any]) -> Iterable[Tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]]:
+    """Yield ``(result, rule_index)`` pairs from valid SARIF runs."""
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        rule_index = _build_rule_index(run)
+        results = run.get("results", [])
+        if not isinstance(results, list):
+            continue
+        for result in results:
+            if isinstance(result, dict):
+                yield result, rule_index
+
+
 def parse_sarif(
     data: Dict[str, Any],
     provider: str,
     repo_root: Path,
     normalizer: BaseNormalizer,
 ) -> List[Finding]:
-    """Parse a SARIF 2.1.0 payload and return canonical Finding objects.
-
-    Parameters
-    ----------
-    data : dict
-        Parsed SARIF JSON (the top-level object with ``runs`` array).
-    provider : str
-        Provider name for taxonomy lookup and corroborator construction.
-    repo_root : Path
-        Repository root for path validation.
-    normalizer : BaseNormalizer
-        The normalizer instance (used for ``_build_finding``).
-
-    Returns
-    -------
-    List[Finding]
-        Canonical findings parsed from all SARIF runs.
-    """
-    findings: List[Finding] = []
+    """Parse a SARIF 2.1.0 payload and return canonical Finding objects."""
     runs = data.get("runs", [])
     if not isinstance(runs, list):
-        return findings
-
-    index = 0
-    for run in runs:
-        if not isinstance(run, dict):
-            continue
-        rule_index = _build_rule_index(run)
-
-        results = run.get("results", [])
-        if not isinstance(results, list):
-            continue
-
-        for result in results:
-            if not isinstance(result, dict):
-                continue
-
-            rule_id = str(result.get("ruleId", "unknown"))
-            rule_meta = rule_index.get(rule_id, {})
-            message = _extract_message(result)
-            level = str(result.get("level", "warning")).lower()
-            severity = _SARIF_LEVEL_TO_SEVERITY.get(level, "medium")
-            file_path, line, end_line, column = _extract_location(result)
-            category = lookup(provider, rule_id) or rule_id
-            tags = _extract_tags(result)
-            cwe = _extract_cwe(result)
-            category_group = _classify_category_group(category, tags)
-            rule_url = _extract_rule_url(rule_meta)
-            context_snippet = _extract_context_snippet(result)
-
-            finding = normalizer._build_finding(FindingDraft(
-                finding_id=f"{provider.lower()}-{index:04d}",
-                file=file_path,
-                line=line,
-                end_line=end_line,
-                column=column,
-                category=category,
-                category_group=category_group,
-                severity=severity,
-                primary_message=message,
-                rule_id=rule_id,
-                rule_url=rule_url,
-                original_message=message,
-                context_snippet=context_snippet,
-                cwe=cwe,
-            ))
-            findings.append(finding)
-            index += 1
-
+        return []
+    findings: List[Finding] = []
+    for index, (result, rule_index) in enumerate(_iter_sarif_results(runs)):
+        rule_id = str(result.get("ruleId", "unknown"))
+        rule_meta = rule_index.get(rule_id, {})
+        draft = _build_sarif_finding_draft(
+            result=result,
+            rule_meta=rule_meta,
+            provider=provider,
+            index=index,
+        )
+        findings.append(normalizer._build_finding(draft))
     return findings
 
 


### PR DESCRIPTION
## **User description**
## Summary

`parse_sarif` was the biggest Lizard nloc offender at 70 lines (limit 50).

| Function | Before | After |
|---|---|---|
| `_sarif.py:parse_sarif` | 70 nloc | **17 nloc** ✅ |

## Changes

Two helpers split the validation and the per-result draft construction:

- `_iter_sarif_results(runs)` — generator yielding `(result, rule_index)` tuples from valid SARIF runs. Concentrates the isinstance checks for run/results/result that previously dominated parse_sarif's nloc.
- `_build_sarif_finding_draft(result, rule_meta, provider, index)` — per-result extraction (rule_id, message, level, location, category, tags, cwe) packaged into FindingDraft.

`parse_sarif` itself is now a 17-line linear flow: runs guard → enumerate iter → build draft → append.

## Verified

- 1477 tests pass
- lizard -L 50 -C 8 reports 0 warnings on _sarif.py

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored SARIF parsing to reduce `parse_sarif` nloc from 70 to 17 for better readability and to satisfy Lizard limits. Behavior is unchanged; all tests pass.

- **Refactors**
  - Added `_iter_sarif_results(runs)` to validate runs and yield `(result, rule_index)` pairs, consolidating type checks.
  - Added `_build_sarif_finding_draft(...)` to construct `FindingDraft` per result (message, level, location, category, tags, CWE, rule URL).
  - Simplified `parse_sarif` to a linear flow: guard runs → iterate → build draft → append via `normalizer._build_finding`.

<sup>Written for commit 24695496b92f4e8e6dcd07c18a20675da9746b4b. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep SARIF import behavior unchanged while simplifying how findings are parsed

### What Changed
- SARIF files still produce the same findings, but the parsing flow is now split into smaller steps for each result
- Invalid or unexpected SARIF runs and results are still skipped
- Each finding now gets built in one place before being added to the final import list

### Impact
`✅ Same SARIF import results`
`✅ Fewer parsing regressions`
`✅ Easier SARIF maintenance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5piHUDqlVkYrxryd2Aa2-Bgm8OsufDFxB-zp8SO6QFA&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
