### PR TITLE
fix(sonar): NOSONAR on IIFE bootstrap to resolve linter trilemma

### DIFF
--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -417,6 +417,6 @@ export { _internals };
 // async-function bodies, only on ``.then()`` chains at the top
 // scope. Resolves the inline-disable-comment asymmetry between
 // Codacy's PR-scope and main-scope ESLint analyzers.
-(async () => {
+(async () => {  // NOSONAR javascript:S7785 — IIFE form needed for Codacy ESLint expr (Sonar/Codacy linter conflict, see reference_sonar_codacy_top_level_await_conflict)
   await runCliIfEntrypoint(import.meta.url);
 })();


### PR DESCRIPTION
## **User description**
## Summary

Sonar javascript:S7785 has 3 firing conditions discovered empirically:
1. Top-level await as bare expression (where Codacy expr also fires)
2. \`.then()\` chain at top scope (documented S7785 message)
3. **Async IIFE at top scope** (NEW — only revealed after PR #216 merged)

This creates a true trilemma. The only viable resolution is \`// NOSONAR\` on the IIFE line — Sonar's universal per-line suppression directive.

## Why NOSONAR

| Approach | Codacy expr | Sonar S7785 | Sonar S7724 | Codacy main scope |
|---|---|---|---|---|
| Bare top-level await | ❌ fires | ✅ | ✅ | ❌ ignores disable |
| .then() chain | ✅ | ❌ fires | ✅ | ✅ |
| Async IIFE | ✅ | ❌ fires | ✅ | ✅ |
| Named eslint-disable | ✅ (PR scope) | ✅ | ✅ | ❌ ignores |
| Bare eslint-disable | ✅ | ✅ | ❌ fires | ❌ ignores |
| Multi-rule eslint-disable | ✅ (PR scope) | ✅ | ✅ | ❌ ignores |
| **IIFE + NOSONAR** | ✅ | **✅ silenced** | ✅ | ✅ |

## Test plan

- [x] \`node --check\` clean
- [x] \`node --test --experimental-test-coverage\` — 44/44 pass at 100.00% line/branch
- [ ] Codacy isUpToStandards=True
- [ ] Sonar PR scope: 0 issues
- [ ] **Sonar main scope: 0 code_smells** (was the asymmetry-induced floor)

## After this lands

Closes the QZP strict-zero gap definitively. The fleet's only remaining Codacy gap is the operator-blocked DevExtreme queue lag (#172).

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add `// NOSONAR` to the async IIFE in `scripts/provider_ui/provider_admin_bootstrap.mjs` to silence Sonar `javascript:S7785` while keeping Codacy ESLint clean. No runtime changes; resolves the top‑level await/IIFE/.then linter conflict and restores zero issues in both tools.

<sup>Written for commit 0251832b69949a639a26c27acbfdc7638b17f7cb. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/217">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Silence the Sonar warning on the CLI bootstrap entrypoint**

### What Changed
- Added a Sonar suppression note to the app’s CLI bootstrap line so the existing startup flow no longer triggers a Sonar warning
- Keeps the current entrypoint behavior unchanged while resolving the linter conflict between Sonar and Codacy checks

### Impact
`✅ Fewer false-positive lint failures`
`✅ Cleaner CI checks`
`✅ No change to startup behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=GzD8LMbXLuFgYQ6ShNgX4VA7Fdt4WdWexXGeRjsEGF4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
