### PR TITLE
fix(verify): unset inherited GIT_* so pre-push fixtures cannot mutate the real repo

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Isolation: when run from a git hook, git exports GIT_DIR/GIT_WORK_TREE/etc into
+# the env, which makes fixture-test git commands operate on the REAL repo. Clear them.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_PREFIX GIT_REFLOG_ACTION GIT_QUARANTINE_PATH 2>/dev/null || true
 
 if command -v python >/dev/null 2>&1; then
   PYTHON_CMD=(python)


### PR DESCRIPTION
## **User description**
## Problem
The pre-push hook runs `scripts/verify` -> the unittest suite. Several fixture tests (`test_apply_deterministic_patches`, `test_ratchet_gate`, `test_check_blocked_paths`) do `git init` + `git config user.email test@test.com` + `git commit -m init` (example.py). Git exports `GIT_DIR`/`GIT_WORK_TREE`/etc into the hook environment, so those fixtures operated on the **REAL repo** — mutating the branch (and the repo's git identity to `Test`), which then got pushed: **every local push self-clobbered to an `example.py`/init tree.** CI was unaffected (no `GIT_DIR` there).

## Fix
`scripts/verify` now `unset`s the inherited `GIT_*` vars before running the suite, so fixture git commands operate on their tmp dirs as intended. Verified: pushes from worktrees now land cleanly (no clobber); `scripts/verify` passes (72 node tests, profiles validated, coverage gate).

All-repo relevance: this hook ships to every governed repo, so the defect (and fix) is fleet-wide. See `Reframe/docs/quality-zero/INCIDENT-2026-06-09-qzp-self-clobber.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents pre-push runs of `scripts/verify` from leaking `GIT_*` env vars so fixture tests don’t touch the real repo. Local pushes no longer clobber branches; fixture git commands run only in temp dirs.

- **Bug Fixes**
  - Unset `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`, `GIT_PREFIX`, `GIT_REFLOG_ACTION`, `GIT_QUARANTINE_PATH` at script start to isolate the test suite across all repos using this hook.

<sup>Written for commit cc00fecccf09c2b13b185be95b65d1a71b83d8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Prevent pre-push verification from touching the real repository**

### What Changed
- `scripts/verify` now clears inherited Git environment settings before running tests
- Fixture tests that create or commit in temporary repos no longer inherit the active repository context
- Local pre-push checks no longer risk changing the current branch or git identity in the real repo

### Impact
`✅ Safer pre-push checks`
`✅ Fewer accidental branch changes`
`✅ Fixture tests stay isolated`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
