### PR TITLE
fix(codacy): single-finding cleanup batch — 7 mechanical fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ When `TeamCreate` and `SendMessage` tools are available, the orchestrator uses T
 ## Guides
 
 Development patterns and standards are documented in `guides/`:
+
 - `agent-coordination.md` — Team Mode vs Task Mode, agent dispatch patterns
 - `build-validation.md` — Build and validation workflow
 - `coding-standards.md` — Code style and conventions

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It replaces the old queue/template baseline with reusable workflows, shared qual
 
 > [!IMPORTANT]
 > **Where to start:**
+>
 > - **Adding a new repo to the fleet?** → [`docs/ONBOARDING.md`](docs/ONBOARDING.md)
 > - **Choosing gates / thresholds?** → [`docs/QUALITY-GATES.md`](docs/QUALITY-GATES.md)
 > - **Running fleet-wide operations?** → [`docs/OPERATOR-RUNBOOK.md`](docs/OPERATOR-RUNBOOK.md)

--- a/scripts/quality/alerts.py
+++ b/scripts/quality/alerts.py
@@ -75,7 +75,7 @@ class AlertType(enum.Enum):
     FLEET_BUMP_FAIL = "alert:fleet-bump-fail"
     REPO_NOT_PROFILED = "alert:repo-not-profiled"
     FLAG_MISSING = "alert:flag-missing"
-    SECRET_MISSING = "alert:secret-missing"  # nosec B105 — issue label, not a credential
+    SECRET_MISSING = "alert:secret-missing"  # noqa: S105  # nosec — issue label, not a credential
 
     @property
     def label(self) -> str:

--- a/scripts/quality/bump_workflow_shas.py
+++ b/scripts/quality/bump_workflow_shas.py
@@ -106,7 +106,14 @@ def bump_workflow_files(
     return results
 
 
-if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+def _run_cli() -> None:  # pragma: no cover — ad-hoc CLI
+    """Dispatch one bump-workflow-shas run from argv to stdout/stderr.
+
+    Wrapped in a function so the loop variable ``path`` stays local and
+    doesn't shadow the same-named loop variable in
+    ``bump_workflow_files`` (pylint W0621 — see
+    ``reference_pylint_c0103_module_main_block`` memory).
+    """
     import argparse
     import json
 
@@ -123,27 +130,31 @@ if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
         "--apply", action="store_true",
         help="Write changes to disk (default: dry-run, prints a summary).",
     )
-    _args = parser.parse_args()
+    args = parser.parse_args()
 
-    _wd = Path(_args.workflow_dir)
-    if not _wd.is_dir():
-        print(f"workflow dir not found: {_wd}", file=sys.stderr)
+    workflow_dir = Path(args.workflow_dir)
+    if not workflow_dir.is_dir():
+        print(f"workflow dir not found: {workflow_dir}", file=sys.stderr)
         raise SystemExit(2)
 
-    _files = {
+    files = {
         str(p): p.read_text(encoding="utf-8")
-        for p in sorted(_wd.glob("*.yml"))
+        for p in sorted(workflow_dir.glob("*.yml"))
     }
-    _results = bump_workflow_files(_files, target_sha=_args.target_sha)
+    results = bump_workflow_files(files, target_sha=args.target_sha)
 
     summary = {
-        path: result["bumped"] for path, result in _results.items()
+        path: result["bumped"] for path, result in results.items()
     }
     print(json.dumps(summary, indent=2, sort_keys=True))
 
-    if _args.apply:
-        for path, result in _results.items():
+    if args.apply:
+        for path, result in results.items():
             if result["bumped"]:
                 Path(path).write_text(result["new_text"], encoding="utf-8")
                 print(f"wrote {path} ({result['bumped']} pin(s) bumped)",
                       file=sys.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover — ad-hoc CLI
+    _run_cli()

--- a/scripts/quality/coverage_findings.py
+++ b/scripts/quality/coverage_findings.py
@@ -2,10 +2,12 @@
 
 from __future__ import absolute_import
 
-from typing import List, Set, Tuple
+from typing import TYPE_CHECKING, List, Set, Tuple
 
 from scripts.quality.coverage_paths import _normalize_source_path
-from scripts.quality.coverage_types import CoverageStats
+
+if TYPE_CHECKING:
+    from scripts.quality.coverage_types import CoverageStats
 
 
 def _matches_required_source(source_path: str, required_source: str) -> bool:

--- a/scripts/quality/rollup_v2/pipeline.py
+++ b/scripts/quality/rollup_v2/pipeline.py
@@ -69,7 +69,7 @@ def _derive_autofixable(findings: List[Finding]) -> List[Finding]:
     autofixable = (patch_source != "none")
     """
     return [
-        replace(f, autofixable=(f.patch_source != "none"))
+        replace(f, autofixable=f.patch_source != "none")
         for f in findings
     ]
 

--- a/scripts/quality/security_class_guard.py
+++ b/scripts/quality/security_class_guard.py
@@ -24,7 +24,7 @@ open-pr-and-wait.
 
 ``ensure_pr_only_for_security(findings)`` is the assertion the loop
 uses as a belt-and-suspenders guard: it raises
-``SecurityAutoMergeRefused`` if called with a mode ``auto_merge`` AND
+``SecurityAutoMergeRefusedError`` if called with a mode ``auto_merge`` AND
 any finding is security-class.
 """
 
@@ -65,7 +65,7 @@ _CWE_RE = re.compile(r"\bCWE-\d+\b", re.IGNORECASE)
 _OWASP_RE = re.compile(r"\bA0\d:\d{4}\b", re.IGNORECASE)
 
 
-class SecurityAutoMergeRefused(RuntimeError):
+class SecurityAutoMergeRefusedError(RuntimeError):
     """Raised when QRv2 tries to auto-merge a security-class remediation."""
 
 
@@ -136,7 +136,7 @@ def ensure_pr_only_for_security(
 ) -> None:
     """Belt-and-suspenders guard called by the QRv2 loop.
 
-    Raises :class:`SecurityAutoMergeRefused` when ``intends_auto_merge``
+    Raises :class:`SecurityAutoMergeRefusedError` when ``intends_auto_merge``
     is true AND any finding in ``findings`` is security-class. Silent
     when no auto-merge is intended or no security-class findings are
     present.
@@ -149,7 +149,7 @@ def ensure_pr_only_for_security(
             str(f.get("id") or f.get("rule") or "<anonymous>")
             for f in classified.must_open_pr
         )
-        raise SecurityAutoMergeRefused(
+        raise SecurityAutoMergeRefusedError(
             f"QRv2 refused to auto-merge: security-class findings present "
             f"({ids}). Security-class remediations must open a PR."
         )

--- a/tests/test_security_class_guard.py
+++ b/tests/test_security_class_guard.py
@@ -3,7 +3,7 @@
 Verifies that synthetic security-class findings (Dependabot-class,
 CWE-tagged, scanner-name heuristic, category flag, OWASP reference)
 are all pulled out of the auto-merge-eligible set. Also exercises the
-``SecurityAutoMergeRefused`` belt-and-suspenders error.
+``SecurityAutoMergeRefusedError`` belt-and-suspenders error.
 """
 
 from __future__ import absolute_import
@@ -123,7 +123,7 @@ class EnsurePrOnlyGuardTests(unittest.TestCase):
 
     def test_auto_merge_with_security_raises(self) -> None:
         """A Dependabot-class finding blocks auto-merge."""
-        with self.assertRaises(sg.SecurityAutoMergeRefused) as ctx:
+        with self.assertRaises(sg.SecurityAutoMergeRefusedError) as ctx:
             sg.ensure_pr_only_for_security(
                 [{"scanner": "dependabot", "id": "DEP-42"}],
                 intends_auto_merge=True,
@@ -142,7 +142,7 @@ class EnsurePrOnlyGuardTests(unittest.TestCase):
 
     def test_refusal_message_names_every_security_finding(self) -> None:
         """The error message lists each finding's id so logs stay actionable."""
-        with self.assertRaises(sg.SecurityAutoMergeRefused) as ctx:
+        with self.assertRaises(sg.SecurityAutoMergeRefusedError) as ctx:
             sg.ensure_pr_only_for_security(
                 [
                     {"scanner": "codeql", "id": "py/injection"},
@@ -171,7 +171,7 @@ class EnsurePrOnlyGuardTests(unittest.TestCase):
         classified = sg.filter_auto_merge_candidates([synthetic])
         self.assertEqual(len(classified.must_open_pr), 1)
         self.assertEqual(classified.auto_merge_ok, [])
-        with self.assertRaises(sg.SecurityAutoMergeRefused):
+        with self.assertRaises(sg.SecurityAutoMergeRefusedError):
             sg.ensure_pr_only_for_security([synthetic], intends_auto_merge=True)
 
 


### PR DESCRIPTION
## **User description**
## Summary

Resolves 7 single-instance Codacy findings via canonical fixes.

| Finding | Fix |
|---|---|
| README.md:8 + CLAUDE.md:183 (markdownlint_MD032 ×2) | Add blank line before list items |
| security_class_guard.py:68 (Ruff_N818) | Rename `SecurityAutoMergeRefused` → `SecurityAutoMergeRefusedError` (8 references updated) |
| alerts.py:78 (Ruff_S105) | `# nosec B105` → `# noqa: S105  # nosec` (Codacy's Bandit doesn't honor ID-tagged nosec — bare form works) |
| coverage_findings.py:8 (Ruff_TC001) | Move `from scripts.quality.coverage_types import CoverageStats` into `TYPE_CHECKING` block (only used as string annotation) |
| pipeline.py:72 (PyLintPython3_C0325) | Drop unnecessary parens around `f.patch_source != "none"` |
| bump_workflow_shas.py:103 (PyLintPython3_W0621) | Extract `if __name__ == "__main__":` body into `_run_cli()` so loop var `path` no longer shadows the same-named loop var in `bump_workflow_files`. Same pattern as PR #208's `bypass_labels.py` extraction |

## Test plan

- [x] `pytest -k 'security_class or alerts or coverage_findings or pipeline or bump_workflow or codacy_compatibility'` — 98/98 pass
- [x] `python -m py_compile` on all 5 Python files
- [ ] Codacy Zero gate green
- [ ] Sonar Zero gate green

## Expected Codacy delta

- 16 → 9 (-7: 2 MD032 + 1 N818 + 1 S105 + 1 TC001 + 1 C0325 + 1 W0621)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Cleans up 7 Codacy findings with mechanical, no-behavior changes. Drops Codacy issues from 16 to 9.

- **Refactors**
  - Add blank lines before list items in `README.md` and `CLAUDE.md` (MD032).
  - Rename `SecurityAutoMergeRefused` → `SecurityAutoMergeRefusedError`; update usages and tests (N818).
  - Switch to `# noqa: S105  # nosec` on the `SECRET_MISSING` label in `alerts.py` (S105).
  - Gate `CoverageStats` import behind `TYPE_CHECKING` in `coverage_findings.py` (TC001).
  - Remove unnecessary parentheses in `rollup_v2/pipeline.py` (C0325).
  - Move CLI logic in `bump_workflow_shas.py` to `_run_cli()` to avoid `path` shadowing; call from `__main__` (W0621).

<sup>Written for commit dc8d38d010d2af06a302c49eac1eaf12b02d4378. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Fix Codacy findings without changing product behavior

### What Changed
- Renamed the security auto-merge refusal error so it clearly reads as an exception type
- Kept security-class findings blocked from auto-merge and updated the tests to match the new error name
- Moved one coverage-only import behind a type-checking guard, removed a redundant pair of parentheses, and wrapped the workflow SHA bump CLI so its local names stay isolated
- Adjusted markdown spacing in the README and Claude guide, and changed one alert label comment to a form Codacy accepts

### Impact
`✅ Fewer Codacy failures`
`✅ Cleaner security error naming`
`✅ No change in workflow behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=8sdZDjdwvYik7hXxH6f1YkI3dF8HhIush0ZQB8WJOXg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
