### PR TITLE
fix(codacy): run_pipeline nloc 59→18 — final Lizard nloc-medium

### DIFF
--- a/scripts/quality/rollup_v2/pipeline.py
+++ b/scripts/quality/rollup_v2/pipeline.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from scripts.quality.rollup_v2 import patches as patch_dispatcher
 from scripts.quality.rollup_v2.dedup import assign_stable_ids, dedup
@@ -181,6 +181,49 @@ def _finding_to_dict(f: Finding) -> Dict[str, Any]:
     }
 
 
+def _normalize_all_artifacts(
+    artifacts: Dict[str, Any],
+    repo_root: Path,
+) -> Tuple[List[Finding], List[Dict[str, str]], List[Dict[str, str]]]:
+    """Run every registered normalizer over its matching artifact.
+
+    Returns ``(findings, normalizer_errors, security_drops)``.
+    """
+    all_findings: List[Finding] = []
+    all_errors: List[Dict[str, str]] = []
+    all_drops: List[Dict[str, str]] = []
+    for key, artifact in artifacts.items():
+        normalizer = NORMALIZER_REGISTRY.get(key)
+        if normalizer is None:
+            continue
+        result: NormalizerResult = normalizer.run(artifact=artifact, repo_root=repo_root)
+        all_findings.extend(result.findings)
+        all_errors.extend(result.normalizer_errors)
+        all_drops.extend(result.security_drops)
+    return all_findings, all_errors, all_drops
+
+
+def _build_canonical_payload(
+    final_findings: List[Finding],
+    all_errors: List[Dict[str, str]],
+    all_drops: List[Dict[str, str]],
+) -> Dict[str, Any]:
+    """Assemble the rollup canonical payload (provider_summaries + meta)."""
+    provider_summaries = _build_provider_summaries(final_findings)
+    configured_providers = {s["provider"] for s in provider_summaries}
+    for placeholder in _build_not_configured_summaries():
+        if placeholder["provider"] not in configured_providers:
+            provider_summaries.append(placeholder)
+    return {
+        "schema_version": "qzp-rollup/1",
+        "total_findings": len(final_findings),
+        "findings": final_findings,
+        "provider_summaries": provider_summaries,
+        "normalizer_errors": all_errors,
+        "security_drops": all_drops,
+    }
+
+
 def run_pipeline(
     artifacts: Dict[str, Any],
     repo_root: Path,
@@ -200,57 +243,16 @@ def run_pipeline(
     6. Build canonical payload
     7. Render markdown
     """
-    all_findings: List[Finding] = []
-    all_errors: List[Dict[str, str]] = []
-    all_drops: List[Dict[str, str]] = []
-
-    # Step 1-2: Normalize
-    for key, artifact in artifacts.items():
-        normalizer = NORMALIZER_REGISTRY.get(key)
-        if normalizer is None:
-            continue
-        result: NormalizerResult = normalizer.run(artifact=artifact, repo_root=repo_root)
-        all_findings.extend(result.findings)
-        all_errors.extend(result.normalizer_errors)
-        all_drops.extend(result.security_drops)
-
-    # Step 3: Dedup + merge + stable IDs
-    deduped = dedup(all_findings)
-    deduped = assign_stable_ids(deduped)
-
-    # Step 4: Patch dispatch
+    all_findings, all_errors, all_drops = _normalize_all_artifacts(artifacts, repo_root)
+    deduped = assign_stable_ids(dedup(all_findings))
     patched = _apply_patches(deduped, repo_root)
-
-    # Step 5: Derive autofixable
     final_findings = _derive_autofixable(patched)
-
-    # Step 6: Build canonical payload
-    provider_summaries = _build_provider_summaries(final_findings)
-
-    # Add not-configured placeholders for reserved lanes without artifacts
-    configured_providers = {s["provider"] for s in provider_summaries}
-    for placeholder in _build_not_configured_summaries():
-        if placeholder["provider"] not in configured_providers:
-            provider_summaries.append(placeholder)
-
-    canonical_payload: Dict[str, Any] = {
-        "schema_version": "qzp-rollup/1",
-        "total_findings": len(final_findings),
-        "findings": final_findings,
-        "provider_summaries": provider_summaries,
-        "normalizer_errors": all_errors,
-        "security_drops": all_drops,
-    }
-
-    # Step 7: Render markdown
+    canonical_payload = _build_canonical_payload(final_findings, all_errors, all_drops)
     markdown = render_markdown(canonical_payload)
-
-    # Build JSON-serializable version of canonical payload
     json_payload = {
         **canonical_payload,
         "findings": [_finding_to_dict(f) for f in final_findings],
     }
-
     return PipelineResult(
         findings=final_findings,
         normalizer_errors=all_errors,


### PR DESCRIPTION
## **User description**
## Summary

Final Lizard nloc-medium target in QZP. `run_pipeline` was 59 lines (limit 50) covering all 7 pipeline steps.

| Function | Before | After |
|---|---|---|
| `pipeline.py:run_pipeline` | 59 nloc | **18 nloc** ✅ |

## Changes

Extract two helpers:
- `_normalize_all_artifacts(artifacts, repo_root) -> Tuple[findings, errors, drops]` — steps 1-2 (normalizer registry lookup + result aggregation).
- `_build_canonical_payload(final_findings, errors, drops)` — step 6 (provider_summaries + not-configured placeholders + canonical dict).

`run_pipeline()` is now a 14-line linear orchestration: each of the 7 documented steps is one line.

## Verified

- 1477 tests pass
- lizard -L 50 -C 8 reports 0 warnings on pipeline.py

## After this lands

QZP main should have **0 Lizard ccn-medium / nloc-medium findings** post-Codacy-reanalysis. Last 2 (parse_sarif from #201, run_pipeline here) clear together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal pipeline processing logic for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Simplify the quality rollup pipeline without changing its output

### What Changed
- Split the rollup flow into smaller steps for artifact normalization and final report assembly
- Kept the same findings, errors, security drops, and markdown report output
- Preserved placeholder summaries for configured lanes that have no matching artifacts

### Impact
`✅ Same rollup results`
`✅ Consistent markdown reports`
`✅ Lower risk of report regressions`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=WuLwvKMsWVAs01alFxODfBlOTsocoiRzup0fRZGWE_I&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
