### PR TITLE
chore(qzt-hygiene): fix CodeQL #215 implicit string-concat + document main red signal

### DIFF
--- a/tests/test_check_codacy_zero_retry.py
+++ b/tests/test_check_codacy_zero_retry.py
@@ -405,7 +405,7 @@ class CodacyZeroRetryTests(unittest.TestCase):
         threshold_findings = [
             "Codacy complex-files percentage is 15% (goal: <= 10%).",
             "Codacy coverage is missing — no coverage report was uploaded "
-            "(strict-zero floor: 100% line+branch).",
+            + "(strict-zero floor: 100% line+branch).",
         ]
         with (
             patch.object(


### PR DESCRIPTION
## Summary

QZT hygiene pass (additive-only; no machinery removed; no required-context / ruleset / branch-protection changes — those are deferred to the runbook).

### CodeQL #215 — fixed
`py/implicit-string-concatenation-in-list [warning]` at `tests/test_check_codacy_zero_retry.py:407`.

The two adjacent string literals in `threshold_findings` were an intentional long message split across two source lines, which CodeQL flags as a possible missing-comma bug. Made the concatenation explicit with `+` — preserves the exact string value, clears the alert. `scripts/verify` runs green (1501 tests OK, coverage 100%).

### `main` not-green — root cause (operator/runbook item, NOT fixed here)

Investigated `gh run list --branch main`. The reds on the current main HEAD (`9844de0`) are:

1. **`Quality Zero Gate` (`quality-zero-gate.yml`)** — `failure`. The failing step is **"Assert required quality contexts are green"** in `reusable-quality-zero-gate.yml` → `run_quality_zero_gate.py`. It asserts the SaaS-era required contexts (Sonar/Codacy/QLTY/DeepSource/Coverage-fleet) are green on the SHA. Those SaaS gates are being retired under the lean 6-gate model, so the assertion permanently fails. **This is an obsolete SaaS-gate red.**
2. **`Reusable Quality Zero Bypass` (`reusable-quality-zero-bypass.yml`)** — 2× `failure`, `push` event. This is a `workflow_call`-only reusable workflow; GitHub surfaced phantom push-event startup-failures (zero jobs) on the #251 push. Cosmetic commit-status noise only.

**Neither failing workflow is a required-status-check context.** Verified against active ruleset `14488866`: required contexts are the `shared-scanner-matrix / *` set (Coverage 100 Gate, Codacy/Sonar/QLTY/DeepSource/Semgrep/Sentry/DeepScan Zero, Codecov, CodeQL, SonarCloud) — `Quality Zero Gate` and the bypass workflow are NOT in that set. So these reds do not block the merge queue via the ruleset.

**Why not neutered in this PR:** the obvious fix (set `quality-zero-gate.yml` to `on: workflow_dispatch`) is **blocked by the repo's own contract tests** — `tests/test_workflow_contracts.py::test_parity_wrappers_list_push_pull_request_and_manual_triggers` and `::test_wrapper_triplets_support_merge_group` hard-require `push:` / `pull_request:` / `merge_group:` triggers on this workflow AND its `templates/repo/` twin. Neutering breaks `scripts/verify` (the pre-push contract) and would diverge from the published template. Retiring this gate requires updating the workflow + its parity template + the contract tests + the ruleset together — that is runbook scope (SaaS-machinery removal), not a single hygiene PR.

**→ OPERATOR/RUNBOOK ITEM:** retire `quality-zero-gate.yml` and the `reusable-quality-zero-bypass.yml` push-noise as part of the lean-template cutover (update parity template + workflow-contract tests + ruleset in one coordinated change).

## Test plan
- [x] `scripts/verify` green locally (1501 tests OK, coverage 100%)
- [x] `test_workflow_contracts` + `test_check_codacy_zero_retry` pass
- [ ] CodeQL re-scan confirms #215 cleared (cloud, post-merge)
