### PR TITLE
chore(deps): bump qltysh/qlty-action 2.2.0->2.2.1

### DIFF
--- a/.github/workflows/reusable-scanner-matrix.yml
+++ b/.github/workflows/reusable-scanner-matrix.yml
@@ -178,7 +178,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
       - name: Install Qlty CLI
         if: steps.profile.outputs.qlty_enabled == 'true' && (matrix.lane == 'qlty_zero' || (matrix.lane == 'coverage' && steps.profile.outputs.qlty_coverage_files != '' && runner.os != 'Windows'))
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
+        uses: qltysh/qlty-action/install@fd52dc852530a708d68c3b7342f8d33d1df4cd55
       - name: Run selected lane
         shell: bash
         env:

--- a/tests/quality/rollup_v2/test_verify_action_pins.py
+++ b/tests/quality/rollup_v2/test_verify_action_pins.py
@@ -110,7 +110,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
+      - uses: qltysh/qlty-action/install@fd52dc852530a708d68c3b7342f8d33d1df4cd55
 """)
         violations = scan_workflow(wf)
         self.assertEqual(len(violations), 0)

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -206,7 +206,7 @@ class WorkflowContractTests(unittest.TestCase):
     def test_scanner_matrix_pins_qlty_actions_to_full_sha(self) -> None:
         """Pin QLTY and PR creation actions to immutable full SHAs."""
         text = (ROOT / ".github" / "workflows" / "reusable-scanner-matrix.yml").read_text(encoding="utf-8")
-        self.assertIn("qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899", text)
+        self.assertIn("qltysh/qlty-action/install@fd52dc852530a708d68c3b7342f8d33d1df4cd55", text)
         self.assertIn(
             "matrix.lane == 'qlty_zero' || (matrix.lane == 'coverage' && steps.profile.outputs.qlty_coverage_files != '' && runner.os != 'Windows')",
             text,


### PR DESCRIPTION
## **User description**
Re-applies dependabot #238 (closed: dependabot PRs get no repo secrets, so secret-gated Zero checks could never pass). Same vetted v2.2.1 SHA; from a normal branch the secret-gated lanes run. Ref QZT #184.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `qltysh/qlty-action/install` to v2.2.1 in the scanner workflow so secret-gated lanes run and Zero checks can pass from a non-Dependabot branch. Aligns with Linear QZT-184 to keep QLTY actions pinned to immutable SHAs.

- **Dependencies**
  - Update workflow to use `qltysh/qlty-action/install` v2.2.1 (full SHA).
  - Update tests to expect the new pin.

<sup>Written for commit 7cba503c05560e3d71701339424fbef0d9ed8a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/quality-zero-platform/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Run Qlty checks from normal branches again**

### What Changed
- Updated the Qlty install pin used by the scanner workflow to a newer fixed version
- This lets the secret-gated Qlty Zero checks run from a regular branch instead of being blocked in the Dependabot flow
- Updated tests to expect the new pinned version

### Impact
`✅ Qlty checks can run from non-Dependabot branches`
`✅ Fewer blocked Zero checks`
`✅ More reliable scanner workflow runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
