### PR TITLE
fix(security): clear QZT jinja2-autoescape XSS + import-sort (Codacy zero)

### DIFF
--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -20,7 +20,9 @@ if str(Path(__file__).resolve().parents[2]) not in sys.path:
 
 from scripts.quality import codacy_zero_helpers, codacy_zero_support
 from scripts.quality.codacy_quality_thresholds import (
-    DEFAULT_COVERAGE_FLOOR, evaluate_quality_thresholds, fetch_repository_quality,
+    DEFAULT_COVERAGE_FLOOR,
+    evaluate_quality_thresholds,
+    fetch_repository_quality,
 )
 from scripts.quality.common import utc_timestamp, write_report
 from scripts.security_helpers import load_json_https

--- a/scripts/quality/template_render.py
+++ b/scripts/quality/template_render.py
@@ -58,22 +58,19 @@ def _build_environment(templates_root: Path | None = None) -> Environment:
 
     Semgrep's ``direct-use-of-jinja2`` and ``incorrect-autoescape-disabled``
     rules target web-framework rendering where HTML escaping protects
-    against XSS. This module renders *non-HTML* files (YAML, TOML,
-    source) for a filesystem-write pipeline — HTML escaping would
-    actively corrupt those outputs. ``select_autoescape([])`` states the
-    policy explicitly: opt in to escaping only for the listed
-    extensions, which is none.
+    against XSS. This module renders *non-HTML* files (YAML, JSON, source)
+    for a filesystem-write pipeline — HTML escaping would actively corrupt
+    those outputs. ``select_autoescape()`` is the canonical safe
+    constructor the SAST rules recommend: it opts HTML escaping IN only for
+    ``.html``/``.htm``/``.xml`` templates. Every template here is a
+    ``.yml.j2``/``.json.j2`` config file, so escaping stays OFF for them
+    while the policy is expressed in the rule-recognised form.
     """
     root = templates_root or _TEMPLATES_ROOT
     loader = FileSystemLoader(str(root))
-    autoescape_policy = select_autoescape(enabled_extensions=(), default=False)
-    # The context comment above ``_build_environment`` explains why
-    # disabling HTML autoescape is correct for this YAML/config renderer.
-    # Bare ``nosemgrep`` on the constructor line below — the rule-id
-    # form was being ignored by --config auto.
-    return Environment(  # nosec  # nosem
+    return Environment(
         loader=loader,
-        autoescape=autoescape_policy,
+        autoescape=select_autoescape(),
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,


### PR DESCRIPTION
## **User description**
Drives QZT's own Codacy dashboard to zero — the 1 security + 1 quality residual.

## Security (2 Critical XSS SRM items → 0) · `scripts/quality/template_render.py:76`
`autoescape=select_autoescape(enabled_extensions=(), default=False)` was flagged by **both** Ruff `S701` and Semgrep/Opengrep `incorrect-autoescape-disabled` (hence 2 SRM rows), and the existing `# nosec`/`# nosem` comments sat on the constructor line (74), not the finding line (76), so they never suppressed it anyway.

Fix: use the canonical `select_autoescape()` — the exact remediation both rules' messages recommend. It opts HTML escaping IN only for `.html`/`.htm`/`.xml`; **every template in `profiles/templates/` is `.yml` (14) or `.json` (1)** — none of those extensions — so escaping stays OFF for them: **identical behavior** (HTML-escaping YAML/JSON would corrupt it), with no suppression.

Ruff S701 verified clear locally; Semgrep cleared via Codacy's re-scan on this PR.

## Quality (Ruff I001 → 0) · `scripts/quality/check_codacy_zero.py:26`
Sorted the import block.

## Verification
`bash scripts/verify` green: 100% line+branch coverage, template_render tests (22) pass, Node 72/72, 15 profiles validated. Behavior-preserving.


___

## **CodeAnt-AI Description**
**Keep config templates rendering without HTML escaping and clear a linter warning**

### What Changed
- The template renderer now uses the standard safe auto-escaping setup that the security checks expect, while still leaving YAML, JSON, and source templates unescaped
- This keeps generated config files unchanged and avoids the XSS warning that was being raised on this renderer
- A separate import order warning in the Codacy check script was cleaned up

### Impact
`✅ Fewer false security alerts`
`✅ No accidental escaping in generated config files`
`✅ Cleaner Codacy and lint results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `jinja2`’s `select_autoescape()` in the config template renderer to clear XSS findings without changing outputs. Also sort imports in the Codacy check script to resolve a Ruff warning.

- **Bug Fixes**
  - `scripts/quality/template_render.py`: replace disabled autoescape with `select_autoescape()`; HTML escaping stays off for `.yml.j2`/`.json.j2`; removes Ruff S701 and Semgrep alerts.
  - `scripts/quality/check_codacy_zero.py`: sort imports to clear Ruff I001.

<sup>Written for commit ef38c7043758a6c9165fbeee8074683922dc8296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

