### PR TITLE
fix(codacy): E402 batch — 8 sys.path-then-import noqa annotations

### DIFF
--- a/scripts/quality/admin_dashboard_pages.py
+++ b/scripts/quality/admin_dashboard_pages.py
@@ -18,15 +18,15 @@ full inventory scan.
 
 from __future__ import absolute_import
 
-# Newline constant used by the body builders so the duplicate "\n" literal
-# Sonar's python:S1192 rule flagged at line 93 stays at zero.
-_NL = "\n"
-
 import html
 import json
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
+
+# Newline constant used by the body builders so the duplicate "\n" literal
+# Sonar's python:S1192 rule flagged at line 93 stays at zero.
+_NL = "\n"
 
 
 def _ensure_platform_on_syspath() -> None:

--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -24,15 +24,15 @@ _CoverageMapping = Dict[str, Any]
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # pragma: no cover
 
-from scripts.quality import assert_coverage_100
-from scripts.quality.common import (
+from scripts.quality import assert_coverage_100  # noqa: E402
+from scripts.quality.common import (  # noqa: E402
     DEFAULT_COVERAGE_JSON,
     DEFAULT_COVERAGE_MD,
     NONE_BULLET,
     utc_timestamp,
     write_report,
 )
-from scripts.security_helpers import load_bytes_https, normalize_https_url
+from scripts.security_helpers import load_bytes_https, normalize_https_url  # noqa: E402
 
 
 def _parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## **User description**
## Summary

Resolves 8 Ruff_E402_module-import-not-at-top findings via two patterns:

1. **`run_coverage_gate.py`** (3 sites): Add `# noqa: E402` to imports following the canonical sys.path-bootstrap pattern. Matches established convention in `assert_coverage_100.py`, `drift_sync.py`, `template_render.py`, `validate_codecov_flags.py`.

2. **`admin_dashboard_pages.py`** (5 sites): Move `_NL = \"\n\"` constant after the stdlib import block. Constant is still module-level and accessible to all body builders that depend on it (Sonar python:S1192 dedup).

## Why noqa over reorder for run_coverage_gate.py

The sys.path bootstrap MUST run before importing `scripts.quality.*` packages — that's the whole point of the bootstrap. Reordering would break the script's standalone-CLI entry point.

## Test plan

- [x] `pytest -k \"coverage_gate or admin_dashboard or codacy_compatibility\"` — 53/53 pass
- [x] `python -m py_compile` on both files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 69 → 61 (-8 E402 findings)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes 8 E402 (module-import-not-at-top) findings without changing behavior. Keeps the sys.path bootstrap intact and cleans up import order.

- **Refactors**
  - Added `# noqa: E402` to imports after the sys.path insert in `run_coverage_gate.py` (`scripts.quality`, `scripts.security_helpers`) to preserve the CLI bootstrap.
  - Moved `_NL = "\n"` below stdlib imports in `admin_dashboard_pages.py` to keep imports at the top and maintain Sonar python:S1192 dedup.

<sup>Written for commit 7a7daf77fb88322ea843e87136d696755e34e01e. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Keep coverage and dashboard scripts working while fixing import-order warnings**

### What Changed
- Kept the coverage-gate script’s startup flow intact while marking imports that must come after the path setup as intentional
- Moved the shared newline constant below the import block in the admin dashboard page script so imports stay first
- No user-facing behavior changed; this only resolves lint and code-quality warnings

### Impact
`✅ Fewer CI quality warnings`
`✅ Cleaner dashboard script checks`
`✅ No change to runtime behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=SWJBosNj-Z7lgLhuYS_SHEsz88QSdf1eBD95qhgqTHU&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
