### PR TITLE
fix(codeql): export _CoverageMapping via __all__ to silence py/unused-global-variable

### DIFF
--- a/scripts/quality/run_coverage_gate.py
+++ b/scripts/quality/run_coverage_gate.py
@@ -15,11 +15,16 @@ from pathlib import Path
 from typing import Any, Dict, List, cast
 
 # Type alias used by the three ``cast`` call sites below. Sonar's
-# python:S1192 flags the bare string form ``cast(_CoverageMapping, ...)``
+# python:S1192 flags the bare string form ``cast("_CoverageMapping", ...)``
 # (introduced by ruff TC006 auto-fix) as a duplicate-literal smell once
 # it appears 3+ times. Defining the alias once eliminates the repeated
 # string literal while keeping ``cast`` happy.
 _CoverageMapping = Dict[str, Any]
+# CodeQL's py/unused-global-variable can't follow string literals to
+# type aliases, so it flags the alias as unused. The ``__all__`` export
+# below gives it an explicit reference without changing runtime
+# behavior or introducing additional duplicate string literals.
+__all__ = ["_CoverageMapping"]
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # pragma: no cover


### PR DESCRIPTION
## **User description**
## Summary

Resolves QZP CodeQL alert #214: ``py/unused-global-variable`` on ``_CoverageMapping`` at run_coverage_gate.py:22.

The variable IS used at 3 call sites via ``cast(\"_CoverageMapping\", ...)`` string form (chosen to satisfy Sonar S1192 duplicate-literal rule). CodeQL's static analysis can't follow string literals to type aliases, so it flagged the alias as unused.

## Fix

Add ``__all__ = [\"_CoverageMapping\"]`` immediately below the alias definition:

\`\`\`python
_CoverageMapping = Dict[str, Any]
__all__ = [\"_CoverageMapping\"]  # explicit reference for CodeQL
\`\`\`

- Gives CodeQL the explicit non-string reference it needs
- No runtime behavior change (``__all__`` controls star imports; not used here)
- No new duplicate string literals (Sonar S1192 stays clean)

## Test plan

- [x] \`pytest -k 'run_coverage_gate or codacy_compatibility'\` — 23/23 pass
- [x] \`python -m py_compile\` clean
- [ ] CodeQL alert #214 closes
- [ ] All other gates green

## After this lands

QZP CodeQL: 1 → 0 alerts (last open security alert closed).


___

## **CodeAnt-AI Description**
**Silence a false CodeQL alert in the coverage gate script**

### What Changed
- The coverage gate script now explicitly exports `_CoverageMapping`, so CodeQL no longer reports it as unused
- The script’s runtime behavior stays the same; this only affects static analysis results

### Impact
`✅ Fewer false security alerts`
`✅ Cleaner CI scan results`
`✅ No change in coverage gate behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=JH38MF4et0PJSyPE0bdwI_5sq1WQTUNu7njpCjOUH0w&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
