### PR TITLE
fix(sonar): remove unused repo_root parameter from parse_sarif (S1172)

### DIFF
--- a/scripts/quality/rollup_v2/normalizers/_sarif.py
+++ b/scripts/quality/rollup_v2/normalizers/_sarif.py
@@ -214,10 +214,15 @@ def _iter_sarif_results(runs: List[Any]) -> Iterable[Tuple[Dict[str, Any], Dict[
 def parse_sarif(
     data: Dict[str, Any],
     provider: str,
-    repo_root: Path,
     normalizer: BaseNormalizer,
 ) -> List[Finding]:
-    """Parse a SARIF 2.1.0 payload and return canonical Finding objects."""
+    """Parse a SARIF 2.1.0 payload and return canonical Finding objects.
+
+    SARIF artifact paths are taken from ``artifactLocation.uri`` as-is —
+    the rollup pipeline's path-safety check (``_base.run`` →
+    ``validate_finding_file``) handles repo-root validation downstream,
+    so this parser does not need ``repo_root`` itself.
+    """
     runs = data.get("runs", [])
     if not isinstance(runs, list):
         return []
@@ -251,4 +256,5 @@ class SarifBackedNormalizer(BaseNormalizer):
             data = artifact
         else:
             return []
-        return parse_sarif(data, self.provider, repo_root, self)
+        del repo_root  # forwarded by BaseNormalizer.run() but unused here
+        return parse_sarif(data, self.provider, self)

--- a/tests/quality/rollup_v2/test_sarif_common.py
+++ b/tests/quality/rollup_v2/test_sarif_common.py
@@ -116,7 +116,7 @@ class ParseSarifTests(unittest.TestCase):
 
     def test_empty_results(self):
         sarif = _minimal_sarif(results=[])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings, [])
 
     def test_parses_single_result(self):
@@ -129,7 +129,7 @@ class ParseSarifTests(unittest.TestCase):
                 start_column=10,
             ),
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
         f = findings[0]
         self.assertEqual(f.file, "src/app.py")
@@ -153,7 +153,7 @@ class ParseSarifTests(unittest.TestCase):
                 "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 2}}}],
             },
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 2)
         self.assertEqual(findings[0].severity, "medium")
         self.assertEqual(findings[1].severity, "low")
@@ -168,14 +168,14 @@ class ParseSarifTests(unittest.TestCase):
                     "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}],
                 }
             ])
-            findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+            findings = parse_sarif(sarif, "TestProvider", self.normalizer)
             self.assertEqual(findings[0].severity, expected_sev, f"level={level}")
 
     def test_missing_locations_defaults(self):
         sarif = _minimal_sarif(results=[
             {"ruleId": "no-loc", "level": "warning", "message": {"text": "no location"}}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].file, "unknown")
         self.assertEqual(findings[0].line, 1)
@@ -190,7 +190,7 @@ class ParseSarifTests(unittest.TestCase):
                 "properties": {"cwe": "CWE-79"},
             }
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].cwe, "CWE-79")
 
     def test_cwe_extraction_from_tags(self):
@@ -203,7 +203,7 @@ class ParseSarifTests(unittest.TestCase):
                 "properties": {"tags": ["CWE-89", "security"]},
             }
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].cwe, "CWE-89")
 
     def test_security_tags_set_category_group(self):
@@ -216,7 +216,7 @@ class ParseSarifTests(unittest.TestCase):
                 "properties": {"tags": ["security"]},
             }
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].category_group, "security")
 
     def test_context_snippet_extraction(self):
@@ -239,7 +239,7 @@ class ParseSarifTests(unittest.TestCase):
                 ],
             }
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].context_snippet, snippet_text)
 
     def test_rule_url_from_driver_rules(self):
@@ -265,17 +265,17 @@ class ParseSarifTests(unittest.TestCase):
                 ],
             }],
         }
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].corroborators[0].rule_url, "https://example.com/rule-with-help")
 
     def test_malformed_runs_returns_empty(self):
-        findings = parse_sarif({"runs": "not-a-list"}, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif({"runs": "not-a-list"}, "TestProvider", self.normalizer)
         self.assertEqual(findings, [])
 
     def test_malformed_results_in_run(self):
         sarif = {"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "T", "rules": []}}, "results": "not-list"}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings, [])
 
     def test_end_line_extraction(self):
@@ -284,7 +284,7 @@ class ParseSarifTests(unittest.TestCase):
                 rule_id="end-line-test", start_line=5, end_line=10,
             ),
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].end_line, 10)
 
     def test_finding_id_format(self):
@@ -292,7 +292,7 @@ class ParseSarifTests(unittest.TestCase):
             {"ruleId": "r1", "level": "warning", "message": {"text": "a"}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]},
             {"ruleId": "r2", "level": "warning", "message": {"text": "b"}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 2}}}]},
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].finding_id, "testprovider-0000")
         self.assertEqual(findings[1].finding_id, "testprovider-0001")
 
@@ -316,7 +316,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}],
              "properties": "not-a-dict"}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_tags_not_list_returns_empty_tags(self):
@@ -325,7 +325,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}],
              "properties": {"tags": "not-a-list"}}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_cwe_not_in_props_falls_to_tags(self):
@@ -334,7 +334,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}],
              "properties": {"cwe": ""}}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertIsNone(findings[0].cwe)
 
     def test_location_non_dict_returns_defaults(self):
@@ -342,7 +342,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": ["not-a-dict"]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].file, "unknown")
 
     def test_region_not_dict_falls_back(self):
@@ -350,7 +350,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": "not-dict"}}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].line, 1)
 
     def test_context_snippet_non_dict_loc(self):
@@ -358,7 +358,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [42]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].context_snippet, "")
 
     def test_context_snippet_non_dict_phys(self):
@@ -366,7 +366,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": "not-dict"}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].context_snippet, "")
 
     def test_context_snippet_non_dict_region(self):
@@ -374,7 +374,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": 42}}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].context_snippet, "")
 
     def test_context_snippet_string_snippet(self):
@@ -382,12 +382,12 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1, "snippet": "string-not-dict"}}}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].context_snippet, "")
 
     def test_run_not_dict_skipped(self):
         sarif = {"runs": ["not-a-dict", {"tool": {"driver": {"name": "T", "rules": []}}, "results": []}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings, [])
 
     def test_tool_not_dict_no_rules(self):
@@ -395,7 +395,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_driver_not_dict_no_rules(self):
@@ -403,7 +403,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_rules_not_list(self):
@@ -411,7 +411,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_rule_not_dict_skipped(self):
@@ -419,7 +419,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_rule_empty_id_skipped(self):
@@ -427,12 +427,12 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(len(findings), 1)
 
     def test_result_not_dict_skipped(self):
         sarif = _minimal_sarif(results=["not-a-dict"])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings, [])
 
     def test_message_as_string(self):
@@ -440,7 +440,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": "plain string",
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].primary_message, "plain string")
 
     def test_message_as_int_falls_through(self):
@@ -448,7 +448,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": 42,
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ])
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertEqual(findings[0].primary_message, "")
 
     def test_help_uri_not_string_ignored(self):
@@ -456,7 +456,7 @@ class SarifDefensiveBranchTests(unittest.TestCase):
             {"ruleId": "r", "level": "warning", "message": {"text": "m"},
              "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}, "region": {"startLine": 1}}}]}
         ]}]}
-        findings = parse_sarif(sarif, "TestProvider", self.root, self.normalizer)
+        findings = parse_sarif(sarif, "TestProvider", self.normalizer)
         self.assertIsNone(findings[0].corroborators[0].rule_url)
 
 


### PR DESCRIPTION
## **User description**
## Summary

Sonar python:S1172 flagged `parse_sarif()` for an unused `repo_root` argument introduced in PR #201's SARIF refactor. The parser takes paths from `artifactLocation.uri` as-is — the rollup pipeline's path-safety check (`_base.run` → `validate_finding_file`) handles repo-root validation downstream, so the parser doesn't need it.

## Changes

- **`scripts/quality/rollup_v2/normalizers/_sarif.py`**:
  - Drop `repo_root` from `parse_sarif()` signature
  - Document why in the docstring
  - Add `del repo_root` in `SarifBackedNormalizer.parse` to mark the (still-required) base-class arg as intentionally unused

- **`tests/quality/rollup_v2/test_sarif_common.py`**: Update 33 call sites to drop the old positional argument

## Why orthogonal to PR #208

#208 touches `_base.py`, `pipeline.py`, `finding.py`, `sonar_zero_support.py`, `bypass_labels.py`. This PR only touches `_sarif.py` + its test file. No conflicts.

## Test plan

- [x] `pytest -k 'sarif or codeql or semgrep'` — 68/68 pass
- [x] `python -m py_compile` on both files
- [ ] Sonar Zero gate green (this is the fix)
- [ ] Codacy Zero gate green (no Codacy regression)

## Expected delta

- Sonar code_smells: 1 → 0 (the only smell on QZP main)
- Codacy: no change (-0)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the unused `repo_root` parameter from `parse_sarif()` to resolve Sonar python:S1172 and simplify the parser. Paths are read from `artifactLocation.uri` and validated later in the rollup via `_base.run` → `validate_finding_file`.

- **Bug Fixes**
  - Dropped `repo_root` from `parse_sarif()` and documented the rationale.
  - In `SarifBackedNormalizer.parse`, explicitly ignore the forwarded `repo_root` with `del`.
  - Updated tests to use the new `parse_sarif()` signature.

<sup>Written for commit 4956d4f6fba5997f8098d09218163d3972168cb9. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/209?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Remove an unused SARIF path argument**

### What Changed
- SARIF parsing no longer takes a repo root value it does not use
- The parser now relies on the file path from the SARIF result itself, while repo-root checks still happen later in the rollup flow
- Updated SARIF tests to use the shorter parser call

### Impact
`✅ Fewer Sonar code smells`
`✅ Simpler SARIF parsing calls`
`✅ No change to SARIF path validation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=aAYXFvZUDMzGHzvx4vkQ2rgb94JpC2xkbAeo6iqW5S8&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
