### PR TITLE
fix(codacy): ruff auto-fix batch 4 + UP038 isinstance modernization

### DIFF
--- a/scripts/quality/admin_dashboard_pages.py
+++ b/scripts/quality/admin_dashboard_pages.py
@@ -86,7 +86,7 @@ def render_coverage_trend_page(
     for row in rows:
         slug = html.escape(str(row.get("slug", "")))
         cov = row.get("coverage_percent")
-        cov_text = f"{cov:.1f}" if isinstance(cov, (int, float)) else html.escape(
+        cov_text = f"{cov:.1f}" if isinstance(cov, int | float) else html.escape(
             str(cov or ""),
         )
         tbl_rows.append(f"      <tr><td>{slug}</td><td>{cov_text}</td></tr>")

--- a/scripts/quality/bypass_labels.py
+++ b/scripts/quality/bypass_labels.py
@@ -23,7 +23,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone, UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Mapping, Optional
 

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -99,7 +99,7 @@ def _request_json(
 def _direct_total_open(payload: Mapping[str, Any]) -> int | None:
     """Read the total issue count from one flat payload."""
     for key, value in payload.items():
-        if key in TOTAL_KEYS and isinstance(value, (int, float)):
+        if key in TOTAL_KEYS and isinstance(value, int | float):
             return int(value)
     return None
 

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -67,7 +67,7 @@ def extract_total_open(payload: Any) -> int | None:
     """Handle extract total open."""
     if isinstance(payload, dict):
         for key, value in payload.items():
-            if key in TOTAL_KEYS and isinstance(value, (int, float)):
+            if key in TOTAL_KEYS and isinstance(value, int | float):
                 return int(value)
     for nested in _nested_payload_values(payload):
         total = extract_total_open(nested)

--- a/scripts/quality/common.py
+++ b/scripts/quality/common.py
@@ -6,7 +6,7 @@ import json
 import sys
 from copy import deepcopy
 from dataclasses import dataclass
-from datetime import datetime, timezone, UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping
 

--- a/scripts/quality/coverage_findings.py
+++ b/scripts/quality/coverage_findings.py
@@ -49,10 +49,8 @@ def _coverage_threshold_findings(
     for item in stats_list:
         if item.percent < min_percent:
             findings.append(
-                
-                    f"{item.name} coverage below {min_percent:.2f}%: "
-                    f"{item.percent:.2f}% ({item.covered}/{item.total})"
-                
+                f"{item.name} coverage below {min_percent:.2f}%: "
+                f"{item.percent:.2f}% ({item.covered}/{item.total})"
             )
 
     combined_total = sum(item.total for item in stats_list)
@@ -62,10 +60,8 @@ def _coverage_threshold_findings(
     )
     if combined < min_percent:
         findings.append(
-            
-                f"combined coverage below {min_percent:.2f}%: {combined:.2f}% "
-                f"({combined_covered}/{combined_total})"
-            
+            f"combined coverage below {min_percent:.2f}%: {combined:.2f}% "
+            f"({combined_covered}/{combined_total})"
         )
     return findings
 
@@ -88,11 +84,9 @@ def _branch_coverage_findings_for_stats(
     for item in stats:
         if item.branch_percent < branch_min_percent:
             findings.append(
-                
-                    f"{item.name} branch coverage below "
-                    f"{branch_min_percent:.2f}%: {item.branch_percent:.2f}% "
-                    f"({item.branch_covered}/{item.branch_total})"
-                
+                f"{item.name} branch coverage below "
+                f"{branch_min_percent:.2f}%: {item.branch_percent:.2f}% "
+                f"({item.branch_covered}/{item.branch_total})"
             )
     return findings
 
@@ -114,10 +108,8 @@ def _branch_threshold_findings(
     combined_total, combined_covered, combined = _combined_branch_coverage(stats_list)
     if combined_total > 0 and combined < branch_min_percent:
         findings.append(
-            
-                f"combined branch coverage below {branch_min_percent:.2f}%: "
-                f"{combined:.2f}% ({combined_covered}/{combined_total})"
-            
+            f"combined branch coverage below {branch_min_percent:.2f}%: "
+            f"{combined:.2f}% ({combined_covered}/{combined_total})"
         )
     return findings
 
@@ -129,10 +121,10 @@ def _required_source_findings(
     findings: List[str] = []
     if _is_tests_only_report(reported_sources):
         findings.append(
-            
+
                 "coverage inputs only reference tests/ paths; first-party "
                 "sources are missing."
-            
+
         )
     findings.extend(
         f"missing required source path: {missing_source}"

--- a/scripts/quality/coverage_findings.py
+++ b/scripts/quality/coverage_findings.py
@@ -49,10 +49,10 @@ def _coverage_threshold_findings(
     for item in stats_list:
         if item.percent < min_percent:
             findings.append(
-                (
+                
                     f"{item.name} coverage below {min_percent:.2f}%: "
                     f"{item.percent:.2f}% ({item.covered}/{item.total})"
-                )
+                
             )
 
     combined_total = sum(item.total for item in stats_list)
@@ -62,10 +62,10 @@ def _coverage_threshold_findings(
     )
     if combined < min_percent:
         findings.append(
-            (
+            
                 f"combined coverage below {min_percent:.2f}%: {combined:.2f}% "
                 f"({combined_covered}/{combined_total})"
-            )
+            
         )
     return findings
 
@@ -88,11 +88,11 @@ def _branch_coverage_findings_for_stats(
     for item in stats:
         if item.branch_percent < branch_min_percent:
             findings.append(
-                (
+                
                     f"{item.name} branch coverage below "
                     f"{branch_min_percent:.2f}%: {item.branch_percent:.2f}% "
                     f"({item.branch_covered}/{item.branch_total})"
-                )
+                
             )
     return findings
 
@@ -114,10 +114,10 @@ def _branch_threshold_findings(
     combined_total, combined_covered, combined = _combined_branch_coverage(stats_list)
     if combined_total > 0 and combined < branch_min_percent:
         findings.append(
-            (
+            
                 f"combined branch coverage below {branch_min_percent:.2f}%: "
                 f"{combined:.2f}% ({combined_covered}/{combined_total})"
-            )
+            
         )
     return findings
 
@@ -129,10 +129,10 @@ def _required_source_findings(
     findings: List[str] = []
     if _is_tests_only_report(reported_sources):
         findings.append(
-            (
+            
                 "coverage inputs only reference tests/ paths; first-party "
                 "sources are missing."
-            )
+            
         )
     findings.extend(
         f"missing required source path: {missing_source}"

--- a/scripts/quality/rollup_v2/normalizers/_sarif.py
+++ b/scripts/quality/rollup_v2/normalizers/_sarif.py
@@ -244,7 +244,7 @@ class SarifBackedNormalizer(BaseNormalizer):
     """
 
     def parse(self, artifact: Any, repo_root: Path) -> Iterable[Finding]:
-        if isinstance(artifact, (str, bytes)):
+        if isinstance(artifact, str | bytes):
             check_sarif_size(artifact)
             data = json.loads(artifact)
         elif isinstance(artifact, dict):

--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -283,10 +283,10 @@ def _load_baseline_coverage_payload(profile: Dict[str, Any]) -> Dict[str, Any]:
     run_id = _find_successful_run_id(workflow_runs, "Quality Zero Platform")
     if run_id is None:
         raise RuntimeError(
-            (
+            
                 "Unable to find a successful Quality Zero Platform run on the "
                 "default branch."
-            )
+            
         )
     artifacts_url = (
         f"https://api.github.com/repos/{repo_slug}/actions/runs/{run_id}/artifacts"
@@ -341,10 +341,10 @@ def _write_non_regression_report(
     if current_percent < baseline_percent:
         status = "fail"
         findings.append(
-            (
+            
                 "combined coverage regressed from "
                 f"{baseline_percent:.2f}% to {current_percent:.2f}%"
-            )
+            
         )
     payload = {
         "status": status,

--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -283,10 +283,8 @@ def _load_baseline_coverage_payload(profile: Dict[str, Any]) -> Dict[str, Any]:
     run_id = _find_successful_run_id(workflow_runs, "Quality Zero Platform")
     if run_id is None:
         raise RuntimeError(
-            
-                "Unable to find a successful Quality Zero Platform run on the "
-                "default branch."
-            
+            "Unable to find a successful Quality Zero Platform run on the "
+            "default branch."
         )
     artifacts_url = (
         f"https://api.github.com/repos/{repo_slug}/actions/runs/{run_id}/artifacts"
@@ -341,10 +339,10 @@ def _write_non_regression_report(
     if current_percent < baseline_percent:
         status = "fail"
         findings.append(
-            
+
                 "combined coverage regressed from "
                 f"{baseline_percent:.2f}% to {current_percent:.2f}%"
-            
+
         )
     payload = {
         "status": status,

--- a/scripts/quality/security_class_guard.py
+++ b/scripts/quality/security_class_guard.py
@@ -94,7 +94,7 @@ def _has_security_tag(finding: Mapping[str, Any]) -> bool:
         if isinstance(value, str):
             haystack_parts.append(value)
     tags = finding.get("tags")
-    if isinstance(tags, (list, tuple)):
+    if isinstance(tags, list | tuple):
         haystack_parts.extend(str(t) for t in tags if isinstance(t, str))
     haystack = " | ".join(haystack_parts)
     if _CWE_RE.search(haystack):


### PR DESCRIPTION
## **User description**
## Summary

- 11 Ruff auto-fixes (F401 unused-imports x2, I001 unsorted-imports x2, UP034 extraneous-parentheses x7)
- 5 manual UP038 conversions: `isinstance(x, (A, B))` → `isinstance(x, A | B)` (PEP 604 form)

## Why

Codacy still flags `Ruff_UP038_non-pep604-isinstance` even though the rule was removed in newer local ruff versions. Explicit manual conversion required since auto-fix is no longer available locally.

## Why PEP 604 here is safe

- PEP 604 union (`X | Y`) in `isinstance` is **runtime-supported since Python 3.10**
- Project targets Python 3.12 (per `pyproject.toml`)
- This is distinct from the PEP 585 ban on generic-type-hint syntax (`tuple[str, str]`) which still applies to type annotations — see `tests/test_quality_codacy_compatibility.py`

## Test plan

- [x] `pytest tests/test_quality_codacy_compatibility.py` — 4/4 pass (PEP 585 ban intact)
- [x] `pytest tests/ -k "sarif or codacy or deepscan or security_class or admin_dashboard or coverage_findings"` — 150/150 pass
- [x] `python -m py_compile` on all 9 modified files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 85 → 69 (-16: 11 ruff + 5 UP038, plus PyLint W0611 echoes of F401)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Modernized `isinstance` checks to PEP 604 unions, applied `ruff` autofixes, and cleaned up UP034 formatting leftovers to satisfy Codacy. Reduces Codacy findings from 85 to 69 and resolves 4 new lint warnings.

- **Refactors**
  - Converted 5 sites of `isinstance(x, (A, B))` to `isinstance(x, A | B)` in quality scripts (Python 3.10+ safe; project targets 3.12).
  - Applied 11 `ruff` fixes: remove unused imports, sort imports, drop extraneous parentheses.
  - Fixed UP034 follow-up whitespace/indentation at 5 sites (`coverage_findings.py` x4, `run_coverage_gate.py` x1) to clear `W293`/`C0303`.

<sup>Written for commit c7174cee524105cb695831bca6c66c5e7b9552b3. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep quality-check scripts compatible with current lint rules

### What Changed
- Updated several quality scripts to use the current Python-style `isinstance` form so Codacy no longer flags them.
- Cleaned up coverage and quality-gate message formatting so error output stays readable and consistent.
- Reordered one import set to match the expected style.

### Impact
`✅ Fewer Codacy lint failures`
`✅ Cleaner quality-gate output`
`✅ Less noise in coverage checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xgoDVGNVCfUgVMdYqcN-XemfcEELcX3BoNxeUjU4dFI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
