### PR TITLE
fix(codacy): SIM batch — needless-bool, suppressible-exception, ternary

### DIFF
--- a/scripts/quality/admin_dashboard_pages.py
+++ b/scripts/quality/admin_dashboard_pages.py
@@ -114,13 +114,11 @@ def render_drift_page(
         slug = html.escape(str(entry.get("slug", "")))
         status = html.escape(str(entry.get("status", "")))
         pr_url = str(entry.get("pr_url", ""))
-        if pr_url:
-            pr_cell = (
-                f"<a href=\"{html.escape(pr_url)}\">"
-                f"{html.escape(pr_url)}</a>"
-            )
-        else:
-            pr_cell = "&mdash;"
+        pr_cell = (
+            f'<a href="{html.escape(pr_url)}">{html.escape(pr_url)}</a>'
+            if pr_url
+            else "&mdash;"
+        )
         rows.append(
             f"      <tr><td>{slug}</td><td>{status}</td><td>{pr_cell}</td></tr>",
         )

--- a/scripts/quality/profile_coverage_normalization.py
+++ b/scripts/quality/profile_coverage_normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import contextlib
 import re
 from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Sequence, Tuple
@@ -83,12 +84,10 @@ def _add_optional_input_fields(item: Mapping[str, Any], dest: Dict[str, Any]) ->
             str(s).strip() for s in item["sources"] if str(s).strip()
         ]
     if "min_percent" in item:
-        try:
+        # Drop the field on parse error so downstream consumers fall
+        # back to the schema default rather than a malformed value.
+        with contextlib.suppress(TypeError, ValueError):
             dest["min_percent"] = float(item["min_percent"])
-        except (TypeError, ValueError):
-            # Drop the field on parse error so downstream consumers fall
-            # back to the schema default rather than a malformed value.
-            pass
 
 
 def _normalize_one_input(item: Any) -> Dict[str, Any] | None:

--- a/scripts/quality/security_class_guard.py
+++ b/scripts/quality/security_class_guard.py
@@ -99,9 +99,7 @@ def _has_security_tag(finding: Mapping[str, Any]) -> bool:
     haystack = " | ".join(haystack_parts)
     if _CWE_RE.search(haystack):
         return True
-    if _OWASP_RE.search(haystack):
-        return True
-    return False
+    return bool(_OWASP_RE.search(haystack))
 
 
 def is_security_finding(finding: Mapping[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

Resolves 3 Ruff_SIM findings via canonical Pythonic simplifications.

| Site | Rule | Before | After |
|---|---|---|---|
| `security_class_guard.py:102` | SIM103 needless-bool | `if _OWASP_RE.search(...): return True; return False` | `return bool(_OWASP_RE.search(...))` |
| `profile_coverage_normalization.py:86` | SIM105 suppressible-exception | `try: ... except (TypeError, ValueError): pass` | `with contextlib.suppress(TypeError, ValueError):` |
| `admin_dashboard_pages.py:117` | SIM108 if-else-block | 7-line if/else block | single-expression ternary |

All three are documented Pythonic patterns — `contextlib.suppress`, `bool(re.search(...))`, and ternary expressions are idiomatic Python.

## Test plan

- [x] `pytest -k 'security_class or profile_coverage or admin_dashboard or codacy_compatibility'` — 60/60 pass
- [x] `ruff check scripts/ --select SIM103,SIM105,SIM108` — All checks passed!
- [x] `python -m py_compile` on all 3 files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 19 → 16 (-3: 1 SIM103 + 1 SIM105 + 1 SIM108)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified three spots to resolve SIM103, SIM105, and SIM108 from `ruff`. No behavior changes; code is clearer and Codacy issues drop by 3.

- **Refactors**
  - `scripts/quality/security_class_guard.py`: replace needless bool with `return bool(_OWASP_RE.search(haystack))` (SIM103).
  - `scripts/quality/profile_coverage_normalization.py`: use `contextlib.suppress(TypeError, ValueError)` when parsing `min_percent` (SIM105).
  - `scripts/quality/admin_dashboard_pages.py`: use a ternary to render the `pr_url` cell in one expression (SIM108).

<sup>Written for commit dbedaf525e4d9e013e6770fb34aa112c468b1d8d. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/211?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

