### PR TITLE
fix(gate): deepscan red-blocks when status context is missing

### DIFF
--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -235,15 +235,29 @@ def _status_findings(status: Dict[str, Any] | None, context: str) -> List[str]:
 def _evaluate_github_check_context(
     args: argparse.Namespace, token: str
 ) -> Tuple[int | None, str, List[str]]:
-    """Handle evaluate github check context."""
+    """Evaluate the DeepScan GitHub check status for the current commit.
+
+    Strict-zero contract: when no DeepScan status is published for the
+    SHA, the gate must red-block instead of pass-by-default. The previous
+    silent-pass branch (`status is None and event in {push,workflow_dispatch}`)
+    masked repos that never integrated with DeepScan — the user
+    explicitly called this out: "make sure that depscan properly red
+    gated blocked on both PR and main, on this repo and the rest of them
+    as well and especially on QZP repo".
+    """
     payload = _github_status_payload(_github_repo(args), _github_sha(args), token)
     context = str(
         getattr(args, "github_context", DEEPSCAN_STATUS_CONTEXT)
         or DEEPSCAN_STATUS_CONTEXT
     )
     status = _find_github_status(payload, context)
-    if status is None and _event_name() in {"push", "workflow_dispatch"}:
-        return 0, "", []
+    if status is None:
+        return None, "", [
+            f"DeepScan status context '{context}' is missing for the commit. "
+            "Install the DeepScan GitHub App on the repository so each push "
+            "publishes a DeepScan check, or set DEEPSCAN_POLICY_MODE=open_issues "
+            "+ DEEPSCAN_OPEN_ISSUES_URL to query the API directly.",
+        ]
     findings = _status_findings(status, context)
     open_issues = 0 if not findings else None
     return open_issues, _status_target_url(status), findings

--- a/tests/test_check_deepscan_zero.py
+++ b/tests/test_check_deepscan_zero.py
@@ -172,7 +172,7 @@ class DeepScanZeroTests(unittest.TestCase):
     def test_github_check_context_mode_fails_when_deepscan_status_is_missing(
         self,
     ) -> None:
-        """Cover github check context mode fails when deepscan status is missing."""
+        """Missing DeepScan status must red-block (strict-zero contract)."""
         args = Namespace(repo="Prekzursil/quality-zero-platform", sha="abc123")
         api_token = _placeholder_token("api")
 
@@ -189,10 +189,18 @@ class DeepScanZeroTests(unittest.TestCase):
 
         self.assertIsNone(open_issues)
         self.assertEqual(source_url, "")
-        self.assertIn("DeepScan GitHub status context is missing.", findings)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("DeepScan", findings[0])
+        self.assertIn("missing", findings[0])
 
-    def test_github_check_context_mode_allows_missing_status_on_push_main(self) -> None:
-        """Cover github check context mode allows missing status on push main."""
+    def test_github_check_context_mode_red_blocks_missing_status_on_push(self) -> None:
+        """Strict-zero: push events with no DeepScan status must red-block.
+
+        Previously the gate silently passed when no DeepScan status was
+        published for a push/workflow_dispatch event. The user explicitly
+        asked for the inverse — a missing status means DeepScan isn't
+        integrated and the lane must red-block until it is.
+        """
         args = Namespace(repo="Prekzursil/quality-zero-platform", sha="abc123")
         api_token = _placeholder_token("api")
 
@@ -209,9 +217,10 @@ class DeepScanZeroTests(unittest.TestCase):
                 )
             )
 
-        self.assertEqual(open_issues, 0)
+        self.assertIsNone(open_issues)
         self.assertEqual(source_url, "")
-        self.assertEqual(findings, [])
+        self.assertEqual(len(findings), 1)
+        self.assertIn("missing", findings[0])
 
     def test_validate_deepscan_inputs_accepts_github_check_context_mode(self) -> None:
         """Cover validate deepscan inputs accepts github check context mode."""


### PR DESCRIPTION
## **User description**
## Summary

The DeepScan gate's `github_check_context` mode previously had a silent-pass branch:

\`\`\`python
if status is None and _event_name() in {\"push\", \"workflow_dispatch\"}:
    return 0, \"\", []  # silent pass
\`\`\`

This meant any repo without the DeepScan GitHub App installed produced green CI on main / merge_group despite never being analysed by DeepScan — exactly the silent-pass shape the user flagged: *\"make sure that depscan properly red gated blocked on both PR and main, on this repo and the rest of them as well and especially on QZP repo\"*.

## Change

Replace the silent-pass with a hard fail + actionable error message:

> DeepScan status context 'DeepScan' is missing for the commit. Install the DeepScan GitHub App on the repository so each push publishes a DeepScan check, or set DEEPSCAN_POLICY_MODE=open_issues + DEEPSCAN_OPEN_ISSUES_URL to query the API directly.

Repos without DeepScan integration (e.g., Airline-Reservations-System) will block on this gate until either:
- The DeepScan GitHub App is installed (so each push publishes a status), OR
- `DEEPSCAN_POLICY_MODE` repo variable is set to `open_issues` + `DEEPSCAN_OPEN_ISSUES_URL` is configured

## Inverted contract test

The previous test `test_github_check_context_mode_allows_missing_status_on_push_main` asserted the silent-pass behavior. Inverted to require red-block — same anti-pattern as the Semgrep contract test fixed in #221 (a contract test was actively *locking in* the silent-pass).

## Test plan

- [x] `pytest tests/test_check_deepscan_zero.py` — 11/11 pass
- [ ] Branch CI green (QZP itself has DeepScan integrated)
- [ ] Verify Airline now red-blocks on missing-status (the user-flagged case)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make the DeepScan gate strict: red-block when the `github_check_context` status is missing instead of silently passing. This prevents green CI on pushes/merge_group when DeepScan isn’t integrated.

- **Bug Fixes**
  - Removed the silent-pass branch for `push`/`workflow_dispatch` when no status is found.
  - Now fails with a clear message: install the DeepScan GitHub App or use `open_issues` policy mode.
  - Updated tests to require red-block on missing status.

- **Migration**
  - Install the DeepScan GitHub App so each push publishes a status.
  - Or set `DEEPSCAN_POLICY_MODE=open_issues` and provide `DEEPSCAN_OPEN_ISSUES_URL`.

<sup>Written for commit c4db615ceb10ea7b7c91b5b9518da7eb0df1dbb3. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/224?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Require a DeepScan status before the gate can pass

### What Changed
- If a commit has no DeepScan status at all, the gate now blocks instead of passing silently
- The failure message now tells users to install the DeepScan GitHub App or switch to the open issues policy mode
- Tests now expect missing status on push events to red-block, matching the new strict behavior

### Impact
`✅ Fewer CI runs that pass without DeepScan coverage`
`✅ Clearer setup guidance when DeepScan is not installed`
`✅ Stricter blocking on commits with no DeepScan status`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=P4jQI6-do1Q5_VM6QH_KeuVAPgi7aBU9NUi3olLu4kg&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
