### PR TITLE
fix(codacy): shellcheck + E741 batch — quote vars, source directive, rename ambiguous l

### DIFF
--- a/bin/pr-comments-check.sh
+++ b/bin/pr-comments-check.sh
@@ -25,7 +25,7 @@ UNADDRESSED=0
 echo "=== Inline Code Review Comments ==="
 
 # Fetch all comments first, fail if API error
-COMMENTS_JSON=$(gh api --paginate repos/$OWNER/$REPO_NAME/pulls/$PR_NUMBER/comments 2>&1) || {
+COMMENTS_JSON=$(gh api --paginate "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/comments" 2>&1) || {
   echo "API ERROR: Failed to fetch PR comments"
   echo "   $COMMENTS_JSON"
   exit 2
@@ -64,7 +64,7 @@ fi
 echo ""
 echo "=== General PR Discussion Comments ==="
 # List discussion comments (bot comments typically don't need replies)
-ISSUE_COMMENTS=$(gh api --paginate repos/$OWNER/$REPO_NAME/issues/$PR_NUMBER/comments 2>&1) || {
+ISSUE_COMMENTS=$(gh api --paginate "repos/${OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments" 2>&1) || {
   echo "WARNING: Could not fetch discussion comments"
   echo "   $ISSUE_COMMENTS"
 }

--- a/bin/pr-comments-filter.sh
+++ b/bin/pr-comments-filter.sh
@@ -16,6 +16,7 @@ set -e
 # Load environment variables if .env exists
 if [ -f .env ]; then
   set -a
+  # shellcheck source=/dev/null  # .env is operator-supplied at runtime
   source .env
   set +a
 fi

--- a/scripts/quality/rollup_v2/patches/hardcoded_secret.py
+++ b/scripts/quality/rollup_v2/patches/hardcoded_secret.py
@@ -57,7 +57,7 @@ def generate(
 
     # Add `import os` at the top if not already present
     has_os_import = any(
-        re.match(r"^\s*import\s+os\b", l) for l in lines
+        re.match(r"^\s*import\s+os\b", line) for line in lines
     )
     if not has_os_import:
         patched_lines.insert(0, "import os\n")

--- a/scripts/quality/rollup_v2/patches/wrong_import_order.py
+++ b/scripts/quality/rollup_v2/patches/wrong_import_order.py
@@ -81,7 +81,9 @@ def _find_import_block(lines: List[str]) -> Optional[Tuple[int, int]]:
 
 def _build_sorted_block(import_lines: List[str]) -> List[str]:
     """Sort import lines by group and build a block with group separators."""
-    sorted_imports = sorted(import_lines, key=lambda l: (_classify_import(l), l.strip()))
+    sorted_imports = sorted(
+        import_lines, key=lambda imp: (_classify_import(imp), imp.strip())
+    )
     grouped: List[str] = []
     prev_group = -1
     for imp in sorted_imports:


### PR DESCRIPTION
## **User description**
## Summary

Resolves 5 findings across two languages:

- **`bin/pr-comments-check.sh`** (2x SC2086): quote variables in two `gh api` argument paths
- **`bin/pr-comments-filter.sh`** (1x SC1091): add `# shellcheck source=/dev/null` directive above `source .env` (runtime-supplied file)
- **`rollup_v2/patches/hardcoded_secret.py:60`** (1x E741): rename `l` → `line`
- **`rollup_v2/patches/wrong_import_order.py:84`** (1x E741): rename lambda `l` → `imp`

## Why these specific fixes

- **SC2086**: Even though `${PR_NUMBER}` is numeric and unlikely to contain spaces, shellcheck flags any unquoted variable expansion in command arguments. Adding quotes is the canonical fix and costs nothing at runtime.
- **SC1091**: This is the documented shellcheck escape for runtime-only sourced files. Cleaner than disabling shellcheck globally for the file.
- **E741**: PEP 8 forbids single-character `l`/`I`/`O` because they're visually ambiguous (l vs 1, O vs 0). `line` and `imp` carry meaning.

## Test plan

- [x] `pytest -k 'hardcoded_secret or wrong_import_order or codacy_compatibility'` — 11/11 pass
- [x] `bash -n` parse-check on both shell scripts
- [x] `python -m py_compile` on both Python files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 38 → 33 (-5: 2 SC2086 + 1 SC1091 + 2 E741)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix ShellCheck (SC2086, SC1091) and Python E741 warnings by quoting vars, adding a safe source directive, and renaming ambiguous identifiers. Removes 5 Codacy findings with no behavior changes.

- **Bug Fixes**
  - bin/pr-comments-check.sh: quote variables in two `gh api` calls (SC2086).
  - bin/pr-comments-filter.sh: add `# shellcheck source=/dev/null` before `source .env` (SC1091).
  - scripts/quality/rollup_v2/patches/hardcoded_secret.py: rename `l` to `line` (E741).
  - scripts/quality/rollup_v2/patches/wrong_import_order.py: rename lambda param `l` to `imp` and rewrap call (E741).

<sup>Written for commit 3a24c156367713a3eec8935d60517d239e07a532. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Clean up PR comment scripts and patch generators

### What Changed
- Quoted PR comment API paths so repo and PR values are handled safely even when they contain spaces or special characters
- Added a shellcheck source note for the runtime `.env` file so the filter script can load local settings without triggering a warning
- Renamed ambiguous single-letter variables in the patch generators to clearer names

### Impact
`✅ Fewer PR comment check failures`
`✅ Safer handling of repository and PR names`
`✅ Cleaner Codacy and shell checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=SgE409bIefWX3Dzt_wOXzzVDiGLS9dqnDLduGsNGnYU&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
