### PR TITLE
fix(sonar): use bare NOSONAR (no rule suffix) on IIFE bootstrap

### DIFF
--- a/scripts/provider_ui/provider_admin_bootstrap.mjs
+++ b/scripts/provider_ui/provider_admin_bootstrap.mjs
@@ -417,6 +417,10 @@ export { _internals };
 // async-function bodies, only on ``.then()`` chains at the top
 // scope. Resolves the inline-disable-comment asymmetry between
 // Codacy's PR-scope and main-scope ESLint analyzers.
-(async () => {  // NOSONAR javascript:S7785 — IIFE form needed for Codacy ESLint expr (Sonar/Codacy linter conflict, see reference_sonar_codacy_top_level_await_conflict)
+// IIFE form needed for Codacy ESLint expr (top-level await fires
+// Codacy's no-unused-expressions). NOSONAR silences Sonar's
+// javascript:S7785 ("prefer top-level await") which conflicts with
+// the IIFE pattern. See reference_sonar_codacy_top_level_await_conflict.
+(async () => { // NOSONAR
   await runCliIfEntrypoint(import.meta.url);
 })();


### PR DESCRIPTION
## **User description**
## Summary

PR #217's NOSONAR with rule suffix didn't silence Sonar's S7785 on main scope (PR scope was clean; main scope still flagged the IIFE).

**Pattern parallel to Codacy:** Sonar's NOSONAR directive — like Codacy's eslint-disable — is honored only in the **bare form** (no rule names suffix). Adding rule names or descriptions makes it parse as a comment, not a directive.

\`\`\`js
(async () => { // NOSONAR
  await runCliIfEntrypoint(import.meta.url);
})();
\`\`\`

Reason text moved to the multi-line block comment above so maintainers still see the linter-conflict context without confusing Sonar's directive parser.

## Test plan

- [x] \`node --check\` clean
- [ ] Sonar PR scope: 0 issues
- [ ] **Sonar main scope: 0 code_smells** (the persistent floor)
- [ ] Codacy isUpToStandards=True

## After this lands

5/5 fleet repos at TRUE strict-zero on Sonar. Only DevExtreme Codacy=100 remains (operator-blocked queue).


___

## **CodeAnt-AI Description**
**Use a bare Sonar suppression comment for the CLI bootstrap IIFE**

### What Changed
- The CLI startup wrapper now uses a plain `NOSONAR` comment so Sonar stops flagging the top-level await warning
- The explanation for why the IIFE wrapper is needed was moved above the code, keeping the suppression effective while preserving the context
- The CLI startup behavior itself did not change

### Impact
`✅ Fewer false Sonar warnings`
`✅ Cleaner CLI bootstrap scans`
`✅ Clearer linter notes for maintainers`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=csSquGlYHLCJKi601xb22sGDodijWbP42Kv83b_CZu4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
