### PR TITLE
fix(linters): async IIFE bootstrap — eliminates inline-disable dependency

### DIFF
--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -408,13 +408,15 @@ export { _internals };
 // Bootstrap entrypoint: kicks off main() when invoked as a CLI.
 // ``runCliIfEntrypoint``'s internal try/catch routes failures to
 // ``reportCliError``, so the resolved boolean (true=ran-as-CLI,
-// false=imported-as-module) is intentionally unused here. Top-level
-// await is the idiom Sonar javascript:S7785 prefers; bare top-level
-// await is what Codacy's ESLint "expr" rule rejects. The two
-// linters disagree on the canonical shape, so we list multiple
-// candidate rule names — this satisfies Sonar javascript:S7724
-// ("Specify the rules you want to disable") AND covers whichever
-// rule name Codacy's ESLint engine internally uses for the
-// ``Expected an assignment or function call`` finding.
-// eslint-disable-next-line no-unused-expressions, no-void, no-floating-promises
-await runCliIfEntrypoint(import.meta.url);
+// false=imported-as-module) is intentionally unused here. Wrapping
+// the call in an async IIFE makes the top-level statement a regular
+// function call (which all ESLint configs accept as a valid
+// expression statement) rather than a bare ``await`` expression.
+// Inside the IIFE the await is in an async function body — Sonar's
+// javascript:S7785 ("prefer top-level await") doesn't fire on
+// async-function bodies, only on ``.then()`` chains at the top
+// scope. Resolves the inline-disable-comment asymmetry between
+// Codacy's PR-scope and main-scope ESLint analyzers.
+(async () => {
+  await runCliIfEntrypoint(import.meta.url);
+})();


### PR DESCRIPTION
## **User description**
## Summary

Replaces the inline-disable-comment-based suppression in PR #214/#215 with an **async IIFE pattern** that satisfies all linters by code structure alone — no inline disable comments needed.

\`\`\`js
(async () => {
  await runCliIfEntrypoint(import.meta.url);
})();
\`\`\`

## Why this works for both linters

- **Codacy ESLint expr**: The outer \`(...)()\` is a **function call** — ESLint's \`no-unused-expressions\` accepts function calls as valid expression statements. Inside the IIFE, await is in an async function body (also accepted).
- **Sonar javascript:S7785** (prefer top-level await): only fires on \`.then()\` chains at the top scope. Async function bodies are exempt.
- **Sonar javascript:S7724** (eslint-disable specify rules): N/A — no inline disable comments.
- **Codacy main-vs-PR asymmetry**: N/A — no comment-honoring required.

## Test plan

- [x] \`node --check\` clean
- [x] \`node --test --experimental-test-coverage\` — 44/44 tests pass at **100.00% line / 100.00% branch**
- [ ] Codacy isUpToStandards=True (PR scope)
- [ ] Sonar PR scope: 0 issues
- [ ] **Codacy main scope: 0 issues** (the previously-asymmetric scope)

## If this lands

Closes the QZP strict-zero gap. Sonar fleet was already at 0 issues; Codacy main going to 0 closes the asymmetry-induced 1-finding floor documented in \`reference_sonar_codacy_top_level_await_conflict.md\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to bootstrap initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Use an async IIFE for CLI startup to satisfy linters without disable comments

### What Changed
- The CLI bootstrap now runs inside an async wrapper instead of using a bare top-level `await`
- This removes the inline lint suppression comment that was needed before
- The startup behavior stays the same when the file is run directly, while imported usage is unchanged

### Impact
`✅ Fewer lint failures in CI`
`✅ No inline disable comments needed`
`✅ Cleaner CLI bootstrap checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4wdrbByhEmwqM0wH5U7rz0NElk4sPXiLtBDPauMCquk&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the CLI bootstrap to an async IIFE to remove inline `eslint-disable` comments and satisfy both Codacy and Sonar. This fixes the linter conflict without changing runtime behavior.

- **Bug Fixes**
  - Wraps `runCliIfEntrypoint(import.meta.url)` in an async IIFE in `scripts/provider_ui/provider_admin_bootstrap.mjs`.
  - Removes inline disables; avoids Sonar `javascript:S7724` and Codacy ESLint `no-unused-expressions`.
  - Eliminates Codacy PR vs main scope mismatch; CI linters pass with no exceptions.

<sup>Written for commit 79639ace492f55c45f79b7412cc81fb1bca59633. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/216">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

