### PR TITLE
fix(codacy): Checkov CKV_GHA_7 batch — workflow input suppressions

### DIFF
--- a/.github/workflows/bump-workflow-shas-wave.yml
+++ b/.github/workflows/bump-workflow-shas-wave.yml
@@ -9,6 +9,7 @@ name: Bump Workflow SHAs Wave
 
 permissions: {}
 
+# checkov:skip=CKV_GHA_7:operator-dispatched fleet sweep; inputs are control-plane params (target SHA, dry-run flag, slug filter), not build-output mutators
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/drift-sync-wave.yml
+++ b/.github/workflows/drift-sync-wave.yml
@@ -8,6 +8,7 @@ name: Drift Sync Wave
 
 permissions: {}
 
+# checkov:skip=CKV_GHA_7:operator-dispatched fleet sweep; inputs are control-plane params (dry-run flag, slug filter), not build-output mutators
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/reusable-bootstrap-repo.yml
+++ b/.github/workflows/reusable-bootstrap-repo.yml
@@ -17,6 +17,7 @@ name: Reusable Bootstrap Repo
 
 permissions: {}
 
+# checkov:skip=CKV_GHA_7:operator-dispatched bootstrap; inputs are control-plane params (target repo, stack name), not build-output mutators
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/reusable-bumps.yml
+++ b/.github/workflows/reusable-bumps.yml
@@ -19,6 +19,7 @@ name: Reusable Bumps
 
 permissions: {}
 
+# checkov:skip=CKV_GHA_7:fleet-bump orchestrator; inputs are control-plane params (recipe path, fleet inventory, dry-run flag), not build-output mutators
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/scheduled-alerts.yml
+++ b/.github/workflows/scheduled-alerts.yml
@@ -17,6 +17,7 @@ name: Scheduled Alerts
 
 permissions: {}
 
+# checkov:skip=CKV_GHA_7:dry_run is a control-plane flag (computes triggers without firing gh CLI), not a build-output mutator
 on:
   schedule:
     # Every 6 hours, offset by 17 minutes to avoid the top-of-hour


### PR DESCRIPTION
## **User description**
## Summary

Resolves 5 Checkov_CKV_GHA_7 findings via documented per-file suppression directives.

## Why suppress vs refactor

CKV_GHA_7 fires on every \`workflow_dispatch\` input regardless of whether the input is a build mutator or a control-plane flag. All 5 flagged workflows are **operator-dispatched fleet orchestrators** where inputs gate side-effects (PR creation, issue opening, fleet bumps) rather than mutate build output:

| Workflow | Inputs | Purpose |
|---|---|---|
| scheduled-alerts.yml | dry_run | Toggle whether triggers fire gh CLI |
| bump-workflow-shas-wave.yml | target_sha, dry_run, slug_filter | Fleet sweep dispatch |
| reusable-bumps.yml | recipe_path, fleet_path, dry_run | Fleet-bump orchestrator |
| drift-sync-wave.yml | dry_run, slug_filter | Drift PR gate |
| reusable-bootstrap-repo.yml | repo_slug, stack | Bootstrap target |

The rule cannot distinguish these from build mutators. Per-file \`# checkov:skip=CKV_GHA_7:<reason>\` documents the justification at each call site.

## Test plan

- [x] \`yaml.safe_load\` succeeds on all 5 workflows (parse validation)
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 24 → 19 (-5: 5 CKV_GHA_7 findings)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Suppresses false-positive CKV_GHA_7 findings in five GitHub Actions workflows by documenting control‑plane inputs at the `on: workflow_dispatch` block. No runtime behavior changes; this unblocks Codacy.

- **Bug Fixes**
  - Added `# checkov:skip=CKV_GHA_7:<reason>` above `on:` in five operator-dispatched orchestrators (scheduled-alerts.yml, bump-workflow-shas-wave.yml, reusable-bumps.yml, drift-sync-wave.yml, reusable-bootstrap-repo.yml). Inputs are control-plane flags like `dry_run`, `target_sha`, and `slug_filter`, not build-output mutators.
  - Codacy delta: 24 → 19 (-5). YAML validation passes.

<sup>Written for commit 2d3e9a9f7a5c3ca2b0e1e3c46c7635fe9fba786f. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Document workflow dispatch inputs so Codacy stops flagging valid manual fleet runs**

### What Changed
- Added Checkov suppression notes to five manually triggered GitHub Actions workflows so their control flags are treated as operator inputs, not build changes
- Kept the workflows’ behavior the same while clearly documenting why each manual input is allowed
- This removes false-positive security findings from the affected workflow files

### Impact
`✅ Fewer false security alerts in workflow checks`
`✅ Cleaner Codacy results for manual fleet workflows`
`✅ Unblocked CI gates without changing runtime behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Ul44NcHSqNoF6BhofCdGKvKadKY9gmVaCWEAhDpI0xk&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
