### PR TITLE
fix(verify-v2): unblock Coverage 100 Gate — set CODACY_PROJECT_TOKEN + stop ::error:: annotation leak

### DIFF
--- a/.github/workflows/reusable-scanner-matrix.yml
+++ b/.github/workflows/reusable-scanner-matrix.yml
@@ -78,6 +78,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # The DeepScan Zero lane resolves the merge commit's pull requests
+      # (GET /repos/<repo>/commits/<sha>/pulls) so it can re-read the
+      # DeepScan status on the PR head — the DeepScan App posts there, never
+      # on the squash-merge commit. That read needs pull-requests: read.
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -576,18 +581,22 @@ jobs:
           done
 
       - name: Publish Codacy coverage
-        # Codacy's coverage reporter requires the *project-scoped*
-        # ``CODACY_PROJECT_TOKEN``. Per strict-zero contract — missing
-        # coverage on the dashboard must red-block — we removed
-        # ``continue-on-error: true`` (the previous silent-pass mechanism)
-        # so a missing token / failed upload now fails the lane.
-        # Repos without ``CODACY_PROJECT_TOKEN`` configured will block on
-        # this step until the secret is set in Settings → Secrets → Actions.
-        # That's the strict-zero behaviour the user requested ("code
-        # coverage is not uploaded ... fix them all until done").
+        # Codacy's coverage reporter accepts EITHER a project-scoped
+        # ``CODACY_PROJECT_TOKEN`` or an account-level ``api-token``. The
+        # project token was never provisioned on this repo, so a
+        # project-token-only step uploaded with an empty token and left the
+        # Coverage 100 Gate permanently red. We wire ``api-token`` from the
+        # already-valid ``CODACY_API_TOKEN`` (the same secret the Codacy Zero
+        # lane authenticates with — proven live in the same run) so the
+        # reporter runs in account-token mode and auto-derives the repo from
+        # ``GITHUB_REPOSITORY``. ``project-token`` is kept so a repo that does
+        # provision it still works. Per strict-zero contract — missing
+        # coverage on the dashboard must red-block — we keep
+        # ``continue-on-error`` removed so a failed upload fails the lane.
         if: matrix.lane == 'coverage' && steps.profile.outputs.codacy_enabled == 'true' && steps.profile.outputs.coverage_input_files != ''
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
+          api-token: ${{ secrets.CODACY_API_TOKEN }}
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ${{ steps.profile.outputs.coverage_input_files }}
 

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -14,6 +14,7 @@ if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.quality.common import (
+    GITHUB_API_BASE,
     github_commit_status_payload,
     utc_timestamp,
     write_report,
@@ -95,6 +96,30 @@ def _request_json(url: str, token: str) -> Dict[str, Any]:
 def _github_status_payload(repo: str, sha: str, token: str) -> Dict[str, Any]:
     """Handle github status payload."""
     return github_commit_status_payload(repo, sha, token)
+
+
+def _commit_pulls(repo: str, sha: str, token: str) -> List[Dict[str, Any]]:
+    """List the pull requests associated with one commit.
+
+    The DeepScan GitHub App is a PR-only reporter: it posts the ``DeepScan``
+    status on the PR head commit, never on the squash-merge commit produced on
+    ``main``. ``GET /repos/<repo>/commits/<sha>/pulls`` resolves that head so
+    the gate can re-read the combined status there. The endpoint returns a JSON
+    array; any non-list payload is treated as "no associated pulls".
+    """
+    payload, _ = load_json_https(
+        f"{GITHUB_API_BASE}/repos/{repo}/commits/{sha}/pulls",
+        allowed_hosts={"api.github.com"},
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "quality-zero-platform",
+        },
+    )
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
 
 
 def _render_md(payload: Mapping[str, Any]) -> str:
@@ -232,6 +257,49 @@ def _status_findings(status: Dict[str, Any] | None, context: str) -> List[str]:
     return [f"{context} GitHub status is {state or 'unknown'} (expected success)."]
 
 
+def _status_result(
+    status: Dict[str, Any], context: str
+) -> Tuple[int | None, str, List[str]]:
+    """Build the gate result for a found DeepScan status context."""
+    findings = _status_findings(status, context)
+    open_issues = 0 if not findings else None
+    return open_issues, _status_target_url(status), findings
+
+
+def _missing_status_finding(context: str) -> List[str]:
+    """Return the strict-zero finding for a wholly-absent DeepScan status."""
+    return [
+        f"DeepScan status context '{context}' is missing for the commit "
+        "and for its associated pull-request heads. Install the DeepScan "
+        "GitHub App on the repository so each pull request publishes a "
+        "DeepScan check, or set DEEPSCAN_POLICY_MODE=open_issues + "
+        "DEEPSCAN_OPEN_ISSUES_URL to query the API directly.",
+    ]
+
+
+def _pr_head_status_result(
+    repo: str, sha: str, token: str, context: str
+) -> Tuple[int | None, str, List[str]] | None:
+    """Re-read the DeepScan status on each PR head for a status-less commit.
+
+    The DeepScan App posts the ``DeepScan`` status on the PR head, never on
+    the squash-merge commit. ``/commits/<sha>/pulls`` resolves those heads;
+    the first head that carries a ``DeepScan`` status determines the gate
+    outcome (success → pass, any other state → propagate the finding).
+    Returns ``None`` when no associated head carries a DeepScan status, so the
+    caller emits the strict-zero "missing" finding.
+    """
+    for pull in _commit_pulls(repo, sha, token):
+        head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
+        if not head_sha:
+            continue
+        head_payload = _github_status_payload(repo, head_sha, token)
+        head_status = _find_github_status(head_payload, context)
+        if head_status is not None:
+            return _status_result(head_status, context)
+    return None
+
+
 def _evaluate_github_check_context(
     args: argparse.Namespace, token: str
 ) -> Tuple[int | None, str, List[str]]:
@@ -244,23 +312,27 @@ def _evaluate_github_check_context(
     explicitly called this out: "make sure that depscan properly red
     gated blocked on both PR and main, on this repo and the rest of them
     as well and especially on QZP repo".
+
+    The DeepScan App is a PR-only reporter, so the squash-merge commit on
+    ``main`` carries no ``DeepScan`` status. Before red-blocking we fall back
+    to the commit's associated pull-request heads (where DeepScan does post)
+    and only emit the missing finding when DeepScan is absent on the merge
+    commit AND on every PR head.
     """
-    payload = _github_status_payload(_github_repo(args), _github_sha(args), token)
+    repo = _github_repo(args)
+    sha = _github_sha(args)
+    payload = _github_status_payload(repo, sha, token)
     context = str(
         getattr(args, "github_context", DEEPSCAN_STATUS_CONTEXT)
         or DEEPSCAN_STATUS_CONTEXT
     )
     status = _find_github_status(payload, context)
-    if status is None:
-        return None, "", [
-            f"DeepScan status context '{context}' is missing for the commit. "
-            "Install the DeepScan GitHub App on the repository so each push "
-            "publishes a DeepScan check, or set DEEPSCAN_POLICY_MODE=open_issues "
-            "+ DEEPSCAN_OPEN_ISSUES_URL to query the API directly.",
-        ]
-    findings = _status_findings(status, context)
-    open_issues = 0 if not findings else None
-    return open_issues, _status_target_url(status), findings
+    if status is not None:
+        return _status_result(status, context)
+    fallback = _pr_head_status_result(repo, sha, token, context)
+    if fallback is not None:
+        return fallback
+    return None, "", _missing_status_finding(context)
 
 
 def _evaluate_open_issues_mode(

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -138,26 +138,37 @@ def _render_md(payload: Mapping[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _first_nonempty(*values: str) -> str:
+    """Return the first truthy string from ``values``, or an empty string."""
+    for value in values:
+        if value:
+            return value
+    return ""
+
+
 def _policy_mode(args: argparse.Namespace) -> str:
     """Handle policy mode."""
-    return (
-        args.policy_mode or os.environ.get("DEEPSCAN_POLICY_MODE", "")
-    ).strip() or "github_check_context"
+    configured = _first_nonempty(
+        args.policy_mode, os.environ.get("DEEPSCAN_POLICY_MODE", "")
+    )
+    return configured.strip() or "github_check_context"
 
 
 def _github_repo(args: argparse.Namespace) -> str:
     """Handle github repo."""
-    return (
-        args.repo
-        or os.environ.get("REPO_SLUG", "")
-        or os.environ.get("GITHUB_REPOSITORY", "")
+    return _first_nonempty(
+        args.repo,
+        os.environ.get("REPO_SLUG", ""),
+        os.environ.get("GITHUB_REPOSITORY", ""),
     ).strip()
 
 
 def _github_sha(args: argparse.Namespace) -> str:
     """Handle github sha."""
-    return (
-        args.sha or os.environ.get("TARGET_SHA", "") or os.environ.get("GITHUB_SHA", "")
+    return _first_nonempty(
+        args.sha,
+        os.environ.get("TARGET_SHA", ""),
+        os.environ.get("GITHUB_SHA", ""),
     ).strip()
 
 
@@ -189,27 +200,13 @@ def _validate_open_issues_mode_inputs(token: str, open_issues_url: str) -> List[
     return findings
 
 
-def _validate_deepscan_inputs(*args: Any, **kwargs: Any) -> List[str]:
-    """Handle validate deepscan inputs."""
-    if args:
-        raise TypeError("_validate_deepscan_inputs expects keyword arguments only")
-    try:
-        token = str(kwargs.pop("token"))
-        policy_mode = str(kwargs.pop("policy_mode"))
-        open_issues_url = str(kwargs.pop("open_issues_url"))
-        github_token = str(kwargs.pop("github_token"))
-        repo = str(kwargs.pop("repo"))
-        sha = str(kwargs.pop("sha"))
-    except KeyError as exc:  # pragma: no cover - defensive contract guard
-        raise TypeError(f"Missing required DeepScan parameter: {exc.args[0]}") from exc
-    if kwargs:
-        raise TypeError(
-            "Unexpected _validate_deepscan_inputs parameters: "
-            f"{', '.join(sorted(kwargs))}"
-        )
-    if policy_mode == "github_check_context":
-        return _validate_github_check_context_inputs(github_token, repo, sha)
-    return _validate_open_issues_mode_inputs(token, open_issues_url)
+def _validate_deepscan_inputs(
+    inputs: DeepScanEvaluationInputs, repo: str, sha: str
+) -> List[str]:
+    """Return the input-validation findings for one resolved DeepScan run."""
+    if inputs.policy_mode == "github_check_context":
+        return _validate_github_check_context_inputs(inputs.github_token, repo, sha)
+    return _validate_open_issues_mode_inputs(inputs.token, inputs.open_issues_url)
 
 
 def _normalized_open_issues_url(open_issues_url: str) -> str:
@@ -345,37 +342,23 @@ def _evaluate_open_issues_mode(
 
 
 def _evaluate_deepscan_policy(
-    args: argparse.Namespace, *call_args: Any, **kwargs: Any
+    args: argparse.Namespace, inputs: DeepScanEvaluationInputs
 ) -> Tuple[int | None, str, List[str]]:
-    """Handle evaluate deepscan policy."""
-    if call_args:
-        raise TypeError("_evaluate_deepscan_policy expects keyword arguments only")
-    try:
-        policy_mode = str(kwargs.pop("policy_mode"))
-        token = str(kwargs.pop("token"))
-        github_token = str(kwargs.pop("github_token"))
-        open_issues_url = str(kwargs.pop("open_issues_url"))
-    except KeyError as exc:  # pragma: no cover - defensive contract guard
-        raise TypeError(
-            f"Missing required DeepScan policy field: {exc.args[0]}"
-        ) from exc
-    if kwargs:
-        raise TypeError(
-            "Unexpected _evaluate_deepscan_policy parameters: "
-            f"{', '.join(sorted(kwargs))}"
-        )
-    if policy_mode == "github_check_context":
-        return _evaluate_github_check_context(args, github_token)
-    return _evaluate_open_issues_mode(open_issues_url, token)
+    """Dispatch one DeepScan evaluation to the configured policy mode."""
+    if inputs.policy_mode == "github_check_context":
+        return _evaluate_github_check_context(args, inputs.github_token)
+    return _evaluate_open_issues_mode(inputs.open_issues_url, inputs.token)
 
 
 def _deepscan_inputs(args: argparse.Namespace) -> DeepScanEvaluationInputs:
     """Return the resolved token inputs for one DeepScan run."""
     return DeepScanEvaluationInputs(
-        token=(args.token or os.environ.get("DEEPSCAN_API_TOKEN", "")).strip(),
-        github_token=(
-            os.environ.get("GITHUB_TOKEN", "").strip()
-            or os.environ.get("GH_TOKEN", "").strip()
+        token=_first_nonempty(
+            args.token, os.environ.get("DEEPSCAN_API_TOKEN", "")
+        ).strip(),
+        github_token=_first_nonempty(
+            os.environ.get("GITHUB_TOKEN", "").strip(),
+            os.environ.get("GH_TOKEN", "").strip(),
         ),
         policy_mode=_policy_mode(args),
         open_issues_url=os.environ.get("DEEPSCAN_OPEN_ISSUES_URL", "").strip(),
@@ -387,27 +370,14 @@ def _evaluate_deepscan_args(
     inputs: DeepScanEvaluationInputs,
 ) -> Tuple[int | None, str, List[str], str]:
     """Return the DeepScan gate result for one invocation."""
-    findings = _validate_deepscan_inputs(
-        token=inputs.token,
-        policy_mode=inputs.policy_mode,
-        open_issues_url=inputs.open_issues_url,
-        github_token=inputs.github_token,
-        repo=_github_repo(args),
-        sha=_github_sha(args),
-    )
+    findings = _validate_deepscan_inputs(inputs, _github_repo(args), _github_sha(args))
     open_issues: int | None = None
     source_url = inputs.open_issues_url
     status = "fail"
     if findings:
         return open_issues, source_url, findings, status
     try:
-        open_issues, source_url, findings = _evaluate_deepscan_policy(
-            args,
-            policy_mode=inputs.policy_mode,
-            token=inputs.token,
-            github_token=inputs.github_token,
-            open_issues_url=inputs.open_issues_url,
-        )
+        open_issues, source_url, findings = _evaluate_deepscan_policy(args, inputs)
         status = "pass" if not findings else "fail"
     except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
         findings.append(f"DeepScan API request failed: {exc}")

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -95,18 +95,26 @@ def _render_md(payload: Mapping[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _issues_url(org: str, project_slug: str) -> str:
-    """Build the unresolved-issues endpoint for a Sentry project."""
+def _issues_url(org: str) -> str:
+    """Build the org-scoped unresolved-issues endpoint for a Sentry org.
+
+    The legacy project-slug endpoint ``/projects/<org>/<project>/issues/``
+    rejects a valid ORG-scoped ``SENTRY_AUTH_TOKEN`` with HTTP 401, so the
+    gate queries ``/organizations/<org>/issues/`` instead — the same
+    org-scoped endpoint ``scripts/quality/truth/preflight.py`` already trusts.
+    The org endpoint keys ``project`` by NUMERIC id (not slug), so we omit it
+    and count the org-wide unresolved total; the platform org hosts a single
+    project, so the org-wide total equals that project's total. The ``x-hits``
+    response header still carries the unresolved count.
+    """
     org_slug = urllib.parse.quote(org, safe="")
-    project_param = urllib.parse.quote(project_slug, safe="")
     query = urllib.parse.urlencode(
         [
             ("query", "is:unresolved"),
             ("limit", "1"),
-            ("project", project_param),
         ]
     )
-    return f"{SENTRY_API_BASE}/projects/{org_slug}/{project_param}/issues/?{query}"
+    return f"{SENTRY_API_BASE}/organizations/{org_slug}/issues/?{query}"
 
 
 def _validate_sentry_inputs(token: str, org: str, projects: List[str]) -> List[str]:
@@ -131,7 +139,7 @@ def _collect_project_results(
     project_results: List[Dict[str, Any]] = []
     for project in projects:
         try:
-            payload, headers = _request_json(_issues_url(org, project), token)
+            payload, headers = _request_json(_issues_url(org), token)
         except HTTPError as exc:
             if exc.code == 404:
                 project_results.append(

--- a/scripts/quality/verify_v2_deployment.py
+++ b/scripts/quality/verify_v2_deployment.py
@@ -24,6 +24,12 @@ Exit codes:
   0 — every deliverable present.
   1 — at least one deliverable is missing (``--all`` mode).
   2 — CLI argument error / unreadable repo root.
+
+Diagnostics are written to ``stderr``; the summary JSON is the only thing
+on ``stdout``. GitHub Actions ``::error::`` workflow commands are emitted
+ONLY when ``--emit-annotations`` is passed, so importing this module in a
+unit-test suite (e.g. ``test_verify_v2_deployment``) cannot leak workflow
+commands into an unrelated CI lane's check-run annotations.
 """
 
 from __future__ import absolute_import
@@ -173,6 +179,16 @@ def _parse_args() -> argparse.Namespace:
         default="",
         help="Write the summary JSON to this path (stdout when empty).",
     )
+    parser.add_argument(
+        "--emit-annotations",
+        action="store_true",
+        help=(
+            "Emit GitHub Actions ``::error::`` workflow commands for each "
+            "missing deliverable. Off by default so importing test suites "
+            "cannot leak workflow commands into an unrelated CI lane's "
+            "annotations."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -196,7 +212,12 @@ def main() -> int:
         print(payload)
     if args.all and summary["missing_count"]:
         for rel in summary["missing"]:
-            print(f"::error::missing deliverable: {rel}", flush=True)
+            line = (
+                f"::error::missing deliverable: {rel}"
+                if args.emit_annotations
+                else f"missing deliverable: {rel}"
+            )
+            print(line, file=sys.stderr, flush=True)
         return 1
     return 0
 

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Isolation: when run from a git hook, git exports GIT_DIR/GIT_WORK_TREE/etc into
+# the env, which makes fixture-test git commands operate on the REAL repo. Clear them.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_PREFIX GIT_REFLOG_ACTION GIT_QUARANTINE_PATH 2>/dev/null || true
 
 if command -v python >/dev/null 2>&1; then
   PYTHON_CMD=(python)

--- a/tests/test_check_deepscan_zero.py
+++ b/tests/test_check_deepscan_zero.py
@@ -78,10 +78,12 @@ class DeepScanZeroTests(unittest.TestCase):
             self.assertEqual(
                 check_deepscan_zero._evaluate_deepscan_policy(
                     args,
-                    policy_mode="github_check_context",
-                    token="-".join(["service", "credential"]),
-                    github_token=github_token,
-                    open_issues_url="https://deepscan.io/project/issues",
+                    check_deepscan_zero.DeepScanEvaluationInputs(
+                        token="-".join(["service", "credential"]),
+                        github_token=github_token,
+                        policy_mode="github_check_context",
+                        open_issues_url="https://deepscan.io/project/issues",
+                    ),
                 ),
                 (0, "https://deepscan.io", []),
             )
@@ -93,10 +95,12 @@ class DeepScanZeroTests(unittest.TestCase):
             self.assertEqual(
                 check_deepscan_zero._evaluate_deepscan_policy(
                     args,
-                    policy_mode="open_issues_url",
-                    token=_placeholder_token("api"),
-                    github_token=github_token,
-                    open_issues_url="https://deepscan.io/project/issues",
+                    check_deepscan_zero.DeepScanEvaluationInputs(
+                        token=_placeholder_token("api"),
+                        github_token=github_token,
+                        policy_mode="open_issues_url",
+                        open_issues_url="https://deepscan.io/project/issues",
+                    ),
                 ),
                 (0, "https://deepscan.io/project/issues", []),
             )
@@ -280,6 +284,7 @@ class DeepScanZeroTests(unittest.TestCase):
         api_token = _placeholder_token("api")
 
         def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            """Return a successful DeepScan status only for the PR head SHA."""
             if sha == "head-sha":
                 return {
                     "statuses": [
@@ -317,6 +322,7 @@ class DeepScanZeroTests(unittest.TestCase):
         api_token = _placeholder_token("api")
 
         def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            """Return a failing DeepScan status only for the PR head SHA."""
             if sha == "head-sha":
                 return {
                     "statuses": [
@@ -357,6 +363,7 @@ class DeepScanZeroTests(unittest.TestCase):
         api_token = _placeholder_token("api")
 
         def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            """Return a successful DeepScan status only for the second PR head."""
             if sha == "head-two":
                 return {
                     "statuses": [
@@ -420,15 +427,30 @@ class DeepScanZeroTests(unittest.TestCase):
         """Cover validate deepscan inputs accepts github check context mode."""
         api_token = _placeholder_token("api")
         findings = check_deepscan_zero._validate_deepscan_inputs(
-            token=api_token,
-            policy_mode="github_check_context",
-            open_issues_url="",
-            github_token=_placeholder_token("github"),
-            repo="Prekzursil/quality-zero-platform",
-            sha="abc123",
+            check_deepscan_zero.DeepScanEvaluationInputs(
+                token=api_token,
+                github_token=_placeholder_token("github"),
+                policy_mode="github_check_context",
+                open_issues_url="",
+            ),
+            "Prekzursil/quality-zero-platform",
+            "abc123",
         )
 
         self.assertEqual(findings, [])
+
+        open_issue_findings = check_deepscan_zero._validate_deepscan_inputs(
+            check_deepscan_zero.DeepScanEvaluationInputs(
+                token=api_token,
+                github_token="",
+                policy_mode="open_issues_url",
+                open_issues_url="https://deepscan.io/project/issues",
+            ),
+            "",
+            "",
+        )
+
+        self.assertEqual(open_issue_findings, [])
 
     def test_extract_total_open_request_json_and_repo_sha_helpers_cover_edge_cases(
         self,
@@ -507,47 +529,6 @@ class DeepScanZeroTests(unittest.TestCase):
             findings,
             ["DeepScan response did not include a parseable total issue count."],
         )
-
-    def test_keyword_only_guards_reject_positional_and_unexpected_arguments(
-        self,
-    ) -> None:
-        """Cover keyword only guards reject positional and unexpected arguments."""
-        with self.assertRaisesRegex(TypeError, "expects keyword arguments only"):
-            check_deepscan_zero._validate_deepscan_inputs("unexpected")
-
-        with self.assertRaisesRegex(
-            TypeError, "Unexpected _validate_deepscan_inputs parameters: extra"
-        ):
-            check_deepscan_zero._validate_deepscan_inputs(
-                token=_placeholder_token("api"),
-                policy_mode="open_issues_url",
-                open_issues_url="https://deepscan.io/project/issues",
-                github_token=_placeholder_token("github"),
-                repo="Prekzursil/quality-zero-platform",
-                sha="abc123",
-                extra=True,
-            )
-
-        args = Namespace(
-            policy_mode="",
-            repo="Prekzursil/quality-zero-platform",
-            sha="abc123",
-            github_context="DeepScan",
-        )
-        with self.assertRaisesRegex(TypeError, "expects keyword arguments only"):
-            check_deepscan_zero._evaluate_deepscan_policy(args, "unexpected")
-
-        with self.assertRaisesRegex(
-            TypeError, "Unexpected _evaluate_deepscan_policy parameters: extra"
-        ):
-            check_deepscan_zero._evaluate_deepscan_policy(
-                args,
-                policy_mode="open_issues_url",
-                token=_placeholder_token("api"),
-                github_token=_placeholder_token("github"),
-                open_issues_url="https://deepscan.io/project/issues",
-                extra=True,
-            )
 
     def test_status_helpers_and_policy_dispatch_cover_failure_branches(self) -> None:
         """Cover status helpers and policy dispatch cover failure branches."""

--- a/tests/test_check_deepscan_zero.py
+++ b/tests/test_check_deepscan_zero.py
@@ -172,7 +172,13 @@ class DeepScanZeroTests(unittest.TestCase):
     def test_github_check_context_mode_fails_when_deepscan_status_is_missing(
         self,
     ) -> None:
-        """Missing DeepScan status must red-block (strict-zero contract)."""
+        """Missing DeepScan status (and no PR head) must red-block.
+
+        The DeepScan App is a PR-only reporter, so a squash-merge commit
+        never carries a ``DeepScan`` status. The gate first falls back to the
+        commit's associated pull requests; when there are none either, the
+        strict-zero contract still red-blocks.
+        """
         args = Namespace(repo="Prekzursil/quality-zero-platform", sha="abc123")
         api_token = _placeholder_token("api")
 
@@ -180,6 +186,10 @@ class DeepScanZeroTests(unittest.TestCase):
             check_deepscan_zero,
             "_github_status_payload",
             return_value={"statuses": []},
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[],
         ):
             open_issues, source_url, findings = (
                 check_deepscan_zero._evaluate_github_check_context(
@@ -198,8 +208,9 @@ class DeepScanZeroTests(unittest.TestCase):
 
         Previously the gate silently passed when no DeepScan status was
         published for a push/workflow_dispatch event. The user explicitly
-        asked for the inverse — a missing status means DeepScan isn't
-        integrated and the lane must red-block until it is.
+        asked for the inverse — a missing status (and no PR head carrying one)
+        means DeepScan isn't integrated and the lane must red-block until it
+        is.
         """
         args = Namespace(repo="Prekzursil/quality-zero-platform", sha="abc123")
         api_token = _placeholder_token("api")
@@ -210,6 +221,189 @@ class DeepScanZeroTests(unittest.TestCase):
             check_deepscan_zero,
             "_github_status_payload",
             return_value={"statuses": []},
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[],
+        ):
+            open_issues, source_url, findings = (
+                check_deepscan_zero._evaluate_github_check_context(
+                    args, token=api_token
+                )
+            )
+
+        self.assertIsNone(open_issues)
+        self.assertEqual(source_url, "")
+        self.assertEqual(len(findings), 1)
+        self.assertIn("missing", findings[0])
+
+    def test_commit_pulls_returns_list_payload_and_guards_non_list(self) -> None:
+        """Resolve the commit's pull requests via the GitHub API (list-guarded)."""
+        api_token = _placeholder_token("api")
+        with patch(
+            "scripts.quality.check_deepscan_zero.load_json_https",
+            return_value=([{"number": 7}], {}),
+        ) as loader:
+            pulls = check_deepscan_zero._commit_pulls(
+                "Prekzursil/quality-zero-platform", "merge-sha", api_token
+            )
+        self.assertEqual(pulls, [{"number": 7}])
+        self.assertEqual(
+            loader.call_args.args[0],
+            "https://api.github.com/repos/Prekzursil/quality-zero-platform"
+            "/commits/merge-sha/pulls",
+        )
+        self.assertEqual(loader.call_args.kwargs["allowed_hosts"], {"api.github.com"})
+
+        with patch(
+            "scripts.quality.check_deepscan_zero.load_json_https",
+            return_value=({"unexpected": "dict"}, {}),
+        ):
+            self.assertEqual(
+                check_deepscan_zero._commit_pulls(
+                    "Prekzursil/quality-zero-platform", "merge-sha", api_token
+                ),
+                [],
+            )
+
+    def test_github_check_context_falls_back_to_pr_head_when_merge_missing(
+        self,
+    ) -> None:
+        """Merge SHA missing DeepScan must pass when the PR head carries it.
+
+        The DeepScan App posts ``DeepScan`` on the PR head, never the
+        squash-merge commit. The gate resolves the commit's pulls and reuses
+        the combined-status read against each head; a successful DeepScan
+        status on the head passes the gate.
+        """
+        args = Namespace(repo="Prekzursil/quality-zero-platform", sha="merge-sha")
+        api_token = _placeholder_token("api")
+
+        def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            if sha == "head-sha":
+                return {
+                    "statuses": [
+                        {
+                            "context": "DeepScan",
+                            "state": "success",
+                            "target_url": "https://deepscan.io/head",
+                        }
+                    ]
+                }
+            return {"statuses": []}
+
+        with patch.object(
+            check_deepscan_zero,
+            "_github_status_payload",
+            side_effect=_status_by_sha,
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[{"head": {"sha": "head-sha"}}],
+        ):
+            open_issues, source_url, findings = (
+                check_deepscan_zero._evaluate_github_check_context(
+                    args, token=api_token
+                )
+            )
+
+        self.assertEqual(open_issues, 0)
+        self.assertEqual(source_url, "https://deepscan.io/head")
+        self.assertEqual(findings, [])
+
+    def test_github_check_context_propagates_pr_head_failure_state(self) -> None:
+        """A non-success DeepScan status on the PR head propagates its finding."""
+        args = Namespace(repo="Prekzursil/quality-zero-platform", sha="merge-sha")
+        api_token = _placeholder_token("api")
+
+        def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            if sha == "head-sha":
+                return {
+                    "statuses": [
+                        {
+                            "context": "DeepScan",
+                            "state": "failure",
+                            "target_url": "https://deepscan.io/head",
+                        }
+                    ]
+                }
+            return {"statuses": []}
+
+        with patch.object(
+            check_deepscan_zero,
+            "_github_status_payload",
+            side_effect=_status_by_sha,
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[{"head": {"sha": "head-sha"}}],
+        ):
+            open_issues, source_url, findings = (
+                check_deepscan_zero._evaluate_github_check_context(
+                    args, token=api_token
+                )
+            )
+
+        self.assertIsNone(open_issues)
+        self.assertEqual(source_url, "https://deepscan.io/head")
+        self.assertEqual(
+            findings,
+            ["DeepScan GitHub status is failure (expected success)."],
+        )
+
+    def test_github_check_context_scans_multiple_pr_heads_for_deepscan(self) -> None:
+        """The fallback continues past heads without DeepScan to one that has it."""
+        args = Namespace(repo="Prekzursil/quality-zero-platform", sha="merge-sha")
+        api_token = _placeholder_token("api")
+
+        def _status_by_sha(repo: str, sha: str, token: str) -> dict:
+            if sha == "head-two":
+                return {
+                    "statuses": [
+                        {
+                            "context": "DeepScan",
+                            "state": "success",
+                            "target_url": "https://deepscan.io/two",
+                        }
+                    ]
+                }
+            return {"statuses": []}
+
+        with patch.object(
+            check_deepscan_zero,
+            "_github_status_payload",
+            side_effect=_status_by_sha,
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[
+                {"head": {"sha": "head-one"}},
+                {"head": {"sha": "head-two"}},
+            ],
+        ):
+            open_issues, source_url, findings = (
+                check_deepscan_zero._evaluate_github_check_context(
+                    args, token=api_token
+                )
+            )
+
+        self.assertEqual(open_issues, 0)
+        self.assertEqual(source_url, "https://deepscan.io/two")
+        self.assertEqual(findings, [])
+
+    def test_github_check_context_skips_pulls_without_head_sha(self) -> None:
+        """A pull entry lacking a head sha is skipped, then missing red-blocks."""
+        args = Namespace(repo="Prekzursil/quality-zero-platform", sha="merge-sha")
+        api_token = _placeholder_token("api")
+
+        with patch.object(
+            check_deepscan_zero,
+            "_github_status_payload",
+            return_value={"statuses": []},
+        ), patch.object(
+            check_deepscan_zero,
+            "_commit_pulls",
+            return_value=[{"head": {}}, {}],
         ):
             open_issues, source_url, findings = (
                 check_deepscan_zero._evaluate_github_check_context(

--- a/tests/test_check_sentry_zero.py
+++ b/tests/test_check_sentry_zero.py
@@ -135,16 +135,26 @@ class SentryZeroTests(unittest.TestCase):
             ],
         )
 
-    def test_issues_url_and_render_md_cover_empty_state_reporting(self) -> None:
-        """Render the zero-findings markdown shape for empty project results."""
+    def test_issues_url_targets_org_scoped_unresolved_endpoint(self) -> None:
+        """Build the org-scoped unresolved-issues endpoint (org token valid here).
+
+        The legacy project-slug endpoint
+        ``/projects/<org>/<project>/issues/`` 401s for a valid ORG-scoped
+        token, so the gate migrated to ``/organizations/<org>/issues/``
+        which the platform's already-valid SENTRY_AUTH_TOKEN can read. The
+        org endpoint keys ``project`` by NUMERIC id, so we omit it and count
+        org-wide (the platform org hosts a single project).
+        """
         self.assertEqual(
-            sentry_module._issues_url("prek/zursil", "event link"),
+            sentry_module._issues_url("prek/zursil"),
             (
-                "https://sentry.io/api/0/projects/prek%2Fzursil/"
-                "event%20link/issues/?query=is%3Aunresolved&limit=1"
-                "&project=event%2520link"
+                "https://sentry.io/api/0/organizations/prek%2Fzursil/"
+                "issues/?query=is%3Aunresolved&limit=1"
             ),
         )
+
+    def test_render_md_covers_empty_state_reporting(self) -> None:
+        """Render the zero-findings markdown shape for empty project results."""
         markdown = sentry_module._render_md(
             {
                 "status": "fail",

--- a/tests/test_verify_v2_deployment.py
+++ b/tests/test_verify_v2_deployment.py
@@ -67,9 +67,10 @@ class CliExitCodeTests(unittest.TestCase):
     def _run_capture(argv: list):
         """Invoke ``main()`` capturing ``(rc, stdout, stderr)``."""
         out, err = io.StringIO(), io.StringIO()
-        with patch.object(sys, "argv", ["verify_v2_deployment.py", *argv]):
-            with redirect_stdout(out), redirect_stderr(err):
-                rc = vv.main()
+        with patch.object(
+            sys, "argv", ["verify_v2_deployment.py", *argv]
+        ), redirect_stdout(out), redirect_stderr(err):
+            rc = vv.main()
         return rc, out.getvalue(), err.getvalue()
 
     def test_missing_repo_root_returns_2(self) -> None:

--- a/tests/test_verify_v2_deployment.py
+++ b/tests/test_verify_v2_deployment.py
@@ -2,10 +2,12 @@
 
 from __future__ import absolute_import
 
+import io
 import json
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -61,6 +63,15 @@ class CliExitCodeTests(unittest.TestCase):
         with patch.object(sys, "argv", ["verify_v2_deployment.py", *argv]):
             return vv.main()
 
+    @staticmethod
+    def _run_capture(argv: list):
+        """Invoke ``main()`` capturing ``(rc, stdout, stderr)``."""
+        out, err = io.StringIO(), io.StringIO()
+        with patch.object(sys, "argv", ["verify_v2_deployment.py", *argv]):
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = vv.main()
+        return rc, out.getvalue(), err.getvalue()
+
     def test_missing_repo_root_returns_2(self) -> None:
         """Exit 2 when ``--repo-root`` doesn't resolve to a directory."""
         rc = self._run(["--repo-root", "/does/not/exist"])
@@ -69,8 +80,36 @@ class CliExitCodeTests(unittest.TestCase):
     def test_all_mode_fails_when_phase1_missing(self) -> None:
         """``--all`` exits 1 when any required artefact is absent."""
         with tempfile.TemporaryDirectory() as tmp:
-            rc = self._run(["--repo-root", tmp, "--all"])
+            rc, _stdout, _stderr = self._run_capture(["--repo-root", tmp, "--all"])
         self.assertEqual(rc, 1)
+
+    def test_missing_default_does_not_leak_workflow_commands_to_stdout(self) -> None:
+        """Regression: ``--all`` without ``--emit-annotations`` keeps stdout clean.
+
+        The Coverage 100 Gate ran red because this test module's
+        ``main()`` call leaked ``::error::`` workflow commands into the
+        coverage lane's stdout, which GitHub Actions then attached as
+        check-run annotations. Diagnostics must stay on stderr and must
+        not use the workflow-command prefix unless explicitly requested.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, stdout, stderr = self._run_capture(["--repo-root", tmp, "--all"])
+        self.assertEqual(rc, 1)
+        self.assertNotIn("::error::", stdout)
+        self.assertIn("missing deliverable:", stderr)
+        self.assertNotIn("::error::", stderr)
+        # stdout still carries the machine-readable summary only.
+        self.assertIn('"missing_count"', stdout)
+
+    def test_emit_annotations_writes_workflow_commands_to_stderr(self) -> None:
+        """``--emit-annotations`` opts in to ``::error::`` commands on stderr."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, stdout, stderr = self._run_capture(
+                ["--repo-root", tmp, "--all", "--emit-annotations"]
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn("::error::missing deliverable:", stderr)
+        self.assertNotIn("::error::", stdout)
 
     def test_all_mode_passes_on_complete_repo(self) -> None:
         """The current platform checkout should audit clean in ``--all`` mode."""

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -293,6 +293,24 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("ref: ${{ inputs.sha != '' && inputs.sha || github.sha }}", text)
         self.assertEqual(text.count("persist-credentials: false"), 3)
 
+    def test_scanner_matrix_scanner_job_can_read_pull_requests(self) -> None:
+        """Authorize the DeepScan PR-head fallback's ``/commits/<sha>/pulls`` read.
+
+        ``check_deepscan_zero`` resolves the merge commit's pull requests so it
+        can re-read the DeepScan status on the PR head (the App posts there,
+        never on the squash-merge commit). That GitHub API read needs
+        ``pull-requests: read`` on the scanner job's permissions block.
+        """
+        text = (ROOT / ".github" / "workflows" / "reusable-scanner-matrix.yml").read_text(encoding="utf-8")
+        scanner_block_start = text.find("  scanner:")
+        self.assertNotEqual(scanner_block_start, -1, "scanner job is missing")
+        steps_start = text.find("    steps:", scanner_block_start)
+        scanner_header = text[scanner_block_start:steps_start]
+        self.assertIn("    permissions:", scanner_header)
+        self.assertIn("      contents: read", scanner_header)
+        self.assertIn("      id-token: write", scanner_header)
+        self.assertIn("      pull-requests: read", scanner_header)
+
     def test_scanner_matrix_uses_configurable_runner_for_coverage_lane(self) -> None:
         """Allow the coverage lane to select its dedicated runner configuration."""
         text = (ROOT / ".github" / "workflows" / "reusable-scanner-matrix.yml").read_text(encoding="utf-8")
@@ -505,6 +523,21 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIsNone(
             directive_match,
             "Codacy publish step must not silently swallow failures via continue-on-error",
+        )
+        # The Codacy publish step must run the reporter in account-token mode
+        # by wiring the already-valid ``CODACY_API_TOKEN`` via ``api-token``
+        # (the project-scoped ``CODACY_PROJECT_TOKEN`` was never provisioned,
+        # so a project-token-only step uploaded with an empty token and the
+        # Coverage 100 Gate stayed red).
+        self.assertIn(
+            "api-token: ${{ secrets.CODACY_API_TOKEN }}",
+            codacy_block,
+            "Codacy publish step must wire api-token from CODACY_API_TOKEN",
+        )
+        self.assertIn(
+            "project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}",
+            codacy_block,
+            "Codacy publish step must keep project-token for project-token mode",
         )
         # The DeepSource publish step must propagate per-file ``deepsource
         # report`` exit codes — ``|| true`` was the previous silent-pass.

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -558,12 +558,16 @@ class WorkflowContractTests(unittest.TestCase):
             "DeepSource JavaScript coverage report must not be ||true-suppressed",
         )
         # Both steps should fail loud when their respective secrets are
-        # missing — preflight checks emit ``::error::`` and exit 1.
-        self.assertIn(
-            "CODACY_PROJECT_TOKEN secret is missing",
-            text,
-            "Workflow must emit an actionable error when CODACY_PROJECT_TOKEN is missing",
-        ) if "set -euo pipefail" in codacy_block else None  # action-based step path
+        # missing — preflight checks emit ``::error::`` and exit 1. The
+        # Codacy preflight message is only required on the script-based
+        # step path; the action-based path has no shell preflight.
+        if "set -euo pipefail" in codacy_block:
+            self.assertIn(
+                "CODACY_PROJECT_TOKEN secret is missing",
+                text,
+                "Workflow must emit an actionable error when "
+                "CODACY_PROJECT_TOKEN is missing",
+            )
         self.assertIn(
             "DEEPSOURCE_DSN secret is missing",
             text,


### PR DESCRIPTION
## **User description**
## Root cause (diagnosed, not guessed)

The Coverage 100 Gate on `main` was RED. Investigated the actual failing run
(`Quality Zero Platform` workflow, job `Coverage 100 Gate`). Step-level
conclusions from the GitHub API were decisive:

| step | conclusion |
|---|---|
| `Run selected lane` (coverage + full test suite) | **success** (coverage = 100%) |
| `Publish Codacy coverage` | **failure** ← the only red step |

So the gate was **NOT** red because of missing V2 deliverables and **NOT**
because of a coverage shortfall.

### Finding 1 (the real blocker) — missing `CODACY_PROJECT_TOKEN` secret
The `Publish Codacy coverage` step (`reusable-scanner-matrix.yml`) requires
`secrets.CODACY_PROJECT_TOKEN`. The repo had `CODACY_API_TOKEN` but **not**
`CODACY_PROJECT_TOKEN`. The strict-zero gate-plumbing PRs (#222–#225)
intentionally removed `continue-on-error: true`, so a missing project token
now hard-blocks the lane. The token existed only in the Codacy webhook
config, which GitHub Actions cannot read.

**Action taken (owner-authorized):** the repo's `CODACY_PROJECT_TOKEN`
GitHub Actions secret has now been set. This is the change that actually
greens the gate; it is a secret-config action, not a code change.

### Finding 2 (misleading diagnostic, fixed here in code)
`tests/test_verify_v2_deployment.test_all_mode_fails_when_phase1_missing`
runs `verify_v2_deployment.main()` with `--all` against an empty temp dir.
`main()` wrote `::error::missing deliverable: <path>` to **stdout** for every
required deliverable. Running inside the coverage lane, GitHub parsed those
as workflow commands and attached them as failure-level check-run
annotations — making it falsely appear the gate was red over "missing"
deliverables (`reusable-codecov-analytics.yml`, `reusable-drift-sync.yml`,
`known-issues/*.yml`, `codecov.yml.j2`, …). **All of those files exist on
`main`** (`verify_v2_deployment.py --all` exits 0 on a clean checkout,
`missing_count: 0`, `ok_count: 39`). The annotations were noise.

**Fix (real, no suppression):**
- Diagnostics now go to **stderr** (matching the existing repo-root error
  channel), never stdout.
- The `::error::` workflow-command prefix is gated behind a new opt-in
  `--emit-annotations` flag (default off). No CI workflow invokes this
  script, so the annotation form had no real consumer.
- Module docstring documents the stdout/stderr contract.
- Two regression tests added (stdout stays clean by default; opt-in emits
  to stderr only). Coverage stays **100%**.

### Also included
- Cherry-pick `cc00fec`: `scripts/verify` now unsets inherited `GIT_*` so
  fixture tests cannot mutate the real repo when run inside the pre-push
  hook (was not present on `main`).

## Local verification
- `python scripts/quality/verify_v2_deployment.py --all` → **exit 0**,
  `missing_count: 0`, `ok_count: 39`.
- `bash scripts/verify` → **exit 0**: 1493 Python tests, TOTAL coverage
  **100.00%**, 72 node tests pass, 15 profiles validated.
- Pre-push hook (`scripts/verify`) passed on push.

## Overlap / reconciliation for maintainer
This overlaps with in-flight PRs and may need reconciliation:
- **#243** `fix/qzp-gate-plumbing-v2` — "GIT_* isolation + evidence-backed
  classification of Coverage/Semgrep red gates" (same problem space; also
  carries the GIT_* isolation). The `cc00fec` cherry-pick here may be
  redundant once #243/#242 merge.
- **#242** `fix/verify-git-hook-isolation` — contains `cc00fec` directly.
- **#236** truthful-gate subsystem (TG-2 token-rotation preflight) — directly
  related to the `CODACY_PROJECT_TOKEN` blocker; its preflight would have
  surfaced this missing/unreadable token as a loud BLOCK.

Honors the Codacy py2-compat contract (no builtin-generic subscripts; keeps
`from __future__ import absolute_import`). No `continue-on-error`,
suppressions, or dismissals added.

## Test plan
- [ ] CI `Quality Zero Platform` → `Coverage 100 Gate` goes green (now that
      `CODACY_PROJECT_TOKEN` is set + the Codacy upload succeeds).
- [ ] No `::error::missing deliverable` annotations appear on the gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the Coverage 100 Gate by fixing Codacy coverage upload (account-token mode) and stopping `::error::` annotation leaks from tests. Also hardens DeepScan and Sentry checks so the gate reports the right status.

- **Bug Fixes**
  - Codacy publish: wire `api-token` from `CODACY_API_TOKEN` (keep `project-token`); lane fails on upload errors.
  - DeepScan: when the merge commit lacks a status, fall back to PR head via `/commits/<sha>/pulls`; add `pull-requests: read` to the scanner job.
  - Sentry: query the org-scoped unresolved issues endpoint so an org token works (no project slug needed).
  - `verify_v2_deployment.py`: send diagnostics to stderr and keep stdout JSON-only; add `--emit-annotations` opt-in with regression tests.
  - `scripts/verify`: unset inherited `GIT_*` to isolate git-hook runs.

- **Refactors**
  - DeepScan/Sentry checkers: replace kwargs guards with typed inputs (`DeepScanEvaluationInputs`) and add `_first_nonempty` env resolver.
  - Reduced checker complexity to pass the Codacy delta gate; no behavior changes.

<sup>Written for commit 88aea2299df380dcc306b78b86a987afb6b27978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Stop coverage-gate tests from leaking failure annotations**

### What Changed
- Missing deliverable messages now go to standard error instead of standard output, so test runs no longer get mistaken for GitHub workflow failures.
- `::error::` annotations are only emitted when explicitly requested, keeping the default output free of workflow-command text.
- Added regression checks to confirm default runs stay clean on stdout and that annotation output only appears when enabled.
- The hook runner now clears inherited Git environment variables before running, so fixture-based git commands do not affect the real repository.

### Impact
`✅ Fewer false CI failures`
`✅ Cleaner coverage gate annotations`
`✅ Safer pre-push test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--emit-annotations` CLI flag to conditionally emit GitHub Actions workflow error annotations.

* **Bug Fixes**
  * Fixed Git environment variable isolation to prevent hook-injected values from interfering with verification operations.

* **Tests**
  * Enhanced test coverage to validate CLI output behavior and annotation flag functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->