### PR TITLE
fix(codacy): E501+E702 batch — 9 line-too-long + multi-statement fixes

### DIFF
--- a/scripts/quality/check_chromatic_zero.py
+++ b/scripts/quality/check_chromatic_zero.py
@@ -63,7 +63,13 @@ def main(argv: List[str] | None = None) -> int:
 
     if args.out_md:
         status = "PASS" if passed else "FAIL"
-        md = f"# Chromatic Zero\n\n**Status:** {status}\n**Total:** {total}\n**Accepted:** {accepted}\n**Errored:** {errored}\n"
+        md = (
+            "# Chromatic Zero\n\n"
+            f"**Status:** {status}\n"
+            f"**Total:** {total}\n"
+            f"**Accepted:** {accepted}\n"
+            f"**Errored:** {errored}\n"
+        )
         out_md = Path(args.out_md)
         out_md.parent.mkdir(parents=True, exist_ok=True)
         out_md.write_text(md, encoding="utf-8")

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -32,13 +32,20 @@ SCOPED_ANALYSIS_RETRY_ATTEMPTS = 180  # PR analysis can lag several minutes behi
 @dataclass(frozen=True)
 class CodacyStatusResult:
     """Describe one resolved Codacy gate result."""
-    status: str; findings: List[str]; open_issues: int | None; pull_request: str
+    status: str
+    findings: List[str]
+    open_issues: int | None
+    pull_request: str
 
 
 @dataclass(frozen=True)
 class CodacyQuery:
     """Describe the repository and optional PR scope for one Codacy query."""
-    provider: str; owner: str; repo: str; pull_request: str = ""; sha: str = ""
+    provider: str
+    owner: str
+    repo: str
+    pull_request: str = ""
+    sha: str = ""
 
 CodacyPendingFn = Callable[[CodacyQuery, str], str | None]
 
@@ -46,8 +53,10 @@ CodacyPendingFn = Callable[[CodacyQuery, str], str | None]
 @dataclass(frozen=True)
 class CodacyRetryConfig:
     """Describe the retry settings for one Codacy zero-gate lookup."""
-    provider_candidates: Tuple[str, ...]; attempts: int
-    pending_fn: CodacyPendingFn; sleep_seconds: float
+    provider_candidates: Tuple[str, ...]
+    attempts: int
+    pending_fn: CodacyPendingFn
+    sleep_seconds: float
 
 
 def _mapping_or_empty(value: Any) -> Dict[str, Any]:

--- a/scripts/quality/rollup_v2/patches/dead_code.py
+++ b/scripts/quality/rollup_v2/patches/dead_code.py
@@ -20,7 +20,7 @@ def _scan_dead_block_end(lines: List[str], target_index: int, target_indent: int
     end_index = target_index
     while end_index < len(lines):
         line = lines[end_index]
-        if not line.strip():  # pragma: no cover -- blank line within dead block; tested but branch depends on exact whitespace
+        if not line.strip():  # pragma: no cover -- blank line in dead block; whitespace-dependent
             end_index += 1
             continue
         line_indent = len(line) - len(line.lstrip())
@@ -57,7 +57,7 @@ def generate(
     target_indent = len(target_line) - len(target_line.lstrip())
     end_index = _scan_dead_block_end(lines, target_index, target_indent)
 
-    if end_index == target_index:  # pragma: no cover -- defensive; requires target line to have lower indent than itself
+    if end_index == target_index:  # pragma: no cover -- defensive: target indent inversion
         return PatchDeclined(
             reason_code="ambiguous-fix",
             reason_text="could not identify unreachable block",

--- a/scripts/quality/rollup_v2/patches/mutable_default.py
+++ b/scripts/quality/rollup_v2/patches/mutable_default.py
@@ -24,7 +24,7 @@ def _build_def_line_replacement(target_line: str, match: re.Match) -> str:
     param_name = match.group(2)
     trailing = match.group(4)
     new_def_line = f"{prefix}{param_name}=None{trailing}{target_line[match.end():]}"
-    if not new_def_line.endswith("\n"):  # pragma: no cover -- source lines always end with newline from splitlines(keepends=True)
+    if not new_def_line.endswith("\n"):  # pragma: no cover -- splitlines(keepends=True) always retains \n
         new_def_line += "\n"
     return new_def_line
 
@@ -32,7 +32,10 @@ def _build_def_line_replacement(target_line: str, match: re.Match) -> str:
 def _find_body_start(lines: List[str], target_index: int) -> int:
     """Skip blank lines after the ``def`` to find where the body begins."""
     body_start = target_index + 1
-    while body_start < len(lines) and lines[body_start].strip() == "":  # pragma: no cover -- blank lines between def and body are rare
+    while (  # pragma: no cover -- blank lines between def and body are rare
+        body_start < len(lines)
+        and lines[body_start].strip() == ""
+    ):
         body_start += 1
     return body_start
 


### PR DESCRIPTION
## **User description**
## Summary

Resolves 9 Ruff findings via canonical PEP 8 splits:

- **`check_codacy_zero.py`** (4 E702): semicolon-packed dataclass fields → one field per line
- **`rollup_v2/patches/dead_code.py`** (2 E501): pragma comment shortening
- **`rollup_v2/patches/mutable_default.py`** (2 E501): one comment shortened; one restructured to parenthesised multi-line `while` (keeps pragma on the statement's first line where coverage.py recognises it)
- **`check_chromatic_zero.py`** (1 E501): long f-string → implicit string concatenation across 6 lines

## Why pragma placement matters

For the `mutable_default.py:35` site, the prior fix moved the pragma to a separate line below the `while` — coverage.py would not have honoured that. The parenthesised multi-line form keeps the pragma on the same logical line as `while (`, which is the form coverage.py recognises.

## Test plan

- [x] `pytest -k 'codacy or chromatic or dead_code or mutable_default or codacy_compatibility'` — 75/75 pass
- [x] `python -m py_compile` on all 4 files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 70 → 61 (-9: 4 E702 + 5 E501) plus PyLint C0321 echoes for the E702 sites (potentially -13 total)


___

## **CodeAnt-AI Description**
**Clean up quality-check script output and keep coverage skips working**

### What Changed
- Split packed field declarations and long lines into standard multi-line form so the quality-check scripts are easier to read and pass lint checks
- Kept the dead-code coverage note on the intended `while` line so the skip still applies where coverage tools expect it
- Reflowed the Chromatic Zero markdown summary across multiple lines without changing the generated report content
- Shortened a few inline comments in the quality-check scripts

### Impact
`✅ Fewer lint failures in quality-check scripts`
`✅ Reliable coverage skips in dead-code cleanup`
`✅ Same Chromatic Zero and Codacy report output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=zjKrNUQDFoVDh7Z6zE5DVnjxpouv9HFo0r_Yh0ASntc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
