### PR TITLE
fix(verify): GIT_* isolation + evidence-backed classification of Coverage/Semgrep red gates

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Isolation: when run from a git hook, git exports GIT_DIR/GIT_WORK_TREE/etc into
+# the env, which makes fixture-test git commands operate on the REAL repo. Clear them.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_PREFIX GIT_REFLOG_ACTION GIT_QUARANTINE_PATH 2>/dev/null || true
 
 if command -v python >/dev/null 2>&1; then
   PYTHON_CMD=(python)


### PR DESCRIPTION
## **User description**
## Summary

Single-pass investigation of the two red gates on the trivial PR #242 (Coverage 100 Gate, Semgrep Zero). This branch lands the **`scripts/verify` GIT_* isolation fix** (cherry-picked `cc00fec`) so the pre-push hook can never clobber the real repo, and documents — with primary-source evidence — why each red gate is **operator-action / design-decision, not a code-level plumbing bug**.

The task's mechanistic diagnoses for both gates are empirically refuted (see below). Forcing them green would require either secrets I cannot set or weakening deliberately-fail-closed, contract-tested behavior (a forbidden dismissal), so this PR does **not** attempt to force green — it makes the honest classification the deliverable.

## What changed (code)

- `scripts/verify`: `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE …` at the top so fixture tests run inside the pre-push hook cannot mutate the real repo (cherry-pick of `cc00fec`). `scripts/verify` passes locally (RC=0): `coverage report --fail-under=100` green, all Python unittests + 72 node tests + 15 profile validations pass.

## Coverage 100 Gate — refuted: data DOES reach the gate; lane reds on a fail-closed Codacy upload

Downloaded the actual `coverage-artifacts` (the "~4329-byte near-empty zip") from run 27181039441:
- `coverage-100/coverage.json` → **`status: pass`**, `findings: []`, both components **100% line + 100% branch** (`platform` 2107/2107, `provider_ui` 804/804), 77 covered sources. The 4329 bytes are just the small JSON/MD gate reports — **not** missing coverage.

Step-level job conclusions (job 80239941859):
- Steps 1–18 (incl. `Run selected lane` = the actual coverage assertion, and `Publish Qlty coverage`) → **success**.
- **Step 19 `Publish Codacy coverage` → FAILURE.** Steps 20–21 skipped.

Root cause: PR #223 ("coverage upload steps no longer silently swallow failures") **deliberately** made the Codacy coverage publish fail-closed when `CODACY_PROJECT_TOKEN` is missing, and locked it in with the contract test `test_coverage_publish_steps_have_no_silent_pass_mechanisms`. The repo has `CODACY_API_TOKEN` but **not** `CODACY_PROJECT_TOKEN` → the reporter exits 1 → lane reds. This is exactly the strict-zero behavior #223 intended.

**Operator action (real-burndown, not plumbing):** add `CODACY_PROJECT_TOKEN` (project-scoped) in Settings → Secrets → Actions. Do not weaken the step — that reintroduces the silent-pass #223 removed and breaks its contract test.

## Semgrep Zero — refuted: SARIF IS produced/uploaded; 2 FPs come from a drifting OSS ruleset

Downloaded `semgrep-artifacts` (186 KB) — SARIF is produced and uploaded fine (not a path/probe/fail-open bug). It contains **2 results** from "Semgrep OSS":
1. `generic.secrets.security.detected-sonarqube-docs-api-key` @ `reusable-scanner-matrix.yml` — the 40-char SonarSource action SHA pin mistaken for an API key (known FP).
2. `python.flask.security.xss.audit.direct-use-of-jinja2` @ `scripts/quality/template_render.py` — deliberate non-autoescaped YAML/config rendering (known FP).

Both are **false positives**; the passing `semgrep-cloud-platform/scan` App check (cloud policy) shows **0**. The lane has **no `SEMGREP_APP_TOKEN`**, so it falls back to `semgrep scan --config auto` (per the contract test `test_semgrep_lane_hard_blocks_via_sarif_zero_gate`, which asserts this fallback exists). `--config auto` pulls a **live, drifting** OSS ruleset: a local rerun on this tree produced **14 entirely different** findings (skill-* rules) — proving the divergence from the cloud policy is inherent, not fixable by chasing per-line suppressions.

PR #242 ran on `cc00fec`, which predates `main`'s switch to bare `# nosem` suppressions for these two FPs (verified locally: same-line bare `# nosem`, prev-line bare `# nosem`, and prev-line `# nosemgrep: <rule-id>` all suppress in semgrep 1.165). `cc00fec` used the brittle prev-line **rule-id** form against a ruleset whose IDs had drifted. **`main` (this branch's base) already carries the bare-`# nosem` fixes**, so a PR branched off current `main` should suppress both FPs.

**Operator action for guaranteed parity (real-burndown, not plumbing):** wire `SEMGREP_APP_TOKEN` so the lane uses `semgrep ci` against the cloud policy (= 0, matching the dashboard) instead of the drifting OSS auto ruleset.

## DeepSource:Python / Codacy (task item 3)

Both **pass** on PR #242 (`gh pr checks`): `shared-scanner-matrix / DeepSource Visible Zero` = pass, `shared-scanner-matrix / Codacy Zero` = pass, `DeepSource: Python` = pass. No plumbing fix needed.

## Constraints honored

No dismissals / suppressions / baselines added or removed. No `git add -A` (only `scripts/verify` committed; incidental `verify`-regenerated artifacts discarded). Pre-push `scripts/verify` ran and passed; pushed exactly once. Remediation/backlog workflows untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates `scripts/verify` from Git when run via pre-push so fixture tests can’t touch the real repo. Also classifies the Coverage 100 and Semgrep Zero red gates as config/operator issues, not code bugs.

- **Bug Fixes**
  - Unset inherited `GIT_*` env vars at script start to prevent repo mutation during hook-run fixture tests.

- **Migration**
  - Add `CODACY_PROJECT_TOKEN` in Actions secrets to allow Codacy coverage publish.
  - Optional: add `SEMGREP_APP_TOKEN` so the lane uses `semgrep ci` (cloud policy) instead of the drifting OSS auto rules.

<sup>Written for commit c319f1125c695437391b22eda72f3c535b037d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Prevent git-hook tests from changing the real repository**

### What Changed
- Clears inherited git environment settings before verification runs, so fixture-based git commands stay inside the test repo
- Stops pre-push hook runs from accidentally mutating the working repository during verification

### Impact
`✅ Safer pre-push checks`
`✅ Fewer accidental repo changes during verification`
`✅ More reliable fixture tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where verification tests could operate on the incorrect repository during git hook execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->