### PR TITLE
feat: lean-gate thin template (reusable-quality.yml + charter-check)

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -1,0 +1,207 @@
+# Lean 6-gate quality template (workflow_call reusable workflow).
+#
+# This is the ADDITIVE thin template adopted by the lean-gate charter
+# (decided 2026-06-16). It is the multi-language generalization of the PROVEN
+# lean gate running in Prekzursil/Reframe (.github/workflows/quality.yml) — same
+# tool pins, same single-job binary green/red model.
+#
+# It does NOT replace the existing fleet reusable workflows; the 13 enrolled
+# repos still call those. The ~80% deletion of the old SaaS machinery is
+# deferred to the migration runbook until the fleet moves off it.
+#
+# ── Adoption (≈5 lines in the caller repo) ──────────────────────────────────
+#   # .github/workflows/quality.yml in the CALLER repo
+#   name: quality
+#   on:
+#     push: { branches: [main] }
+#     pull_request: { branches: [main] }
+#   permissions: { contents: read }
+#   jobs:
+#     quality:
+#       uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@main
+#
+# ── The closed 6-gate charter this workflow enforces ────────────────────────
+#   1. Lint+format+imports+sec-lint (AUTOFIX, via pre-commit):
+#        Ruff[py] · Oxlint+Oxfmt[ts/js] · clippy+rustfmt[rust] ·
+#        golangci-lint v2[go] · ErrorProne+Spotless[java] ·
+#        Roslyn+dotnet-format[c#] · clang-tidy+clang-format[c/c++]
+#   2. Types:        tsc --noEmit[ts] · basedpyright[py]
+#   3. Tests+cov:    STRICT 100% line+branch (standing policy; ratchet retired)
+#   4. SAST:         Opengrep (Semgrep CE acceptable), pinned in-repo ruleset
+#   5. Secrets:      gitleaks (pinned + allowlist) + push-protection
+#   6. Deps:         osv-scanner + Dependabot (no Renovate)
+#
+# Auto-detection: the single `quality` job inspects the CALLER's checked-out
+# tree and runs ONLY the lanes whose language is present. A repo with no Python
+# skips the Python lanes, a repo with no JS/TS skips tsc, etc. Lane 1 (pre-commit)
+# and lanes 4/5/6 (opengrep/gitleaks/osv) run whenever their config is present.
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python toolchain version for the Python lanes."
+        type: string
+        required: false
+        default: "3.12"
+      node-version:
+        description: "Node toolchain version for the JS/TS lanes."
+        type: string
+        required: false
+        default: "20"
+      opengrep-paths:
+        description: "Space-separated paths the SAST gate scans (default: repo root '.')."
+        type: string
+        required: false
+        default: "."
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      # ── Language detection ────────────────────────────────────────────────
+      # Sets boolean outputs consumed by the per-lane `if:` guards below.
+      - name: Detect languages present in caller
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          has() { [ -n "$(git ls-files "$@" 2>/dev/null | head -1)" ] && echo true || echo false; }
+          file_exists() { [ -f "$1" ] && echo true || echo false; }
+          {
+            echo "python=$(has '*.py')"
+            echo "ts=$(has '*.ts' '*.tsx')"
+            echo "jsts=$(has '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')"
+            echo "rust=$(file_exists Cargo.toml)"
+            echo "go=$(file_exists go.mod)"
+            echo "precommit=$(file_exists .pre-commit-config.yaml)"
+            echo "opengrep=$([ -d .quality/opengrep ] && echo true || echo false)"
+            echo "gitleaks=$(file_exists .gitleaks.toml)"
+            echo "osv=$(file_exists osv-scanner.toml)"
+            echo "charter=$([ -f .quality/charter.yml ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+          echo "Detected:"; cat "$GITHUB_OUTPUT"
+
+      # ── Toolchains (set up only what the caller needs) ────────────────────
+      - name: Set up Python
+        if: steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+
+      - name: Set up Node
+        if: steps.detect.outputs.jsts == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Set up Go
+        if: steps.detect.outputs.go == 'true'
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: stable
+
+      # ── Pinned scanner CLIs (only when their config is present) ───────────
+      - name: Install pre-commit
+        if: steps.detect.outputs.precommit == 'true'
+        run: pip install pre-commit==4.6.0
+
+      - name: Install basedpyright
+        if: steps.detect.outputs.python == 'true'
+        run: pip install basedpyright==1.39.8
+
+      - name: Install opengrep
+        if: steps.detect.outputs.opengrep == 'true'
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash -s -- -v v1.22.0
+          echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
+
+      - name: Install gitleaks
+        if: steps.detect.outputs.gitleaks == 'true'
+        run: |
+          curl -sSL -o /tmp/gitleaks.tar.gz \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
+      - name: Install osv-scanner
+        if: steps.detect.outputs.osv == 'true'
+        run: |
+          curl -sSL -o /usr/local/bin/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
+          chmod +x /usr/local/bin/osv-scanner
+
+      # ── GATE 1 + GATE 5 — lint/format/imports/sec-lint autofixers + secrets ─
+      # All lane-1 fixers (ruff / oxlint+oxfmt / clippy+rustfmt / golangci-lint /
+      # spotless / clang-format / ...) AND the gitleaks secrets hook are wired in
+      # the caller's .pre-commit-config.yaml and verified clean here.
+      - name: gate-lint-format-secrets (pre-commit run --all-files)
+        if: steps.detect.outputs.precommit == 'true'
+        run: pre-commit run --all-files --show-diff-on-failure
+
+      # ── GATE 2 — types ────────────────────────────────────────────────────
+      - name: gate-types tsc
+        if: steps.detect.outputs.ts == 'true'
+        run: |
+          if [ -f package.json ]; then npm ci || npm install; fi
+          npx --yes tsc --noEmit
+
+      - name: gate-types basedpyright
+        if: steps.detect.outputs.python == 'true'
+        run: basedpyright
+
+      # ── GATE 3 — tests + coverage (STRICT 100% line+branch) ───────────────
+      # Python via coverage.py; JS/TS via the caller's `test:coverage` script.
+      - name: gate-tests-coverage python
+        if: steps.detect.outputs.python == 'true' && hashFiles('pyproject.toml', 'setup.cfg', 'tox.ini') != ''
+        run: |
+          if grep -rqs 'pytest' pyproject.toml setup.cfg tox.ini 2>/dev/null; then
+            pip install pytest pytest-cov
+            python -m pytest --cov --cov-branch --cov-fail-under=100
+          else
+            python -m coverage run -m unittest discover
+            python -m coverage report --fail-under=100 --show-missing
+          fi
+
+      - name: gate-tests-coverage jsts
+        if: steps.detect.outputs.jsts == 'true' && hashFiles('package.json') != ''
+        run: |
+          if node -e "process.exit((require('./package.json').scripts||{})['test:coverage']?0:1)"; then
+            npm ci || npm install
+            npm run test:coverage
+          else
+            echo "No 'test:coverage' npm script — JS/TS coverage lane skipped (configure it to enforce 100%)."
+          fi
+
+      # ── GATE 4 — SAST (opengrep, curated in-repo ruleset, clean-zero) ─────
+      - name: gate-sast opengrep
+        if: steps.detect.outputs.opengrep == 'true'
+        run: |
+          opengrep scan --config .quality/opengrep --error \
+            --exclude .venv --exclude node_modules --exclude dist --exclude out --exclude build \
+            ${{ inputs.opengrep-paths }}
+
+      # ── GATE 5 (verify) — secrets, gitleaks over working tree (0 findings) ─
+      # The autofixer-side secrets hook runs in pre-commit (gate 1+5); this is the
+      # standalone gitleaks verify when no pre-commit config is present.
+      - name: gate-secrets gitleaks
+        if: steps.detect.outputs.gitleaks == 'true' && steps.detect.outputs.precommit == 'false'
+        run: gitleaks detect --no-banner --redact --config .gitleaks.toml
+
+      # ── GATE 6 — deps (osv-scanner, 0 actionable CVEs) ───────────────────
+      - name: gate-deps osv-scanner
+        if: steps.detect.outputs.osv == 'true'
+        run: osv-scanner scan source --config=osv-scanner.toml --recursive .
+
+      # ── Charter ↔ active-gate consistency (fails if gate set != 6-charter) ─
+      - name: charter-check
+        if: steps.detect.outputs.charter == 'true'
+        run: bash .quality/charter_check.sh

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -35,6 +35,15 @@
 # tree and runs ONLY the lanes whose language is present. A repo with no Python
 # skips the Python lanes, a repo with no JS/TS skips tsc, etc. Lane 1 (pre-commit)
 # and lanes 4/5/6 (opengrep/gitleaks/osv) run whenever their config is present.
+#
+# No silent-pass: the coverage lane (gate 3) NEVER passes a language green
+# without measuring it. If a language has source AND test files but no coverage
+# config/script, the lane FAILS (the 100% gate cannot pass unmeasured). The ONLY
+# coverage skip is the narrow, documented "no test surface by design" case —
+# source present with ZERO test files (e.g. a pure type-stub or generated-only
+# package). Robustness: the pip cache is enabled only when a Python manifest is
+# resolvable; osv-scanner treats "no manifests/lockfiles" as PASS (not exit-128);
+# tsc runs per-tsconfig so nested/monorepo projects are checked, not hard-failed.
 
 on:
   workflow_call:
@@ -74,7 +83,34 @@ jobs:
         run: |
           set -euo pipefail
           has() { [ -n "$(git ls-files "$@" 2>/dev/null | head -1)" ] && echo true || echo false; }
+          any() { [ -n "${1:-}" ] && echo true || echo false; }
           file_exists() { [ -f "$1" ] && echo true || echo false; }
+          # A resolvable Python dependency manifest (used to gate the pip cache so
+          # setup-python never hard-fails when there is nothing to cache).
+          py_manifest="$(git ls-files \
+            requirements.txt requirements*.txt '**/requirements.txt' '**/requirements*.txt' \
+            pyproject.toml '**/pyproject.toml' setup.py '**/setup.py' \
+            setup.cfg '**/setup.cfg' Pipfile '**/Pipfile' 2>/dev/null | head -1)"
+          # Any dependency manifest OR lockfile osv-scanner can actually scan. With
+          # NONE of these, `osv-scanner scan source` exits 128 ("no package sources").
+          osv_sources="$(git ls-files \
+            '**/requirements*.txt' requirements*.txt \
+            '**/package-lock.json' package-lock.json '**/yarn.lock' yarn.lock \
+            '**/pnpm-lock.yaml' pnpm-lock.yaml '**/Cargo.lock' Cargo.lock \
+            '**/go.mod' go.mod '**/go.sum' go.sum '**/Gemfile.lock' Gemfile.lock \
+            '**/poetry.lock' poetry.lock '**/Pipfile.lock' Pipfile.lock \
+            '**/pyproject.toml' pyproject.toml '**/composer.lock' composer.lock \
+            '**/pom.xml' pom.xml '**/gradle.lockfile' gradle.lockfile 2>/dev/null | head -1)"
+          # A Python coverage configuration (pytest/coverage settings live here).
+          py_cov_cfg="$(git ls-files pyproject.toml setup.cfg tox.ini '.coveragerc' 'pytest.ini' 2>/dev/null | head -1)"
+          # Test surface — if a language has source but ZERO test files, a missing
+          # coverage config is "no test surface by design" (skip), not a hole (fail).
+          py_tests="$(git ls-files 'test_*.py' '*_test.py' '**/test_*.py' '**/*_test.py' \
+            'tests/**' '**/tests/**' conftest.py '**/conftest.py' 2>/dev/null | head -1)"
+          jsts_tests="$(git ls-files \
+            '*.test.ts' '*.test.tsx' '*.test.js' '*.test.jsx' '*.test.mjs' '*.test.cjs' \
+            '*.spec.ts' '*.spec.tsx' '*.spec.js' '*.spec.jsx' '*.spec.mjs' '*.spec.cjs' \
+            '**/*.test.*' '**/*.spec.*' '__tests__/**' '**/__tests__/**' 2>/dev/null | head -1)"
           {
             echo "python=$(has '*.py')"
             echo "ts=$(has '*.ts' '*.tsx')"
@@ -86,16 +122,32 @@ jobs:
             echo "gitleaks=$(file_exists .gitleaks.toml)"
             echo "osv=$(file_exists osv-scanner.toml)"
             echo "charter=$([ -f .quality/charter.yml ] && echo true || echo false)"
+            echo "pymanifest=$(any "$py_manifest")"
+            echo "osvsources=$(any "$osv_sources")"
+            echo "pycovcfg=$(any "$py_cov_cfg")"
+            echo "pytests=$(any "$py_tests")"
+            echo "jststests=$(any "$jsts_tests")"
           } >> "$GITHUB_OUTPUT"
           echo "Detected:"; cat "$GITHUB_OUTPUT"
 
       # ── Toolchains (set up only what the caller needs) ────────────────────
-      - name: Set up Python
-        if: steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true'
+      # Two variants so the pip cache is enabled ONLY when a resolvable manifest
+      # exists. `cache: pip` with no requirements.txt/pyproject.toml/setup.cfg/etc
+      # hard-fails setup-python ("No file matched ...") BEFORE any gate runs — the
+      # observed fleet red on dep-less Python repos (codeblocks/devextreme/swfoc/
+      # tanks). Cached path for manifest repos; plain path otherwise.
+      - name: Set up Python (cached)
+        if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: pip
+
+      - name: Set up Python (no cache)
+        if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'false'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ inputs.python-version }}
 
       - name: Set up Node
         if: steps.detect.outputs.jsts == 'true'
@@ -148,11 +200,40 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
       # ── GATE 2 — types ────────────────────────────────────────────────────
+      # tsc per tsconfig.json so monorepo / nested-project shapes (e.g. an `ui/`
+      # subproject with its own tsconfig and no root tsconfig — event-link) are
+      # type-checked instead of hard-failing. Root tsconfig => `tsc --noEmit`;
+      # otherwise discover every nested tsconfig and run `tsc -p <dir> --noEmit`.
+      # Each project's deps are installed from its own package.json when present.
       - name: gate-types tsc
         if: steps.detect.outputs.ts == 'true'
+        shell: bash
         run: |
-          if [ -f package.json ]; then npm ci || npm install; fi
-          npx --yes tsc --noEmit
+          set -euo pipefail
+          install_deps() { # $1 = dir containing package.json
+            if [ -f "$1/package.json" ]; then
+              ( cd "$1" && { npm ci || npm install; } )
+            fi
+          }
+          if [ -f tsconfig.json ]; then
+            install_deps .
+            npx --yes tsc --noEmit
+          else
+            # No root tsconfig — discover nested project configs (excluding vendored trees).
+            mapfile -t configs < <(git ls-files '**/tsconfig.json' tsconfig*.json \
+              | grep -Ev '(^|/)(node_modules|dist|out|build|\.venv)/' || true)
+            if [ "${#configs[@]}" -eq 0 ]; then
+              echo "ts/tsx present but no tsconfig.json (root or nested) - nothing for tsc to check."
+              exit 0
+            fi
+            for cfg in "${configs[@]}"; do
+              dir="$(dirname "$cfg")"
+              echo "::group::tsc -p $cfg"
+              install_deps "$dir"
+              ( cd "$dir" && npx --yes tsc -p "$(basename "$cfg")" --noEmit )
+              echo "::endgroup::"
+            done
+          fi
 
       - name: gate-types basedpyright
         if: steps.detect.outputs.python == 'true'
@@ -160,25 +241,71 @@ jobs:
 
       # ── GATE 3 — tests + coverage (STRICT 100% line+branch) ───────────────
       # Python via coverage.py; JS/TS via the caller's `test:coverage` script.
+      # SILENT-PASS HOLE CLOSED: the old guard `&& hashFiles(pyproject/setup.cfg/
+      # tox.ini)` let a Python repo with code but no coverage config pass GREEN
+      # without ever measuring coverage. Now: if Python source exists we ALWAYS
+      # measure. The ONLY skip is the documented narrow case — Python source with
+      # ZERO test files (no tests, no coverage config) = "no test surface by
+      # design". Source + tests but no cov config (or source + cov config) => FAIL
+      # unless 100%. The 100% gate cannot pass unmeasured.
       - name: gate-tests-coverage python
-        if: steps.detect.outputs.python == 'true' && hashFiles('pyproject.toml', 'setup.cfg', 'tox.ini') != ''
+        if: steps.detect.outputs.python == 'true'
+        shell: bash
         run: |
-          if grep -rqs 'pytest' pyproject.toml setup.cfg tox.ini 2>/dev/null; then
+          set -euo pipefail
+          if [ "${{ steps.detect.outputs.pycovcfg }}" != "true" ] && [ "${{ steps.detect.outputs.pytests }}" != "true" ]; then
+            echo "Python source present with NO test files and NO coverage config - no test surface by design; coverage lane skipped."
+            exit 0
+          fi
+          if [ "${{ steps.detect.outputs.pycovcfg }}" != "true" ] && [ "${{ steps.detect.outputs.pytests }}" == "true" ]; then
+            echo "FAIL gate-tests-coverage python: Python source + tests are present but no coverage config (pyproject.toml/setup.cfg/tox.ini/.coveragerc/pytest.ini) - the 100% gate cannot pass unmeasured. Add coverage config." >&2
+            exit 1
+          fi
+          if grep -rqs 'pytest' pyproject.toml setup.cfg tox.ini pytest.ini 2>/dev/null; then
             pip install pytest pytest-cov
             python -m pytest --cov --cov-branch --cov-fail-under=100
           else
+            pip install coverage
             python -m coverage run -m unittest discover
             python -m coverage report --fail-under=100 --show-missing
           fi
 
+      # SILENT-PASS HOLE CLOSED: the old else-branch printed a message and passed
+      # GREEN when ts/js source existed but no `test:coverage` script — code with
+      # zero measured coverage slipped through the 100% gate. Now: if a coverage
+      # script (or vitest/jest coverage equivalent) is present we run it; if ts/js
+      # source + tests exist but no coverage script => FAIL. The ONLY skip is the
+      # documented narrow case — ts/js source with ZERO test files = "no test
+      # surface by design". A ts/js repo with code + tests but no coverage script
+      # must NOT pass unmeasured.
       - name: gate-tests-coverage jsts
-        if: steps.detect.outputs.jsts == 'true' && hashFiles('package.json') != ''
+        if: steps.detect.outputs.jsts == 'true'
+        shell: bash
         run: |
-          if node -e "process.exit((require('./package.json').scripts||{})['test:coverage']?0:1)"; then
+          set -euo pipefail
+          has_pkg=false; [ -f package.json ] && has_pkg=true
+          has_cov_script=false
+          if [ "$has_pkg" = "true" ] && node -e "process.exit((require('./package.json').scripts||{})['test:coverage']?0:1)" 2>/dev/null; then
+            has_cov_script=true
+          fi
+          # Fallback: a coverage-capable runner (vitest/jest) wired into the `test`
+          # script with a --coverage flag also counts as a configured coverage lane.
+          has_cov_runner=false
+          if [ "$has_pkg" = "true" ] && node -e "const s=(require('./package.json').scripts||{}).test||'';process.exit(/(vitest|jest).*--coverage|--coverage.*(vitest|jest)/.test(s)?0:1)" 2>/dev/null; then
+            has_cov_runner=true
+          fi
+          if [ "$has_cov_script" = "true" ]; then
             npm ci || npm install
             npm run test:coverage
+          elif [ "$has_cov_runner" = "true" ]; then
+            npm ci || npm install
+            npm test
+          elif [ "${{ steps.detect.outputs.jststests }}" != "true" ]; then
+            echo "ts/js source present with NO test files and no coverage script - no test surface by design; coverage lane skipped."
+            exit 0
           else
-            echo "No 'test:coverage' npm script — JS/TS coverage lane skipped (configure it to enforce 100%)."
+            echo "FAIL gate-tests-coverage jsts: ts/js present (with test files) but no coverage script - the 100% gate cannot pass unmeasured. Add a 'test:coverage' npm script (or a vitest/jest '--coverage' test script)." >&2
+            exit 1
           fi
 
       # ── GATE 4 — SAST (opengrep, curated in-repo ruleset, clean-zero) ─────
@@ -197,9 +324,20 @@ jobs:
         run: gitleaks detect --no-banner --redact --config .gitleaks.toml
 
       # ── GATE 6 — deps (osv-scanner, 0 actionable CVEs) ───────────────────
+      # osv-scanner exits 128 ("no package sources found") on a zero-dependency
+      # repo (observed fleet red: star-wars). Treat "no manifests/lockfiles to
+      # scan" as PASS — nothing to scan is not a failure — and only invoke the
+      # scanner when there is at least one scannable source.
       - name: gate-deps osv-scanner
         if: steps.detect.outputs.osv == 'true'
-        run: osv-scanner scan source --config=osv-scanner.toml --recursive .
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.detect.outputs.osvsources }}" != "true" ]; then
+            echo "No dependency manifests or lockfiles present - nothing for osv-scanner to scan; deps gate passes."
+            exit 0
+          fi
+          osv-scanner scan source --config=osv-scanner.toml --recursive .
 
       # ── Charter ↔ active-gate consistency (fails if gate set != 6-charter) ─
       - name: charter-check

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -44,6 +44,11 @@
 # package). Robustness: the pip cache is enabled only when a Python manifest is
 # resolvable; osv-scanner treats "no manifests/lockfiles" as PASS (not exit-128);
 # tsc runs per-tsconfig so nested/monorepo projects are checked, not hard-failed.
+# Gate 3 installs the CALLER's Python runtime deps (requirements*/pyproject/
+# setup.*) before pytest so tests importing a runtime dep don't ModuleNotFoundError,
+# and runs `npm ci` before any node coverage. Gate 1's ts/js lint/format runs the
+# workflow's OWN pinned oxlint+oxfmt SELF-CONTAINED, so a caller-local
+# frontend-eslint pre-commit hook (exit 127) cannot abort the lean gate.
 
 on:
   workflow_call:
@@ -117,6 +122,7 @@ jobs:
             echo "jsts=$(has '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')"
             echo "rust=$(file_exists Cargo.toml)"
             echo "go=$(file_exists go.mod)"
+            echo "frontend=$(has package.json '**/package.json')"
             echo "precommit=$(file_exists .pre-commit-config.yaml)"
             echo "opengrep=$([ -d .quality/opengrep ] && echo true || echo false)"
             echo "gitleaks=$(file_exists .gitleaks.toml)"
@@ -191,13 +197,71 @@ jobs:
             https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
           chmod +x /usr/local/bin/osv-scanner
 
+      # ── GATE 1 (ts/js) — SELF-CONTAINED lint + format (Oxlint + Oxfmt) ───────
+      # GAP 2 FIX — the lean charter's gate-1 for ts/js is Oxlint + Oxfmt (the Oxc
+      # toolchain), which are SELF-CONTAINED in THIS workflow (the Reframe pattern),
+      # NOT the caller's ad-hoc eslint. A caller .pre-commit-config.yaml that
+      # contains a repo-LOCAL `frontend-eslint`-style hook shelling out to a
+      # not-yet-installed tool ("sh: 1: eslint: not found", exit 127) used to
+      # short-circuit the whole gate-1 step (observed: momentstudio). We therefore
+      # run the workflow's OWN pinned oxlint + oxfmt over the caller's ts/js
+      # directly, independent of the caller's local hooks. They need nothing from
+      # the caller (npx fetches the pinned CLIs). Both honor the caller's
+      # .oxlintrc.json / .oxfmtrc.json if present and respect .gitignore; oxfmt
+      # skips node_modules by default. Pins: oxlint 1.69.0 (mirrors Reframe), oxfmt
+      # 0.55.0. Keep in sync with docs/lean-gate/pre-commit-config.template.yaml.
+      - name: gate-lint-format-jsts (self-contained oxlint + oxfmt)
+        if: steps.detect.outputs.jsts == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::group::oxlint@1.69.0 (--deny-warnings)"
+          npx --yes oxlint@1.69.0 --deny-warnings \
+            --ignore-pattern '**/node_modules/**' \
+            --ignore-pattern '**/dist/**' \
+            --ignore-pattern '**/build/**' \
+            --ignore-pattern '**/out/**' \
+            --ignore-pattern '**/.venv/**' \
+            --ignore-pattern '**/vendor/**' \
+            .
+          echo "::endgroup::"
+          echo "::group::oxfmt@0.55.0 (--check)"
+          # `oxfmt --check` exits non-zero on any unformatted file (skips
+          # node_modules; honors .gitignore/.prettierignore).
+          npx --yes oxfmt@0.55.0 --check . || {
+            echo "FAIL gate-lint-format-jsts: oxfmt found unformatted ts/js (run 'oxfmt' / the oxfmt pre-commit hook to fix)." >&2
+            exit 1
+          }
+          echo "::endgroup::"
+
       # ── GATE 1 + GATE 5 — lint/format/imports/sec-lint autofixers + secrets ─
-      # All lane-1 fixers (ruff / oxlint+oxfmt / clippy+rustfmt / golangci-lint /
-      # spotless / clang-format / ...) AND the gitleaks secrets hook are wired in
-      # the caller's .pre-commit-config.yaml and verified clean here.
+      # All lane-1 fixers (ruff / clippy+rustfmt / golangci-lint / spotless /
+      # clang-format / ...) AND the gitleaks secrets hook are wired in the caller's
+      # .pre-commit-config.yaml and verified clean here. The ts/js lint/format is
+      # NOT relied upon from pre-commit (it runs self-contained above) so a caller-
+      # local frontend hook cannot abort the lean gate.
+      #
+      # GAP 2 ROBUSTNESS — when the caller ships a JS/TS manifest, `npm ci` first
+      # so any caller-local pre-commit hooks (e.g. a `frontend-eslint` repo-local
+      # hook) can resolve their tool from node_modules instead of failing with
+      # exit 127. Best-effort: a failed install must not by itself red the gate, so
+      # any caller-local hook that STILL shells out to a tool it never installed is
+      # SKIP-ed (SKIP=frontend-eslint,eslint,prettier,tsc) — those are the caller's
+      # ad-hoc lanes, not the lean charter's self-contained gate-1. Ruff/gitleaks/
+      # the rest of the charter hooks still run and still gate.
       - name: gate-lint-format-secrets (pre-commit run --all-files)
         if: steps.detect.outputs.precommit == 'true'
-        run: pre-commit run --all-files --show-diff-on-failure
+        shell: bash
+        env:
+          SKIP: frontend-eslint,eslint,eslint-local,prettier,tsc,frontend-tsc,frontend-prettier
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.detect.outputs.frontend }}" = "true" ]; then
+            echo "::group::npm ci (resolve any caller-local frontend pre-commit hooks)"
+            ( npm ci || npm install ) || echo "WARN: frontend dep install failed; caller-local frontend hooks are SKIP-ed and the lean ts/js gate runs self-contained above."
+            echo "::endgroup::"
+          fi
+          pre-commit run --all-files --show-diff-on-failure
 
       # ── GATE 2 — types ────────────────────────────────────────────────────
       # tsc per tsconfig.json so monorepo / nested-project shapes (e.g. an `ui/`
@@ -261,6 +325,36 @@ jobs:
             echo "FAIL gate-tests-coverage python: Python source + tests are present but no coverage config (pyproject.toml/setup.cfg/tox.ini/.coveragerc/pytest.ini) - the 100% gate cannot pass unmeasured. Add coverage config." >&2
             exit 1
           fi
+          # GAP 1 FIX — install the CALLER's Python RUNTIME deps before running the
+          # tests. Without this, a repo whose tests import a runtime dependency
+          # fails with ModuleNotFoundError (observed: env-inspector -> "No module
+          # named defusedxml"; the lane previously installed only pytest/coverage).
+          # Priority order: requirements*.txt -> pyproject.toml / setup.cfg /
+          # setup.py (PEP 517 install of the project itself, which pulls its
+          # declared dependencies, incl. Poetry's [tool.poetry.dependencies]).
+          # If NONE exist the repo is pure-stdlib -> proceed (no-op). Best-effort:
+          # a failing optional/heavy install must not mask the real test result,
+          # so each install is guarded and only logged on failure.
+          installed_runtime_deps=false
+          mapfile -t reqs < <(git ls-files \
+            requirements.txt 'requirements/*.txt' 'requirements-*.txt' 'requirements*.txt' \
+            '**/requirements.txt' 2>/dev/null \
+            | grep -Ev '(^|/)(node_modules|\.venv|venv|dist|build|out)/' \
+            | grep -Eiv 'requirements.*(dev|test|lint|doc|ci).*\.txt$' || true)
+          if [ "${#reqs[@]}" -gt 0 ]; then
+            for r in "${reqs[@]}"; do
+              echo "::group::pip install -r $r"
+              pip install -r "$r" || echo "WARN: 'pip install -r $r' failed; continuing (tests will surface any missing import)."
+              echo "::endgroup::"
+            done
+            installed_runtime_deps=true
+          elif [ -f pyproject.toml ] || [ -f setup.cfg ] || [ -f setup.py ]; then
+            echo "::group::pip install . (project deps from pyproject/setup.cfg/setup.py)"
+            pip install . || echo "WARN: 'pip install .' failed; continuing (tests will surface any missing import)."
+            echo "::endgroup::"
+            installed_runtime_deps=true
+          fi
+          [ "$installed_runtime_deps" = "true" ] || echo "No Python runtime manifest (requirements*.txt / pyproject.toml / setup.cfg / setup.py) - assuming pure-stdlib; proceeding."
           if grep -rqs 'pytest' pyproject.toml setup.cfg tox.ini pytest.ini 2>/dev/null; then
             pip install pytest pytest-cov
             python -m pytest --cov --cov-branch --cov-fail-under=100

--- a/.quality/charter.yml
+++ b/.quality/charter.yml
@@ -39,6 +39,11 @@ gates:
     name: tests-coverage
     workflow_step: "gate-tests-coverage"
     policy: "STRICT 100% line+branch; reasoned greppable pragma only"
+    # No silent-pass: a language with source AND test files but no coverage
+    # config/script FAILS (the 100% gate cannot pass unmeasured). The ONLY skip
+    # is the narrow "no test surface by design" case — source present with ZERO
+    # test files (e.g. type-stub-only / generated-only package).
+    no_silent_pass: true
   - id: 4
     name: sast
     workflow_step: "gate-sast"

--- a/.quality/charter.yml
+++ b/.quality/charter.yml
@@ -1,0 +1,82 @@
+# LEAN 6-GATE CHARTER (decided 2026-06-16; supersedes the 10-SaaS QZP model).
+#
+# Single source of truth for the closed set of quality gates. The charter-check
+# (.quality/charter_check.sh, run in CI by reusable-quality.yml) FAILS if the
+# active gate set drifts from this list — either a charter gate is missing from
+# the reusable workflow, or a DELETED (banned) gate has crept back in.
+#
+# Model: Prevent(auto-fix) | Binary green/red | Ratchet-retired:100%-everywhere
+# Closed set — exactly these six gates, nothing more, nothing less.
+
+charter_version: "2026-06-16"
+model:
+  prevent: true        # auto-fix at write time (gate 1 + pre-commit)
+  binary: true         # every gate is pass/fail, no soft scores
+  ratchet_retired: true # 100% coverage everywhere; no ratcheting baseline
+
+# The six gates. `workflow_step` is the substring the charter-check greps for in
+# .github/workflows/reusable-quality.yml to confirm the gate is wired.
+gates:
+  - id: 1
+    name: lint-format-imports-seclint
+    autofix: true
+    workflow_step: "gate-lint-format-secrets"
+    tools:
+      python: [ruff]
+      ts_js: [oxlint, oxfmt]
+      rust: [clippy, rustfmt]
+      go: ["golangci-lint-v2"]
+      java: [errorprone, spotless]
+      csharp: [roslyn, dotnet-format]
+      c_cpp: [clang-tidy, clang-format]
+  - id: 2
+    name: types
+    workflow_step: "gate-types"
+    tools:
+      ts: ["tsc --noEmit"]
+      python: [basedpyright]
+  - id: 3
+    name: tests-coverage
+    workflow_step: "gate-tests-coverage"
+    policy: "STRICT 100% line+branch; reasoned greppable pragma only"
+  - id: 4
+    name: sast
+    workflow_step: "gate-sast"
+    tools: [opengrep]   # Semgrep CE acceptable (rule-compatible)
+    note: "small pinned in-repo ruleset (.quality/opengrep)"
+  - id: 5
+    name: secrets
+    workflow_step: "gate-secrets"        # via pre-commit (gate-lint-format-secrets) or standalone
+    tools: [gitleaks]
+    note: "pinned + allowlist + push-protection"
+  - id: 6
+    name: deps
+    workflow_step: "gate-deps"
+    tools: [osv-scanner, dependabot]      # NO Renovate
+
+# DELETED as gates (must NOT appear as enforced gate steps in the reusable
+# workflow). The charter-check fails if any of these names is wired as a gate.
+deleted_gates:
+  - sonar
+  - codacy
+  - deepsource
+  - deepscan
+  - qlty
+  - codecov        # codecov-as-gate
+  - snyk
+  - applitools
+  - chromatic
+  - percy
+  - sentry         # sentry-as-gate
+  - pylint
+  - bandit         # standalone bandit
+  - eslint         # eslint-classic
+  - biome
+  - trivy          # trivy-for-app-deps
+  - renovate
+
+# CodeQL is NOT a charter gate. Allowed ONLY as a nightly scan on PUBLIC repos
+# (never a required PR status check).
+codeql:
+  as_gate: false
+  allowed: "nightly, public repos only"

--- a/.quality/charter_check.sh
+++ b/.quality/charter_check.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Charter-check (lean 6-gate). FAILS CI if the active gate set in the reusable
+# workflow drifts from the charter declared in .quality/charter.yml:
+#   (a) every charter gate's workflow_step MUST be wired as a step in
+#       .github/workflows/reusable-quality.yml, AND
+#   (b) NO deleted/banned gate (sonar/codacy/.../renovate) may be wired as a
+#       `gate-*` enforcement step.
+#
+# Pure bash + grep/sed (no Python, no PyYAML) so it sidesteps QZT's py2-compat
+# commit contract and runs identically locally and in CI. Terminal-state output:
+# emits PASS / FAIL lines and exits non-zero on any drift.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHARTER="$ROOT/.quality/charter.yml"
+WORKFLOW="$ROOT/.github/workflows/reusable-quality.yml"
+
+fail=0
+note() { printf '%s\n' "$*"; }
+
+[ -f "$CHARTER" ]  || { note "FAIL charter-check: missing $CHARTER"; exit 1; }
+[ -f "$WORKFLOW" ] || { note "FAIL charter-check: missing $WORKFLOW"; exit 1; }
+
+# Strip inline comments + surrounding quotes from a scalar value.
+clean() { sed -e 's/#.*$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^"//' -e 's/"$//'; }
+
+# ── (a) every charter gate workflow_step is present in the workflow ──────────
+required_steps="$(grep -E '^\s*workflow_step:' "$CHARTER" | sed -E 's/^\s*workflow_step:\s*//' | clean)"
+if [ -z "$required_steps" ]; then
+  note "FAIL charter-check: no workflow_step entries found in charter"
+  exit 1
+fi
+while IFS= read -r step; do
+  [ -z "$step" ] && continue
+  if grep -Eq "name:\s*${step}" "$WORKFLOW"; then
+    note "PASS charter-gate step wired: ${step}"
+  else
+    note "FAIL charter-gate step MISSING from workflow: ${step}"
+    fail=1
+  fi
+done <<< "$required_steps"
+
+# ── (b) no deleted/banned gate is wired as a gate-* enforcement step ─────────
+# Collect the deleted_gates list (lines between 'deleted_gates:' and the next
+# top-level key). Each banned name must not appear as a `name: gate-<name>` step.
+banned="$(awk '
+  /^deleted_gates:/ {grab=1; next}
+  grab && /^[a-zA-Z]/ {grab=0}
+  grab && /^\s*-\s*/ {sub(/^\s*-\s*/,""); sub(/#.*/,""); gsub(/[[:space:]]/,""); if (length($0)) print}
+' "$CHARTER")"
+
+# Active gate-* enforcement step names in the workflow.
+active_gate_steps="$(grep -E '^\s*-\s*name:\s*gate-' "$WORKFLOW" | sed -E 's/^\s*-\s*name:\s*//' | clean)"
+
+while IFS= read -r bad; do
+  [ -z "$bad" ] && continue
+  if printf '%s\n' "$active_gate_steps" | grep -Eiq "(^|[^a-z])${bad}([^a-z]|$)"; then
+    note "FAIL banned gate '${bad}' is wired as an enforcement step (charter forbids it)"
+    fail=1
+  fi
+done <<< "$banned"
+
+# ── CodeQL must not be a gate (nightly/public-only) ──────────────────────────
+if printf '%s\n' "$active_gate_steps" | grep -Eiq 'codeql'; then
+  note "FAIL CodeQL wired as a gate step; charter allows CodeQL only as a nightly scan on public repos"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  note "FAILED: charter-check — active gate set != lean 6-gate charter"
+  exit 1
+fi
+note "SUCCESS: charter-check — active gate set matches the lean 6-gate charter"

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -83,6 +83,35 @@ hard-fail *before* a gate can run:
 - **Monorepo / nested TypeScript** — `tsc` runs per `tsconfig.json`: the root
   config if present, otherwise every discovered nested config (e.g. a `ui/`
   subproject). A repo with nested-only configs is checked, not hard-failed.
+- **Tests that import a runtime dependency** — gate 3 installs the caller's
+  Python **runtime** deps before `pytest`/`coverage`, in priority order:
+  `requirements.txt` / `requirements/*.txt` / `requirements*.txt`
+  (`pip install -r`, dev/test/lint/doc/ci-only requirements excluded), then
+  `pyproject.toml` / `setup.cfg` / `setup.py` (`pip install .`, which pulls the
+  project's declared deps incl. Poetry's `[tool.poetry.dependencies]`). With no
+  manifest the repo is treated as pure-stdlib and the lane proceeds. This closes
+  the `ModuleNotFoundError` red on repos whose tests import a runtime dependency
+  (observed: `env-inspector` → `No module named defusedxml`, when the lane had
+  installed only `pytest`/`pytest-cov`). The JS/TS test lane already runs
+  `npm ci` (or `npm install` if no lockfile) before any vitest/jest coverage so
+  `node_modules` exists. The strict `--cov-fail-under=100` / 100% gate is
+  unchanged.
+- **Caller-local frontend pre-commit hook (`eslint: not found`)** — gate 1's
+  ts/js lint+format is **self-contained in this workflow**: a dedicated
+  `gate-lint-format-jsts` step runs the workflow's OWN pinned **oxlint 1.69.0**
+  + **oxfmt 0.55.0** over the caller's ts/js (the Reframe pattern), independent
+  of the caller's `.pre-commit-config.yaml`. A caller repo-local
+  `frontend-eslint`-style hook that shells out to a not-yet-installed tool
+  (`sh: 1: eslint: not found`, exit 127) can therefore no longer abort the lean
+  ts/js gate (observed: `momentstudio`). The `pre-commit run --all-files` step is
+  additionally hardened: when a JS/TS manifest is present it runs `npm ci` first
+  so legitimate caller-local hooks resolve their tool from `node_modules`, and
+  any still-unresolvable ad-hoc frontend hooks are `SKIP`-ed
+  (`SKIP=frontend-eslint,eslint,…,prettier,tsc`) — those are the caller's ad-hoc
+  lanes, not the lean charter's gate-1; ruff, gitleaks, and the rest of the
+  charter hooks still run and still gate. **Chosen approach: (b) self-contained
+  oxlint/oxfmt run directly + (a) `npm ci` before pre-commit** — both, so the
+  lean gate is correct whether or not the caller's local hooks resolve.
 
 ## Charter drift guard
 

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -30,7 +30,7 @@ Model: **Prevent (auto-fix) - Binary green/red - Ratchet-retired (100% everywher
 
 1. **Lint + format + imports + sec-lint** (AUTOFIX): Ruff [py] - Oxlint+Oxfmt [ts/js] - clippy+rustfmt [rust] - golangci-lint v2 [go] - ErrorProne+Spotless [java] - Roslyn+dotnet-format [c#] - clang-tidy+clang-format [c/c++].
 2. **Types**: `tsc --noEmit` [ts] - basedpyright [py].
-3. **Tests + coverage**: STRICT **100% line+branch** (standing user policy; ratchet retired). Reasoned, greppable pragma only.
+3. **Tests + coverage**: STRICT **100% line+branch** (standing user policy; ratchet retired). Reasoned, greppable pragma only. **No silent-pass** — a language with source *and* test files but no coverage config/script **FAILS** (the 100% gate cannot pass unmeasured); the only skip is the narrow *no-test-surface-by-design* case (source present with **zero** test files).
 4. **SAST**: Opengrep (Semgrep CE acceptable), small pinned in-repo ruleset (`.quality/opengrep`).
 5. **Secrets**: gitleaks (pinned + allowlist) + push-protection.
 6. **Deps**: osv-scanner + Dependabot (**no** Renovate).
@@ -67,6 +67,22 @@ Then add the per-language config the gates read:
 Language auto-detection means a caller with no Python skips the Python lanes,
 a caller with no JS/TS skips `tsc`, and so on — each lane is guarded by an
 `if:` keyed off the detected language / present config.
+
+### Robustness on edge-shaped callers
+
+The detection step is hardened so toolchain setup and the deps/types lanes never
+hard-fail *before* a gate can run:
+
+- **Dep-less Python repos** — the `pip` cache is enabled only when a resolvable
+  Python manifest (`requirements*.txt` / `pyproject.toml` / `setup.py` /
+  `setup.cfg` / `Pipfile`) exists. Without one, `setup-python` runs **without**
+  the cache instead of erroring on "no file matched".
+- **Zero-dependency repos** — `osv-scanner` is invoked only when at least one
+  scannable manifest/lockfile exists; otherwise the deps gate **passes**
+  (nothing to scan) rather than exiting 128 ("no package sources found").
+- **Monorepo / nested TypeScript** — `tsc` runs per `tsconfig.json`: the root
+  config if present, otherwise every discovered nested config (e.g. a `ui/`
+  subproject). A repo with nested-only configs is checked, not hard-failed.
 
 ## Charter drift guard
 

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -1,0 +1,81 @@
+# Lean 6-gate thin template
+
+This directory is the **additive lean-gate thin template** adopted by the
+lean 6-gate charter (decided 2026-06-16; supersedes the 10-SaaS QZP model).
+It is the multi-language generalization of the **proven** lean gate already
+running in [`Prekzursil/Reframe`](https://github.com/Prekzursil/Reframe)
+(`.github/workflows/quality.yml`) — same tool pins, same single-job binary
+green/red model.
+
+> **Additive only.** Adding this template does **not** remove the existing
+> fleet reusable workflows. The 13 enrolled repos still call the old SaaS
+> control-plane workflows; the ~80% deletion of that machinery is **deferred
+> to the migration runbook** until the fleet migrates off it. This template
+> also does **not** flip any required-status-check / branch-protection /
+> ruleset — that is also deferred to the runbook (required ⊆ enabled, or the
+> branch goes permanently red).
+
+## What it is
+
+| File | Role |
+|------|------|
+| `../../.github/workflows/reusable-quality.yml` | ONE `workflow_call` reusable workflow, single job `quality`, auto-detects the caller's languages and runs only the relevant lean lanes. |
+| `pre-commit-config.template.yaml` | The gate-1/gate-5 autofix lane (copy to the caller as `.pre-commit-config.yaml`, keep the hooks for languages present). |
+| `../../.quality/charter.yml` | The single source of truth for the closed 6-gate set + the banned (deleted) gates. |
+| `../../.quality/charter_check.sh` | Pure-bash check that FAILS CI if the active gate set drifts from the charter. |
+
+## The closed 6-gate charter
+
+Model: **Prevent (auto-fix) - Binary green/red - Ratchet-retired (100% everywhere)**.
+
+1. **Lint + format + imports + sec-lint** (AUTOFIX): Ruff [py] - Oxlint+Oxfmt [ts/js] - clippy+rustfmt [rust] - golangci-lint v2 [go] - ErrorProne+Spotless [java] - Roslyn+dotnet-format [c#] - clang-tidy+clang-format [c/c++].
+2. **Types**: `tsc --noEmit` [ts] - basedpyright [py].
+3. **Tests + coverage**: STRICT **100% line+branch** (standing user policy; ratchet retired). Reasoned, greppable pragma only.
+4. **SAST**: Opengrep (Semgrep CE acceptable), small pinned in-repo ruleset (`.quality/opengrep`).
+5. **Secrets**: gitleaks (pinned + allowlist) + push-protection.
+6. **Deps**: osv-scanner + Dependabot (**no** Renovate).
+
+**Deleted as gates** (must NOT reappear): Sonar, Codacy, DeepSource, DeepScan,
+qlty, Codecov-as-gate, Snyk, Applitools, Chromatic, Percy, Sentry-as-gate,
+Pylint, standalone Bandit, ESLint-classic, Biome, Trivy-for-app-deps.
+**CodeQL** only nightly, on PUBLIC repos.
+
+## Adopting it (~5 lines in the caller repo)
+
+```yaml
+# .github/workflows/quality.yml in the CALLER repo
+name: quality
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+permissions: { contents: read }
+jobs:
+  quality:
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@main
+```
+
+Then add the per-language config the gates read:
+
+- `.pre-commit-config.yaml` — copy `pre-commit-config.template.yaml`, keep the
+  language hooks you need (gate 1 + gate 5).
+- `.quality/opengrep/*.yaml` — the curated SAST ruleset (gate 4); see the
+  Reframe `.quality/opengrep/README.md` for the curated subset model.
+- `.gitleaks.toml` — secrets allowlist (gate 5).
+- `osv-scanner.toml` + Dependabot config — deps (gate 6).
+- `.quality/charter.yml` + `.quality/charter_check.sh` — the drift guard.
+
+Language auto-detection means a caller with no Python skips the Python lanes,
+a caller with no JS/TS skips `tsc`, and so on — each lane is guarded by an
+`if:` keyed off the detected language / present config.
+
+## Charter drift guard
+
+`bash .quality/charter_check.sh` (run by the `charter-check` step in the
+reusable workflow) FAILS if:
+
+- any charter gate's `workflow_step` is **missing** from the reusable workflow, or
+- any **banned** gate (sonar/codacy/.../renovate) is wired as a `gate-*` step, or
+- CodeQL is wired as a gate (it is nightly/public-only).
+
+Keep the pins in `pre-commit-config.template.yaml`, `reusable-quality.yml`, and
+`.quality/charter.yml` in sync when bumping a tool version.

--- a/docs/lean-gate/pre-commit-config.template.yaml
+++ b/docs/lean-gate/pre-commit-config.template.yaml
@@ -1,0 +1,117 @@
+# Lean 6-gate autofix lane (gate 1 lint/format/imports/sec-lint + gate 5 secrets).
+#
+# TEMPLATE — copy to `.pre-commit-config.yaml` in the CALLER repo and keep only
+# the hooks for languages it actually has (uncomment the relevant blocks).
+#
+# `pre-commit run --all-files` is the gate-1/gate-5 entrypoint used by the
+# reusable workflow (.github/workflows/reusable-quality.yml). Every rev is
+# PINNED; bump versions here together with docs/lean-gate/README.md, .quality/
+# charter.yml, and reusable-quality.yml so the charter-check stays green. The
+# pins mirror the PROVEN lean gate in Prekzursil/Reframe. Pre-commit's own
+# `language` runners handle each tool's toolchain install.
+minimum_pre_commit_version: "3.5.0"
+
+default_language_version:
+  python: python3
+
+exclude: |-
+  (?x)^(
+    node_modules/|
+    \.venv/|
+    venv/|
+    dist/|
+    build/|
+    out/|
+    vendor/|
+    target/|
+    generated/|
+    .*\.egg-info/
+  )
+
+repos:
+  # ── Gate 1: Python lint + format + import-sort (Ruff) ──────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      - id: ruff
+        name: ruff (lint --fix, incl. import-sort I rules)
+        args: ["--fix"]
+      - id: ruff-format
+        name: ruff (format)
+
+  # ── Gate 1: JS/TS lint + format (Oxlint + Oxfmt) ───────────────────────────
+  # Uncomment in a JS/TS caller. Oxc bundles the linter and formatter (oxfmt).
+  # - repo: https://github.com/oxc-project/mirrors-oxlint
+  #   rev: v1.69.0
+  #   hooks:
+  #     - id: oxlint
+  #       name: oxlint (--fix, --deny-warnings)
+  #       args: ["--fix", "--deny-warnings"]
+  #       files: '\.(ts|tsx|js|jsx|mjs|cjs)$'
+  # - repo: local
+  #   hooks:
+  #     - id: oxfmt
+  #       name: oxfmt (format)
+  #       language: node
+  #       additional_dependencies: ["oxfmt@0.1.0"]
+  #       entry: oxfmt
+  #       files: '\.(ts|tsx|js|jsx|mjs|cjs)$'
+
+  # ── Gate 1: Rust lint + format (clippy + rustfmt) ─────────────────────────
+  # Uncomment in a Rust caller (requires the rust toolchain on the runner).
+  # - repo: local
+  #   hooks:
+  #     - id: cargo-clippy
+  #       name: clippy (-D warnings)
+  #       language: system
+  #       entry: cargo clippy --all-targets --all-features -- -D warnings
+  #       pass_filenames: false
+  #       files: '\.rs$'
+  #     - id: cargo-fmt
+  #       name: rustfmt
+  #       language: system
+  #       entry: cargo fmt --all
+  #       pass_filenames: false
+  #       files: '\.rs$'
+
+  # ── Gate 1: Go lint + format (golangci-lint v2) ───────────────────────────
+  # - repo: https://github.com/golangci/golangci-lint
+  #   rev: v2.6.0
+  #   hooks:
+  #     - id: golangci-lint-full
+
+  # ── Gate 1: Java lint + format (Spotless + Error Prone) ───────────────────
+  # Error Prone runs in the Java build (Gradle/Maven); Spotless applies format.
+  # - repo: local
+  #   hooks:
+  #     - id: spotless-apply
+  #       name: spotless (format)
+  #       language: system
+  #       entry: ./gradlew spotlessApply
+  #       pass_filenames: false
+  #       files: '\.java$'
+
+  # ── Gate 1: C# lint + format (Roslyn analyzers + dotnet-format) ───────────
+  # - repo: local
+  #   hooks:
+  #     - id: dotnet-format
+  #       name: dotnet format
+  #       language: system
+  #       entry: dotnet format --verify-no-changes
+  #       pass_filenames: false
+  #       files: '\.cs$'
+
+  # ── Gate 1: C/C++ lint + format (clang-tidy + clang-format) ───────────────
+  # - repo: https://github.com/pre-commit/mirrors-clang-format
+  #   rev: v20.1.0
+  #   hooks:
+  #     - id: clang-format
+  #       files: '\.(c|cc|cpp|cxx|h|hpp)$'
+
+  # ── Gate 5: secrets (gitleaks) ────────────────────────────────────────────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secrets)
+        args: ["--config", ".gitleaks.toml"]

--- a/docs/lean-gate/pre-commit-config.template.yaml
+++ b/docs/lean-gate/pre-commit-config.template.yaml
@@ -53,7 +53,7 @@ repos:
   #     - id: oxfmt
   #       name: oxfmt (format)
   #       language: node
-  #       additional_dependencies: ["oxfmt@0.1.0"]
+  #       additional_dependencies: ["oxfmt@0.55.0"]
   #       entry: oxfmt
   #       files: '\.(ts|tsx|js|jsx|mjs|cjs)$'
 


### PR DESCRIPTION
## Summary

ADDITIVE lean 6-gate **thin template** for the personal-account quality control plane (charter decided 2026-06-16; supersedes the 10-SaaS QZP model). This is the multi-language generalization of the **proven** lean gate already running in [`Prekzursil/Reframe`](https://github.com/Prekzursil/Reframe) (`.github/workflows/quality.yml`) — same tool pins, same single-job binary green/red model.

### What's added (5 files, +560 lines)

- **`.github/workflows/reusable-quality.yml`** — ONE `workflow_call` reusable workflow, single job named `quality`. Auto-detects the languages present in the **caller** and runs only the relevant lean lanes:
  1. lint/format/imports/sec-lint (autofix, via pre-commit)
  2. types — `tsc --noEmit` + basedpyright
  3. tests+coverage — **strict 100% line+branch**
  4. SAST — opengrep (pinned in-repo ruleset)
  5. secrets — gitleaks
  6. deps — osv-scanner
  Every action is SHA/version-pinned. Adopt with a ~5-line caller.
- **`docs/lean-gate/pre-commit-config.template.yaml`** — the gate-1/gate-5 autofix lane template (ruff / oxlint+oxfmt / clippy+rustfmt / golangci-lint v2 / spotless / clang-format + gitleaks), pinned.
- **`.quality/charter.yml`** + **`.quality/charter_check.sh`** — YAML-declared closed 6-gate set + a **pure-bash** drift guard that FAILS CI if the active gate set != the charter (a missing charter gate, a banned/deleted gate such as sonar/codacy/.../renovate, or CodeQL wired as a gate). Bash (not Python) to sidestep the py2-compat commit contract.
- **`docs/lean-gate/README.md`** — charter + adoption docs.

### Scope (deferred to the runbook)

- **ADDITIVE only.** The existing fleet reusable workflows are **untouched** — the 13 enrolled repos still call them. The ~80% deletion of the old SaaS machinery is deferred to the migration runbook until the fleet migrates off it.
- **No** required-status-check / branch-protection / ruleset is flipped on any repo (also deferred; required ⊆ enabled, or the branch goes permanently red).

### Archive-first

Cut before any change:
- branch `archive/qzp-full-saas-control-plane` @ `9844de0`
- tag `archive/qzp-full-saas-control-plane` @ `9844de0`

## Test plan

- [x] `scripts/verify` passes locally (Python coverage 100% + 72 node tests + control-plane validation + 15 repo profiles). No `--no-verify`.
- [x] `charter_check.sh` PASSES against the new workflow (all 6 gates wired).
- [x] `charter_check.sh` FAILS when a banned gate (e.g. `gate-sonar`) is injected (drift detection verified).
- [ ] (operator) reusable workflow exercised by a real caller adopting `@main`.