### PR TITLE
fix(gate): semgrep ci --error --strict hard-blocks on findings

### DIFF
--- a/.github/workflows/reusable-scanner-matrix.yml
+++ b/.github/workflows/reusable-scanner-matrix.yml
@@ -320,7 +320,14 @@ jobs:
             run(cmd, cwd=repo_dir)
           elif lane == "semgrep":
             run([sys.executable, "-m", "pip", "install", "semgrep"], cwd=repo_dir)
-            run(["semgrep", "ci"], cwd=repo_dir)
+            # ``semgrep ci`` exits 0 even when blocking-rule findings were
+            # uploaded to Semgrep Cloud Platform, so the gate would pass
+            # green while findings sit on the dashboard. ``--error`` makes
+            # the CLI exit non-zero on any finding (code OR supply-chain),
+            # forcing the gate to red-block per the strict-zero contract.
+            # ``--strict`` additionally fails when rule loading reports
+            # warnings (catches silent-skip scenarios on stale rule sets).
+            run(["semgrep", "ci", "--error", "--strict"], cwd=repo_dir)
           elif lane == "sentry":
             sentry = profile["vendors"]["sentry"]
             cmd = [

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -327,11 +327,22 @@ class WorkflowContractTests(unittest.TestCase):
         ]:
             self.assertIn(expected, template_text)
 
-    def test_semgrep_lane_uses_supported_cli_invocation(self) -> None:
-        """Keep Semgrep on the supported CLI invocation shape."""
+    def test_semgrep_lane_hard_blocks_on_findings(self) -> None:
+        """Semgrep must hard-block on findings.
+
+        ``semgrep ci`` (the bare form) exits 0 even when blocking-rule
+        findings were uploaded to Semgrep Cloud Platform — the gate
+        passes green while findings sit on the dashboard. ``--error``
+        forces non-zero exit on any finding (code OR supply-chain),
+        and ``--strict`` additionally fails on rule-loading warnings
+        (catches silent-skip on stale rule sets). This contract locks
+        in the strict-zero requirement at the workflow level so a
+        future refactor can't re-introduce the silent-pass invocation.
+        """
         text = (ROOT / ".github" / "workflows" / "reusable-scanner-matrix.yml").read_text(encoding="utf-8")
-        self.assertIn('run(["semgrep", "ci"], cwd=repo_dir)', text)
-        self.assertNotIn('run(["semgrep", "ci", "--error"], cwd=repo_dir)', text)
+        self.assertIn('"semgrep", "ci", "--error", "--strict"', text)
+        # The bare "ci" form (without --error) is the silent-pass bug; reject it.
+        self.assertNotIn('run(["semgrep", "ci"], cwd=repo_dir)', text)
 
     def test_reusable_workflows_do_not_inline_inputs_inside_run_blocks(self) -> None:
         """Reject direct GitHub expression interpolation inside reusable workflow shell blocks."""


### PR DESCRIPTION
## **User description**
## Summary

Semgrep gate was silently passing while findings sat on Semgrep Cloud Platform. The bare `semgrep ci` invocation always exits 0 even when blocking-rule findings are uploaded — the gate goes green while the cloud dashboard shows real findings (DevExtreme: 7 code findings, event-link: 1 supply-chain finding).

This PR makes Semgrep hard-block:
- Adds `--error` so the CLI exits non-zero on any finding (code OR supply-chain)
- Adds `--strict` so it also fails when rule loading reports warnings (catches silent-skip scenarios on stale rule sets)
- Inverts the workflow contract test that was actively locking in the silent-pass invocation — the previous test rejected `--error` and required the bare form

## Why the contract test was wrong

`tests/test_workflow_contracts.py::test_semgrep_lane_uses_supported_cli_invocation` previously asserted the bare form was used and forbade `--error`. That test was preventing exactly the fix needed. Renamed to `test_semgrep_lane_hard_blocks_on_findings` and inverted the assertions: `--error --strict` is required, the bare `ci` form is rejected.

## Test plan

- [x] `pytest tests/test_workflow_contracts.py::TestWorkflowContracts::test_semgrep_lane_hard_blocks_on_findings` passes locally
- [ ] Branch CI green
- [ ] Verify on a downstream repo (event-link / DevExtreme) that Semgrep gate red-blocks when findings exist
- [ ] Confirm green on repos with 0 findings (Airline, env-inspector, QZP itself)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `semgrep` gate hard-block on findings by running `semgrep ci --error --strict`, preventing silent green passes when findings exist. Updates the workflow and flips the contract test to enforce the strict invocation.

- **Bug Fixes**
  - Use `--error` so `semgrep` exits non-zero on any finding (code or supply-chain).
  - Use `--strict` to fail on rule-loading warnings (catches silent-skip cases).
  - Contract test now requires `"semgrep", "ci", "--error", "--strict"` and rejects the bare `"semgrep", "ci"` form.

<sup>Written for commit be465cb0978f210c7554f980766d1b19298333b4. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/220?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make Semgrep gate fail when findings exist**

### What Changed
- Semgrep now stops the gate when it finds code or supply-chain issues instead of passing green and only uploading them to the dashboard
- The gate also fails when rule loading produces warnings, which helps catch stale or skipped rules
- The workflow contract now requires this hardened behavior and rejects the old silent-pass command

### Impact
`✅ Fewer false-green security checks`
`✅ Clearer Semgrep failures when findings exist`
`✅ Lower risk of missed rule-loading issues`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ZAIq5qJ-hINX1JSFu8ltbZRFQABZwDsp5hl2s1HBi-U&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened security scanning enforcement to ensure CI/CD pipelines fail on any detected security findings or rule-loading warnings, replacing the previous behavior of silent passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->