### PR TITLE
fix(lean-gate): biome format gate + detect SIGPIPE + setup-python cache + osv zero-dep + nested coverage

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -22,7 +22,7 @@
 #
 # ── The closed 6-gate charter this workflow enforces ────────────────────────
 #   1. Lint+format+imports+sec-lint (AUTOFIX, via pre-commit):
-#        Ruff[py] · Oxlint+Oxfmt[ts/js] · clippy+rustfmt[rust] ·
+#        Ruff[py] · Oxlint+Biome[ts/js] · clippy+rustfmt[rust] ·
 #        golangci-lint v2[go] · ErrorProne+Spotless[java] ·
 #        Roslyn+dotnet-format[c#] · clang-tidy+clang-format[c/c++]
 #   2. Types:        tsc --noEmit[ts] · basedpyright[py]
@@ -47,7 +47,7 @@
 # Gate 3 installs the CALLER's Python runtime deps (requirements*/pyproject/
 # setup.*) before pytest so tests importing a runtime dep don't ModuleNotFoundError,
 # and runs `npm ci` before any node coverage. Gate 1's ts/js lint/format runs the
-# workflow's OWN pinned oxlint+oxfmt SELF-CONTAINED, so a caller-local
+# workflow's OWN pinned oxlint+biome SELF-CONTAINED, so a caller-local
 # frontend-eslint pre-commit hook (exit 127) cannot abort the lean gate.
 
 on:
@@ -86,7 +86,17 @@ jobs:
         id: detect
         shell: bash
         run: |
-          set -euo pipefail
+          set -eu
+          # SIGPIPE-SAFE detection (round-3 FIX 2): the detection helpers pipe
+          # `git ls-files ... | head -1`; `head` closes the pipe after the first
+          # line, so `git` (the writer) is killed with SIGPIPE and exits 141. Under
+          # `set -o pipefail` that 141 becomes the pipeline's exit and aborts the
+          # whole step (observed: event-link). Detection must NEVER hard-fail — it
+          # only sets boolean outputs — so pipefail is DISABLED for this step. Each
+          # helper already tolerates an empty result (treated as "absent"), and the
+          # `2>/dev/null` keeps stderr quiet. We do NOT set pipefail here; a head-
+          # closed-early SIGPIPE can therefore never red the gate before any lane runs.
+          set +o pipefail
           has() { [ -n "$(git ls-files "$@" 2>/dev/null | head -1)" ] && echo true || echo false; }
           any() { [ -n "${1:-}" ] && echo true || echo false; }
           file_exists() { [ -f "$1" ] && echo true || echo false; }
@@ -96,6 +106,20 @@ jobs:
             requirements.txt requirements*.txt '**/requirements.txt' '**/requirements*.txt' \
             pyproject.toml '**/pyproject.toml' setup.py '**/setup.py' \
             setup.cfg '**/setup.cfg' Pipfile '**/Pipfile' 2>/dev/null | head -1)"
+          # ALL resolvable Python manifests, one per line — used verbatim as
+          # setup-python's `cache-dependency-path` (round-3 FIX 3). actions/setup-
+          # python's `cache: pip` default hash glob is ONLY `**/requirements.txt`
+          # OR `**/pyproject.toml`; a repo whose only manifest is non-standard
+          # (e.g. requirements-dev.txt / requirements/*.txt) matches NEITHER, so
+          # setup-python hard-fails "No file matched to [**/requirements.txt or
+          # **/pyproject.toml]" BEFORE any gate runs (observed: codeblocks). We
+          # therefore feed it the ACTUAL detected manifest paths so the cache key
+          # always has a real file to hash.
+          py_manifest_paths="$(git ls-files \
+            requirements.txt requirements*.txt '**/requirements.txt' '**/requirements*.txt' \
+            'requirements/*.txt' '**/requirements/*.txt' \
+            pyproject.toml '**/pyproject.toml' setup.py '**/setup.py' \
+            setup.cfg '**/setup.cfg' Pipfile '**/Pipfile' 2>/dev/null | sort -u)"
           # Any dependency manifest OR lockfile osv-scanner can actually scan. With
           # NONE of these, `osv-scanner scan source` exits 128 ("no package sources").
           osv_sources="$(git ls-files \
@@ -134,6 +158,14 @@ jobs:
             echo "pytests=$(any "$py_tests")"
             echo "jststests=$(any "$jsts_tests")"
           } >> "$GITHUB_OUTPUT"
+          # Multiline output (round-3 FIX 3): the newline-separated manifest paths
+          # for setup-python's cache-dependency-path. Heredoc delimiter form is
+          # required for multiline GITHUB_OUTPUT values.
+          {
+            echo "pymanifestpaths<<__QZT_EOF__"
+            printf '%s\n' "$py_manifest_paths"
+            echo "__QZT_EOF__"
+          } >> "$GITHUB_OUTPUT"
           echo "Detected:"; cat "$GITHUB_OUTPUT"
 
       # ── Toolchains (set up only what the caller needs) ────────────────────
@@ -142,12 +174,22 @@ jobs:
       # hard-fails setup-python ("No file matched ...") BEFORE any gate runs — the
       # observed fleet red on dep-less Python repos (codeblocks/devextreme/swfoc/
       # tanks). Cached path for manifest repos; plain path otherwise.
+      #
+      # round-3 FIX 3: even WITH a manifest, `cache: pip`'s DEFAULT hash glob is
+      # only `**/requirements.txt` OR `**/pyproject.toml`. A repo whose sole
+      # manifest is non-standard (requirements-dev.txt, requirements/*.txt) matches
+      # neither and setup-python still hard-fails "No file matched ..." (observed:
+      # codeblocks). We pass `cache-dependency-path` set to the ACTUAL detected
+      # manifest paths so the cache key always hashes a real file. (Belt-and-braces:
+      # the `if:` still requires pymanifest == 'true', so this only runs when at
+      # least one manifest exists; setup-python cannot hard-fail before the gates.)
       - name: Set up Python (cached)
         if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: pip
+          cache-dependency-path: ${{ steps.detect.outputs.pymanifestpaths }}
 
       - name: Set up Python (no cache)
         if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'false'
@@ -197,20 +239,31 @@ jobs:
             https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
           chmod +x /usr/local/bin/osv-scanner
 
-      # ── GATE 1 (ts/js) — SELF-CONTAINED lint + format (Oxlint + Oxfmt) ───────
-      # GAP 2 FIX — the lean charter's gate-1 for ts/js is Oxlint + Oxfmt (the Oxc
-      # toolchain), which are SELF-CONTAINED in THIS workflow (the Reframe pattern),
-      # NOT the caller's ad-hoc eslint. A caller .pre-commit-config.yaml that
-      # contains a repo-LOCAL `frontend-eslint`-style hook shelling out to a
-      # not-yet-installed tool ("sh: 1: eslint: not found", exit 127) used to
-      # short-circuit the whole gate-1 step (observed: momentstudio). We therefore
-      # run the workflow's OWN pinned oxlint + oxfmt over the caller's ts/js
-      # directly, independent of the caller's local hooks. They need nothing from
-      # the caller (npx fetches the pinned CLIs). Both honor the caller's
-      # .oxlintrc.json / .oxfmtrc.json if present and respect .gitignore; oxfmt
-      # skips node_modules by default. Pins: oxlint 1.69.0 (mirrors Reframe), oxfmt
-      # 0.55.0. Keep in sync with docs/lean-gate/pre-commit-config.template.yaml.
-      - name: gate-lint-format-jsts (self-contained oxlint + oxfmt)
+      # ── GATE 1 (ts/js) — SELF-CONTAINED lint + format (Oxlint + Biome) ───────
+      # GAP 2 FIX — the lean charter's gate-1 for ts/js runs SELF-CONTAINED in THIS
+      # workflow (the Reframe pattern), NOT the caller's ad-hoc eslint. A caller
+      # .pre-commit-config.yaml that contains a repo-LOCAL `frontend-eslint`-style
+      # hook shelling out to a not-yet-installed tool ("sh: 1: eslint: not found",
+      # exit 127) used to short-circuit the whole gate-1 step (observed:
+      # momentstudio). We therefore run the workflow's OWN pinned linter + formatter
+      # over the caller's ts/js directly, independent of the caller's local hooks.
+      # They need nothing from the caller (npx fetches the pinned CLIs).
+      #
+      # round-3 FIX 1 — FORMATTER SWAP (decided design): the format check is now
+      # BIOME (formatter-only; linting stays with Oxlint), mirroring the PROVEN
+      # Reframe lean gate (Prekzursil/Reframe .github/workflows/quality.yml +
+      # biome.json: biome 2.5.0, `formatter.enabled`, `linter.enabled:false`,
+      # `assist.enabled:false`). `biome ci --formatter-enabled --linter-enabled=false
+      # --assist-enabled=false` is check-only (no writes) and exits non-zero on any
+      # unformatted file. If the caller ships its OWN biome.json/biome.jsonc we honor
+      # it (biome auto-discovers it from cwd); otherwise we point biome at the
+      # template's bundled minimal config (docs/lean-gate/biome.template.json, the
+      # same style as Reframe's: 2-space, single quotes, trailingCommas all,
+      # semicolons always, lineWidth 100, lf) via --config-path so formatting is
+      # deterministic across callers. Oxlint linting is unchanged. Pins: oxlint
+      # 1.69.0 (mirrors Reframe), biome 2.5.0 (mirrors Reframe). Keep in sync with
+      # docs/lean-gate/pre-commit-config.template.yaml + docs/lean-gate/biome.template.json.
+      - name: gate-lint-format-jsts (self-contained oxlint + biome)
         if: steps.detect.outputs.jsts == 'true'
         shell: bash
         run: |
@@ -225,11 +278,32 @@ jobs:
             --ignore-pattern '**/vendor/**' \
             .
           echo "::endgroup::"
-          echo "::group::oxfmt@0.55.0 (--check)"
-          # `oxfmt --check` exits non-zero on any unformatted file (skips
-          # node_modules; honors .gitignore/.prettierignore).
-          npx --yes oxfmt@0.55.0 --check . || {
-            echo "FAIL gate-lint-format-jsts: oxfmt found unformatted ts/js (run 'oxfmt' / the oxfmt pre-commit hook to fix)." >&2
+          echo "::group::biome@2.5.0 (format --check, formatter-only)"
+          # Honor a caller-shipped biome config if present (biome auto-discovers
+          # biome.json/biome.jsonc from cwd); otherwise use the template's bundled
+          # minimal config so formatting is deterministic across callers.
+          biome_cfg_args=()
+          if [ ! -f biome.json ] && [ ! -f biome.jsonc ]; then
+            tmp_biome_dir="$(mktemp -d)"
+            # Bundled minimal config (single-line printf to avoid any YAML/heredoc
+            # indentation pitfalls). Mirrors Reframe's biome.json style.
+            # NB: NO "vcs.useIgnoreFile" here — biome errors ("couldn't find an
+            # ignore file") on a caller without a .gitignore; we exclude vendored
+            # trees explicitly via files.includes negations instead. The config dir
+            # is a mktemp dir OUTSIDE the scanned tree, so biome does not treat it
+            # as a "nested root configuration".
+            printf '%s' '{"$schema":"https://biomejs.dev/schemas/2.5.0/schema.json","files":{"includes":["**/*.ts","**/*.tsx","**/*.js","**/*.jsx","**/*.mjs","**/*.cjs","!**/node_modules/**","!**/dist/**","!**/build/**","!**/out/**","!**/.venv/**","!**/vendor/**"]},"formatter":{"enabled":true,"indentStyle":"space","indentWidth":2,"lineWidth":100,"lineEnding":"lf"},"javascript":{"formatter":{"quoteStyle":"single","trailingCommas":"all","semicolons":"always"}},"linter":{"enabled":false},"assist":{"enabled":false}}' > "$tmp_biome_dir/biome.json"
+            biome_cfg_args=(--config-path "$tmp_biome_dir")
+            echo "No caller biome.json/biome.jsonc - using the lean template's bundled biome config."
+          else
+            echo "Honoring caller-shipped biome config."
+          fi
+          # `biome ci` is the non-mutating check command; restrict it to the
+          # formatter (linting is Oxlint's job, assist disabled).
+          npx --yes @biomejs/biome@2.5.0 ci \
+            --formatter-enabled=true --linter-enabled=false --assist-enabled=false \
+            "${biome_cfg_args[@]}" . || {
+            echo "FAIL gate-lint-format-jsts: biome found unformatted ts/js (run 'biome format --write' / the biome pre-commit hook to fix)." >&2
             exit 1
           }
           echo "::endgroup::"
@@ -372,33 +446,72 @@ jobs:
       # documented narrow case — ts/js source with ZERO test files = "no test
       # surface by design". A ts/js repo with code + tests but no coverage script
       # must NOT pass unmeasured.
+      #
+      # round-3 FIX 5 — NESTED-MONOREPO DISCOVERY: the coverage lane used to inspect
+      # ONLY the ROOT package.json, so a nested project (the package.json lives in a
+      # subdir, root has none — observed: webcoder, package.json in frontend/
+      # webcoder_ui) hard-FAILED "no coverage script" even though the nested project
+      # has one. Mirror the tsc lane (round-1 FIX): if there is a root package.json
+      # use it; otherwise DISCOVER every nested package.json (excluding vendored
+      # trees) and run coverage in each project dir that has a coverage script /
+      # vitest|jest --coverage test script. The silent-pass hole stays closed: a
+      # nested project with test files but NO coverage runner FAILS; the only skip
+      # is the documented "no test surface by design" (zero ts/js test files).
       - name: gate-tests-coverage jsts
         if: steps.detect.outputs.jsts == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          has_pkg=false; [ -f package.json ] && has_pkg=true
-          has_cov_script=false
-          if [ "$has_pkg" = "true" ] && node -e "process.exit((require('./package.json').scripts||{})['test:coverage']?0:1)" 2>/dev/null; then
-            has_cov_script=true
+          # has_cov_lane: does <dir>/package.json define a runnable coverage lane?
+          # Echoes "script" (test:coverage) | "runner" (vitest/jest --coverage in
+          # `test`) | "" (none). Reads only that dir's package.json.
+          has_cov_lane() {
+            # NB: node's require() treats a bare path ('dir/package.json') as a
+            # MODULE lookup, not a relative file - it MUST be './'-prefixed. With
+            # d='.' this yields './././package.json' (valid); with a nested dir it
+            # yields './frontend/ui/package.json' (valid).
+            local d="./$1"
+            if node -e "process.exit((require('$d/package.json').scripts||{})['test:coverage']?0:1)" 2>/dev/null; then
+              echo "script"; return 0
+            fi
+            if node -e "const s=(require('$d/package.json').scripts||{}).test||'';process.exit(/(vitest|jest).*--coverage|--coverage.*(vitest|jest)/.test(s)?0:1)" 2>/dev/null; then
+              echo "runner"; return 0
+            fi
+            echo ""; return 0
+          }
+          run_cov_in_dir() { # $1 dir, $2 lane-kind
+            echo "::group::coverage in $1 ($2)"
+            ( cd "$1" && { npm ci || npm install; } \
+              && if [ "$2" = "script" ]; then npm run test:coverage; else npm test; fi )
+            echo "::endgroup::"
+          }
+          # Build the candidate project dir list: root if it has package.json,
+          # otherwise every nested package.json dir (excluding vendored trees).
+          declare -a proj_dirs=()
+          if [ -f package.json ]; then
+            proj_dirs=(.)
+          else
+            mapfile -t pkgs < <(git ls-files '**/package.json' \
+              | grep -Ev '(^|/)(node_modules|dist|out|build|\.venv|vendor)/' || true)
+            for p in "${pkgs[@]}"; do proj_dirs+=("$(dirname "$p")"); done
           fi
-          # Fallback: a coverage-capable runner (vitest/jest) wired into the `test`
-          # script with a --coverage flag also counts as a configured coverage lane.
-          has_cov_runner=false
-          if [ "$has_pkg" = "true" ] && node -e "const s=(require('./package.json').scripts||{}).test||'';process.exit(/(vitest|jest).*--coverage|--coverage.*(vitest|jest)/.test(s)?0:1)" 2>/dev/null; then
-            has_cov_runner=true
+          ran_any=false
+          if [ "${#proj_dirs[@]}" -gt 0 ]; then
+            for d in "${proj_dirs[@]}"; do
+              lane="$(has_cov_lane "$d")"
+              if [ -n "$lane" ]; then
+                run_cov_in_dir "$d" "$lane"
+                ran_any=true
+              fi
+            done
           fi
-          if [ "$has_cov_script" = "true" ]; then
-            npm ci || npm install
-            npm run test:coverage
-          elif [ "$has_cov_runner" = "true" ]; then
-            npm ci || npm install
-            npm test
+          if [ "$ran_any" = "true" ]; then
+            echo "PASS gate-tests-coverage jsts: ran coverage in ${#proj_dirs[@]} project dir(s)."
           elif [ "${{ steps.detect.outputs.jststests }}" != "true" ]; then
             echo "ts/js source present with NO test files and no coverage script - no test surface by design; coverage lane skipped."
             exit 0
           else
-            echo "FAIL gate-tests-coverage jsts: ts/js present (with test files) but no coverage script - the 100% gate cannot pass unmeasured. Add a 'test:coverage' npm script (or a vitest/jest '--coverage' test script)." >&2
+            echo "FAIL gate-tests-coverage jsts: ts/js present (with test files) but no coverage script in any project dir (root or nested) - the 100% gate cannot pass unmeasured. Add a 'test:coverage' npm script (or a vitest/jest '--coverage' test script) in the project package.json." >&2
             exit 1
           fi
 
@@ -419,9 +532,17 @@ jobs:
 
       # ── GATE 6 — deps (osv-scanner, 0 actionable CVEs) ───────────────────
       # osv-scanner exits 128 ("no package sources found") on a zero-dependency
-      # repo (observed fleet red: star-wars). Treat "no manifests/lockfiles to
-      # scan" as PASS — nothing to scan is not a failure — and only invoke the
-      # scanner when there is at least one scannable source.
+      # repo. Round-1 added an `osvsources` pre-check (skip when no manifest glob
+      # matched). Round-3 FIX 4: that pre-check alone was NOT enough — a repo can
+      # match a manifest glob yet still have NOTHING osv-scanner recognizes as a
+      # scannable package source (e.g. a `pom.xml`/`pyproject.toml` with no
+      # resolvable deps, or only files osv treats as non-lockfiles), so the scanner
+      # still exits 128 (observed fleet red: star-wars, a zero-dependency repo).
+      # The authoritative "nothing to scan" signal is osv-scanner's OWN exit 128.
+      # We therefore: (1) keep the cheap pre-check skip, AND (2) run the scanner
+      # without aborting the step on its exit, then map exit 128 ("no package
+      # sources found") to PASS. Any OTHER non-zero exit (e.g. 1 = vulnerabilities
+      # found) still fails the gate. "Nothing to scan" is not a failure.
       - name: gate-deps osv-scanner
         if: steps.detect.outputs.osv == 'true'
         shell: bash
@@ -431,7 +552,16 @@ jobs:
             echo "No dependency manifests or lockfiles present - nothing for osv-scanner to scan; deps gate passes."
             exit 0
           fi
-          osv-scanner scan source --config=osv-scanner.toml --recursive .
+          rc=0
+          osv-scanner scan source --config=osv-scanner.toml --recursive . || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "PASS gate-deps: osv-scanner found 0 actionable CVEs."
+          elif [ "$rc" -eq 128 ]; then
+            echo "osv-scanner exited 128 (no package sources found) - nothing to scan; deps gate passes."
+          else
+            echo "FAIL gate-deps: osv-scanner exited $rc (vulnerabilities found or scanner error)." >&2
+            exit "$rc"
+          fi
 
       # ── Charter ↔ active-gate consistency (fails if gate set != 6-charter) ─
       - name: charter-check

--- a/.quality/charter.yml
+++ b/.quality/charter.yml
@@ -23,7 +23,7 @@ gates:
     workflow_step: "gate-lint-format-secrets"
     tools:
       python: [ruff]
-      ts_js: [oxlint, oxfmt]
+      ts_js: [oxlint, biome]   # oxlint = lint; biome = formatter-only (mirrors Reframe; round-3 swapped from oxfmt)
       rust: [clippy, rustfmt]
       go: ["golangci-lint-v2"]
       java: [errorprone, spotless]
@@ -76,7 +76,10 @@ deleted_gates:
   - pylint
   - bandit         # standalone bandit
   - eslint         # eslint-classic
-  - biome
+  # NOTE: biome was removed from deleted_gates (2026-06-18, round-3). The lean
+  # charter's gate-1 ts/js FORMATTER is now Biome (formatter-only), mirroring the
+  # proven Reframe gate; Oxlint remains the ts/js linter. Biome is therefore an
+  # ENROLLED gate-1 tool, not a banned standalone gate.
   - trivy          # trivy-for-app-deps
   - renovate
 

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -21,6 +21,7 @@ green/red model.
 |------|------|
 | `../../.github/workflows/reusable-quality.yml` | ONE `workflow_call` reusable workflow, single job `quality`, auto-detects the caller's languages and runs only the relevant lean lanes. |
 | `pre-commit-config.template.yaml` | The gate-1/gate-5 autofix lane (copy to the caller as `.pre-commit-config.yaml`, keep the hooks for languages present). |
+| `biome.template.json` | The bundled minimal Biome formatter config (the same style as Reframe's `biome.json`). A JS/TS caller may copy it to `biome.json`; if absent, the reusable workflow falls back to this config in-process for the gate-1 format check. |
 | `../../.quality/charter.yml` | The single source of truth for the closed 6-gate set + the banned (deleted) gates. |
 | `../../.quality/charter_check.sh` | Pure-bash check that FAILS CI if the active gate set drifts from the charter. |
 
@@ -28,7 +29,7 @@ green/red model.
 
 Model: **Prevent (auto-fix) - Binary green/red - Ratchet-retired (100% everywhere)**.
 
-1. **Lint + format + imports + sec-lint** (AUTOFIX): Ruff [py] - Oxlint+Oxfmt [ts/js] - clippy+rustfmt [rust] - golangci-lint v2 [go] - ErrorProne+Spotless [java] - Roslyn+dotnet-format [c#] - clang-tidy+clang-format [c/c++].
+1. **Lint + format + imports + sec-lint** (AUTOFIX): Ruff [py] - Oxlint+Biome [ts/js] (Oxlint = linter, Biome = formatter-only) - clippy+rustfmt [rust] - golangci-lint v2 [go] - ErrorProne+Spotless [java] - Roslyn+dotnet-format [c#] - clang-tidy+clang-format [c/c++].
 2. **Types**: `tsc --noEmit` [ts] - basedpyright [py].
 3. **Tests + coverage**: STRICT **100% line+branch** (standing user policy; ratchet retired). Reasoned, greppable pragma only. **No silent-pass** — a language with source *and* test files but no coverage config/script **FAILS** (the 100% gate cannot pass unmeasured); the only skip is the narrow *no-test-surface-by-design* case (source present with **zero** test files).
 4. **SAST**: Opengrep (Semgrep CE acceptable), small pinned in-repo ruleset (`.quality/opengrep`).
@@ -37,8 +38,9 @@ Model: **Prevent (auto-fix) - Binary green/red - Ratchet-retired (100% everywher
 
 **Deleted as gates** (must NOT reappear): Sonar, Codacy, DeepSource, DeepScan,
 qlty, Codecov-as-gate, Snyk, Applitools, Chromatic, Percy, Sentry-as-gate,
-Pylint, standalone Bandit, ESLint-classic, Biome, Trivy-for-app-deps.
-**CodeQL** only nightly, on PUBLIC repos.
+Pylint, standalone Bandit, ESLint-classic, Trivy-for-app-deps.
+**CodeQL** only nightly, on PUBLIC repos. (Biome is **not** banned — it is the
+ts/js *formatter* in gate 1, mirroring Reframe; round-3 swapped it in for Oxfmt.)
 
 ## Adopting it (~5 lines in the caller repo)
 
@@ -77,12 +79,37 @@ hard-fail *before* a gate can run:
   Python manifest (`requirements*.txt` / `pyproject.toml` / `setup.py` /
   `setup.cfg` / `Pipfile`) exists. Without one, `setup-python` runs **without**
   the cache instead of erroring on "no file matched".
-- **Zero-dependency repos** — `osv-scanner` is invoked only when at least one
-  scannable manifest/lockfile exists; otherwise the deps gate **passes**
-  (nothing to scan) rather than exiting 128 ("no package sources found").
+- **Non-standard Python manifests (round-3 FIX 3)** — even *with* a manifest,
+  `actions/setup-python`'s `cache: pip` default hash glob is only
+  `**/requirements.txt` **or** `**/pyproject.toml`. A repo whose sole manifest is
+  non-standard (`requirements-dev.txt`, `requirements/*.txt`) matched **neither**,
+  so `setup-python` still hard-failed *"No file matched to [\*\*/requirements.txt
+  or \*\*/pyproject.toml]"* before any gate ran (observed: `codeblocks`). The
+  cached setup now passes `cache-dependency-path` set to the **actual detected
+  manifest paths** (incl. `requirements-dev.txt` / `requirements/*.txt`), so the
+  cache key always hashes a real file and `setup-python` never hard-fails.
+- **Zero-dependency repos (round-3 FIX 4)** — `osv-scanner` is invoked only when
+  at least one scannable manifest/lockfile is detected; **and** when it *is* run,
+  its own exit `128` ("no package sources found") is mapped to **PASS**. The
+  round-1 pre-check alone was insufficient: a repo can match a manifest glob yet
+  still have nothing osv recognizes as a scannable source, so the scanner exited
+  128 and red the gate (observed: `star-wars`, a zero-dependency repo). "Nothing
+  to scan" is not a failure; any **other** non-zero exit (e.g. vulnerabilities
+  found) still fails the gate.
 - **Monorepo / nested TypeScript** — `tsc` runs per `tsconfig.json`: the root
   config if present, otherwise every discovered nested config (e.g. a `ui/`
   subproject). A repo with nested-only configs is checked, not hard-failed.
+- **Monorepo / nested JS-TS coverage (round-3 FIX 5)** — the gate-3 JS/TS
+  coverage lane likewise DISCOVERS nested `package.json` projects (mirroring the
+  `tsc` lane): root `package.json` if present, otherwise every nested
+  `package.json` (excluding vendored trees), running coverage in the project dir
+  that owns the `test:coverage` / `vitest|jest --coverage` script. A nested-only
+  project (root has no `package.json`, the project lives in e.g.
+  `frontend/<app>/`) is now measured instead of hard-failing "no coverage script"
+  (observed: `webcoder`). The **silent-pass hole stays closed**: a project with
+  test files but no coverage runner still **FAILS**; the only skip is the
+  documented *no-test-surface-by-design* case (zero ts/js test files). 100% is
+  unchanged.
 - **Tests that import a runtime dependency** — gate 3 installs the caller's
   Python **runtime** deps before `pytest`/`coverage`, in priority order:
   `requirements.txt` / `requirements/*.txt` / `requirements*.txt`
@@ -99,19 +126,30 @@ hard-fail *before* a gate can run:
 - **Caller-local frontend pre-commit hook (`eslint: not found`)** — gate 1's
   ts/js lint+format is **self-contained in this workflow**: a dedicated
   `gate-lint-format-jsts` step runs the workflow's OWN pinned **oxlint 1.69.0**
-  + **oxfmt 0.55.0** over the caller's ts/js (the Reframe pattern), independent
-  of the caller's `.pre-commit-config.yaml`. A caller repo-local
-  `frontend-eslint`-style hook that shells out to a not-yet-installed tool
-  (`sh: 1: eslint: not found`, exit 127) can therefore no longer abort the lean
-  ts/js gate (observed: `momentstudio`). The `pre-commit run --all-files` step is
-  additionally hardened: when a JS/TS manifest is present it runs `npm ci` first
-  so legitimate caller-local hooks resolve their tool from `node_modules`, and
-  any still-unresolvable ad-hoc frontend hooks are `SKIP`-ed
-  (`SKIP=frontend-eslint,eslint,…,prettier,tsc`) — those are the caller's ad-hoc
-  lanes, not the lean charter's gate-1; ruff, gitleaks, and the rest of the
-  charter hooks still run and still gate. **Chosen approach: (b) self-contained
-  oxlint/oxfmt run directly + (a) `npm ci` before pre-commit** — both, so the
-  lean gate is correct whether or not the caller's local hooks resolve.
+  (linter) + **biome 2.5.0** (formatter-only) over the caller's ts/js (the
+  Reframe pattern), independent of the caller's `.pre-commit-config.yaml`. A
+  caller repo-local `frontend-eslint`-style hook that shells out to a
+  not-yet-installed tool (`sh: 1: eslint: not found`, exit 127) can therefore no
+  longer abort the lean ts/js gate (observed: `momentstudio`). The
+  `pre-commit run --all-files` step is additionally hardened: when a JS/TS
+  manifest is present it runs `npm ci` first so legitimate caller-local hooks
+  resolve their tool from `node_modules`, and any still-unresolvable ad-hoc
+  frontend hooks are `SKIP`-ed (`SKIP=frontend-eslint,eslint,…,prettier,tsc`) —
+  those are the caller's ad-hoc lanes, not the lean charter's gate-1; ruff,
+  gitleaks, and the rest of the charter hooks still run and still gate. **Chosen
+  approach: (b) self-contained oxlint/biome run directly + (a) `npm ci` before
+  pre-commit** — both, so the lean gate is correct whether or not the caller's
+  local hooks resolve.
+  - **Formatter = Biome (round-3 FIX 1).** The CI format check runs
+    `biome ci --formatter-enabled=true --linter-enabled=false --assist-enabled=false`
+    (check-only, no writes). It honors a caller-shipped `biome.json` / `biome.jsonc`
+    if present; otherwise it uses the bundled `docs/lean-gate/biome.template.json`
+    config (in-process via `--config-path`) so formatting is deterministic across
+    callers — 2-space indent, single quotes, `trailingCommas: all`,
+    `semicolons: always`, `lineWidth 100`, `lf`, mirroring Reframe's `biome.json`.
+    The local pre-commit hook (`biomejs/pre-commit@v2.5.0` `biome-format`) autofixes
+    on commit so local and CI agree. (Earlier rounds used Oxfmt 0.55.0; round-3
+    swapped to Biome to match the proven Reframe gate.)
 
 ## Charter drift guard
 

--- a/docs/lean-gate/biome.template.json
+++ b/docs/lean-gate/biome.template.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "files": {
+    "includes": [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.mjs",
+      "**/*.cjs",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/build/**",
+      "!**/out/**",
+      "!**/.venv/**",
+      "!**/vendor/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": { "quoteStyle": "single", "trailingCommas": "all", "semicolons": "always" }
+  },
+  "linter": { "enabled": false },
+  "assist": { "enabled": false }
+}

--- a/docs/lean-gate/pre-commit-config.template.yaml
+++ b/docs/lean-gate/pre-commit-config.template.yaml
@@ -39,8 +39,11 @@ repos:
       - id: ruff-format
         name: ruff (format)
 
-  # ── Gate 1: JS/TS lint + format (Oxlint + Oxfmt) ───────────────────────────
-  # Uncomment in a JS/TS caller. Oxc bundles the linter and formatter (oxfmt).
+  # ── Gate 1: JS/TS lint (Oxlint) + format (Biome, format-only) ──────────────
+  # Uncomment in a JS/TS caller. Oxlint = linter; Biome = formatter (the proven
+  # Reframe split; round-3 swapped the formatter from Oxfmt to Biome so local
+  # pre-commit matches the CI check, which runs `biome ci --formatter-enabled
+  # --linter-enabled=false`). The biome-format hook autofixes on commit.
   # - repo: https://github.com/oxc-project/mirrors-oxlint
   #   rev: v1.69.0
   #   hooks:
@@ -48,14 +51,13 @@ repos:
   #       name: oxlint (--fix, --deny-warnings)
   #       args: ["--fix", "--deny-warnings"]
   #       files: '\.(ts|tsx|js|jsx|mjs|cjs)$'
-  # - repo: local
+  # - repo: https://github.com/biomejs/pre-commit
+  #   rev: v2.5.0
   #   hooks:
-  #     - id: oxfmt
-  #       name: oxfmt (format)
-  #       language: node
-  #       additional_dependencies: ["oxfmt@0.55.0"]
-  #       entry: oxfmt
-  #       files: '\.(ts|tsx|js|jsx|mjs|cjs)$'
+  #     - id: biome-format
+  #       name: biome (format)
+  #       additional_dependencies: ["@biomejs/biome@2.5.0"]
+  #       files: '\.(ts|tsx|js|jsx|mjs|cjs|css|json)$'
 
   # ── Gate 1: Rust lint + format (clippy + rustfmt) ─────────────────────────
   # Uncomment in a Rust caller (requires the rust toolchain on the runner).


### PR DESCRIPTION
## Round-3 fixes to the lean `reusable-quality.yml`

Surgical/additive fixes to the proven lean 6-gate template (mirrors `Prekzursil/Reframe` `.github/workflows/quality.yml`). All prior round-1 + round-2 fixes are preserved; the silent-pass holes stay closed.

### FIX 1 — Formatter swap: Oxfmt -> Biome (decided design)
`gate-lint-format-jsts` now runs **Biome 2.5.0 (formatter-only)** for the format check instead of `oxfmt@0.55.0`, mirroring the proven Reframe gate (`biome.json`: `formatter.enabled`, `linter.enabled:false`, `assist.enabled:false`). **Oxlint 1.69.0 stays the ts/js linter.** Invocation: `npx @biomejs/biome@2.5.0 ci --formatter-enabled=true --linter-enabled=false --assist-enabled=false [--config-path <bundled>] .` (check-only, no writes). Honors a caller-shipped `biome.json`/`biome.jsonc`; otherwise uses a bundled minimal config (same style as Reframe: 2-space, single quotes, `trailingCommas:all`, `semicolons:always`, `lineWidth 100`, `lf`) written to a temp dir **outside** the scanned tree. Verified end-to-end with real `npx` biome: clean+well-formatted -> PASS; misformatted -> FAIL.
- `.quality/charter.yml`: gate-1 `ts_js: [oxlint, biome]`; biome removed from `deleted_gates` (now an enrolled gate-1 tool).
- `docs/lean-gate/pre-commit-config.template.yaml`: swapped the oxfmt local hook for `biomejs/pre-commit@v2.5.0` `biome-format` (autofix) so local pre-commit matches CI.
- `docs/lean-gate/biome.template.json`: new bundled formatter config.

### FIX 2 — Detect step SIGPIPE-safe
The detection helpers pipe `git ls-files ... | head -1`; `head` closing the pipe early kills `git` with SIGPIPE (exit 141), which under `set -o pipefail` aborted the whole step (observed: `event-link`). Detection now runs under `set -eu` with **`set +o pipefail`** locally, so a head-closed-early SIGPIPE can never red the gate before any lane runs.

### FIX 3 — setup-python cache for non-standard manifests
`actions/setup-python`'s `cache: pip` default hash glob is only `**/requirements.txt` OR `**/pyproject.toml`; a repo whose sole manifest is non-standard (`requirements-dev.txt`, `requirements/*.txt`) matched neither and hard-failed *"No file matched ..."* (observed: `codeblocks`). The cached setup-python now passes **`cache-dependency-path`** set to the actual detected manifest paths (multiline `GITHUB_OUTPUT` via heredoc delimiter), so the cache key always hashes a real file. The no-cache path is unchanged.

### FIX 4 — osv-scanner zero-dependency repos
Round-1's `osvsources` pre-check alone wasn't catching `star-wars` (a repo can match a manifest glob yet still have nothing osv recognizes). The gate now ALSO maps osv-scanner's own **exit 128 ("no package sources found") to PASS**, while any other non-zero exit (vulnerabilities) still fails. "Nothing to scan" is not a failure.

### FIX 5 — Nested-monorepo JS/TS coverage
The coverage lane inspected only the ROOT `package.json`, so a nested project (root has none; e.g. `webcoder` -> `frontend/webcoder_ui`) hard-failed "no coverage script". It now **discovers nested `package.json` projects** (mirroring the tsc lane) and runs coverage in the owning project dir. The silent-pass hole stays closed: tests present but no coverage runner -> FAIL; only the documented *no-test-surface-by-design* (zero ts/js test files) skips. 100% unchanged. (Fixed a node `require()` relative-path bug — a bare `dir/package.json` is a module lookup; it must be `./`-prefixed.)

### Prior fixes preserved
Round-1 (pip cache gating / osv base-skip / tsc nested / silent-pass holes) + round-2 (gate-3 installs caller Python runtime deps; gate-1 self-contained ts/js). Actions remain SHA/version-pinned.

### Verification
- `scripts/verify` — PASS (72 node tests, coverage 100%, 15 repo profiles validated).
- `.quality/charter_check.sh` — PASS (active gate set matches the lean 6-gate charter; biome no longer flagged as a banned gate).
- YAML + JSON parse OK; `bash -n` clean on all 16 run blocks.
- Functional tests of FIX 1 (real biome), FIX 2 (SIGPIPE), FIX 3 (multiline output), FIX 5 (5 nested-coverage cases incl. the FAIL-when-tests-but-no-runner hole) all pass.
