### PR TITLE
fix(codacy): pylint batch — R0902 + W0718 disable + bypass_labels CLI extraction

### DIFF
--- a/scripts/quality/bypass_labels.py
+++ b/scripts/quality/bypass_labels.py
@@ -207,7 +207,14 @@ def append_jsonl(audit_path: Path, record: Mapping[str, Any]) -> None:
         handle.write(line + "\n")
 
 
-if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+def _run_cli() -> None:  # pragma: no cover — ad-hoc CLI
+    """Dispatch one bypass-label decision from argv + stdin to stdout.
+
+    Wrapped in a function (rather than inlined under ``if __name__ ==
+    "__main__":``) so all locals stay local-scoped — at module level
+    pylint treats every name as a constant and flags ``filename`` as a
+    C0103 invalid-name finding for not being UPPER_CASE.
+    """
     if len(sys.argv) < 6:
         print(
             "usage: bypass_labels.py <label> <pr_slug> <pr_number> "
@@ -215,22 +222,26 @@ if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
             file=sys.stderr,
         )
         raise SystemExit(2)
-    _label, _slug, _pr_num, _sha, _actor, _audit_dir = sys.argv[1:7]
-    _body = sys.stdin.read()
-    if _label == BREAK_GLASS_LABEL:
-        _decision = evaluate_break_glass(_body, _slug, int(_pr_num), _sha, _actor)
-        _filename = "break-glass.jsonl"
-    elif _label == SKIP_LABEL:
-        _decision = evaluate_skip(_body, _slug, int(_pr_num), _sha, _actor)
-        _filename = "skip.jsonl"
+    label, slug, pr_num, sha, actor, audit_dir = sys.argv[1:7]
+    body = sys.stdin.read()
+    if label == BREAK_GLASS_LABEL:
+        decision = evaluate_break_glass(body, slug, int(pr_num), sha, actor)
+        filename = "break-glass.jsonl"
+    elif label == SKIP_LABEL:
+        decision = evaluate_skip(body, slug, int(pr_num), sha, actor)
+        filename = "skip.jsonl"
     else:
-        print(f"unknown label: {_label}", file=sys.stderr)
+        print(f"unknown label: {label}", file=sys.stderr)
         raise SystemExit(2)
-    if _decision.audit_record is not None:
-        append_jsonl(Path(_audit_dir) / _filename, _decision.audit_record)
+    if decision.audit_record is not None:
+        append_jsonl(Path(audit_dir) / filename, decision.audit_record)
     print(json.dumps({
-        "label": _decision.label,
-        "allowed": _decision.allowed,
-        "incident": _decision.incident,
-        "tracking_issue_title": _decision.tracking_issue_title,
+        "label": decision.label,
+        "allowed": decision.allowed,
+        "incident": decision.incident,
+        "tracking_issue_title": decision.tracking_issue_title,
     }))
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    _run_cli()

--- a/scripts/quality/rollup_v2/normalizers/_base.py
+++ b/scripts/quality/rollup_v2/normalizers/_base.py
@@ -28,7 +28,7 @@ class NormalizerResult:
 
 
 @dataclass(frozen=True, slots=True)
-class FindingDraft:
+class FindingDraft:  # pylint: disable=too-many-instance-attributes
     """Per-result fields supplied by a normalizer; redacted by ``_build_finding``.
 
     Bundled into one dataclass so :py:meth:`BaseNormalizer._build_finding` keeps
@@ -80,7 +80,7 @@ class BaseNormalizer(ABC):
         drops: List[Dict[str, str]] = []
         try:
             raw = list(self.parse(artifact, repo_root))
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             errors.append({
                 "provider": self.provider,
                 "error_class": exc.__class__.__name__,

--- a/scripts/quality/rollup_v2/pipeline.py
+++ b/scripts/quality/rollup_v2/pipeline.py
@@ -95,7 +95,7 @@ def _apply_patches(
             patch_result = patch_dispatcher.dispatch(
                 f, source_file_content=source_content, repo_root=repo_root
             )
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             # Error boundary: patch generation failure is non-fatal (§A.6)
             patched = replace(
                 f,

--- a/scripts/quality/rollup_v2/schema/finding.py
+++ b/scripts/quality/rollup_v2/schema/finding.py
@@ -26,11 +26,18 @@ Corroboration = Literal["multi", "single"]
 
 
 @dataclass(frozen=True, slots=True)
-class Finding:
+class Finding:  # pylint: disable=too-many-instance-attributes
     """Canonical finding produced by any provider normalizer.
 
     All string fields that may contain user/provider content have been passed
     through `redact_secrets()` by the normalizer before construction (see §B.1).
+
+    The 22 attributes are deliberate: this is the union of every column that
+    any downstream consumer (renderer, dedup, patch dispatch, alerts, codex
+    prompt) needs from a finding. Splitting into sub-records would force
+    every consumer to navigate nested objects to read fields they already
+    treat as flat. ``# pylint: disable=too-many-instance-attributes`` keeps
+    the canonical-record intent without per-attribute justification noise.
     """
     schema_version: str
     finding_id: str

--- a/scripts/quality/sonar_zero_support.py
+++ b/scripts/quality/sonar_zero_support.py
@@ -20,7 +20,7 @@ FinalFindingsFn = Callable[[List[str], str | None], List[str]]
 
 
 @dataclass(frozen=True)
-class AnalysisRevisionConfig:
+class AnalysisRevisionConfig:  # pylint: disable=too-many-instance-attributes
     """Configuration needed to resolve one Sonar analysis revision."""
 
     request_json: RequestFn


### PR DESCRIPTION
## **User description**
## Summary

Resolves 7 pylint findings via two distinct mechanisms.

### R0902 too-many-instance-attributes (3 sites) — per-class disable

These are canonical dataclasses where bundling fields is the design choice. Splitting them would force every consumer to navigate nested objects to read fields they already treat as flat.

- **`Finding`** (22 attrs): canonical finding contract — renderer/dedup/patch/alerts/codex all read it flat
- **`FindingDraft`** (15 attrs): bundles parser-supplied fields so `_build_finding` keeps a small parameter count
- **`AnalysisRevisionConfig`** (10 attrs): DI container for Sonar revision resolution

### W0718 broad-exception-caught (2 sites) — per-site disable

Both sites are documented error boundaries per design §A.6 — each crash is recorded, not propagated, so one bad provider/finding doesn't kill the whole pipeline.

- `rollup_v2/normalizers/_base.py:83` (parse() crash boundary)
- `rollup_v2/pipeline.py:98` (patch dispatch crash boundary)

### C0103 invalid-name (2 sites) — `_run_cli()` extraction

`bypass_labels.py` had its CLI logic inline under `if __name__ == \"__main__\":`. At module level pylint treats every name assignment as a constant — flagging `_filename` as not-UPPER_CASE. Wrapping in a function moves the names into local scope where snake_case is correct. Also drops the `_` prefix on the other locals (`label`, `slug`, etc.) since they're no longer pretending to be module-private constants.

## Test plan

- [x] `pytest -k 'bypass_labels or finding or sonar_zero or pipeline or normalizer or codacy_compatibility'` — 221/221 pass
- [x] `python -m py_compile` on all 5 files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 33 → 26 (-7: 3 R0902 + 2 W0718 + 2 C0103)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduces Codacy pylint findings by 7. Keeps intentional data shapes, documents error boundaries, and cleans up the `bypass_labels.py` CLI.

- **Refactors**
  - Disable R0902 on intentional wide dataclasses: `Finding`, `FindingDraft`, `AnalysisRevisionConfig`.
  - Add per-site W0718 disables at documented error boundaries in the normalizer base and patch dispatch.
  - Extract `_run_cli()` in `bypass_labels.py` to fix C0103 by scoping CLI locals; behavior unchanged.

<sup>Written for commit 1ed371e552443f6cb706fc6ac69155be5e019a58. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Silence lint warnings for the quality tooling without changing its behavior

### What Changed
- Kept the main finding record and related config objects as wide, flat data structures so they are treated as intentional rather than lint errors
- Kept crash handling in the normalizer and patch flow, while marking those catch-all boundaries as expected
- Moved the label-bypass command-line logic into a function so its local values are handled correctly when run from the command line

### Impact
`✅ Fewer lint failures in quality checks`
`✅ Unchanged CLI behavior for label bypass decisions`
`✅ Cleaner release gate runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ZUHUkrs8Cqm-jqE0O9TSEh7jxtdtStCzgJM6XI8esXw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
