### PR TITLE
fix(lean-gate): oxlint --no-error-on-unmatched-pattern + ignore minified

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -269,13 +269,22 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::oxlint@1.69.0 (--deny-warnings)"
+          # --no-error-on-unmatched-pattern: when a caller has NO first-party
+          # lintable JS (everything ignored/vendored), oxlint otherwise exits 1
+          # with "No files found to lint" — a false FAIL. With the flag, an empty
+          # match set exits 0 (PASS). This does NOT weaken the gate: when lintable
+          # JS exists, --deny-warnings still runs and still fails on any warning.
+          # **/*.min.js (and node_modules above) are obvious build artifacts that
+          # must never be linted; real source is NOT broadly ignored.
           npx --yes oxlint@1.69.0 --deny-warnings \
+            --no-error-on-unmatched-pattern \
             --ignore-pattern '**/node_modules/**' \
             --ignore-pattern '**/dist/**' \
             --ignore-pattern '**/build/**' \
             --ignore-pattern '**/out/**' \
             --ignore-pattern '**/.venv/**' \
             --ignore-pattern '**/vendor/**' \
+            --ignore-pattern '**/*.min.js' \
             .
           echo "::endgroup::"
           echo "::group::biome@2.5.0 (format --check, formatter-only)"

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -140,6 +140,14 @@ hard-fail *before* a gate can run:
   approach: (b) self-contained oxlint/biome run directly + (a) `npm ci` before
   pre-commit** — both, so the lean gate is correct whether or not the caller's
   local hooks resolve.
+  - **No first-party lintable JS (round-4 FIX).** oxlint runs with
+    `--no-error-on-unmatched-pattern` so a caller whose JS is entirely
+    ignored/vendored (empty match set) PASSes (exit 0) instead of failing with
+    `No files found to lint` (exit 1). This does **not** weaken the gate: when
+    lintable JS exists, `--deny-warnings` still runs and still fails on any
+    warning. The oxlint ignore set also excludes `**/*.min.js` (alongside
+    `node_modules`/`dist`/`build`/`out`/`.venv`/`vendor`) so obvious minified
+    build artifacts are never linted — real source is **not** broadly ignored.
   - **Formatter = Biome (round-3 FIX 1).** The CI format check runs
     `biome ci --formatter-enabled=true --linter-enabled=false --assist-enabled=false`
     (check-only, no writes). It honors a caller-shipped `biome.json` / `biome.jsonc`


### PR DESCRIPTION
## Summary
Round-4 template fix for the QZT lean reusable-quality.yml gate.

In `gate-lint-format-jsts`, the pinned `oxlint@1.69.0` invocation now passes `--no-error-on-unmatched-pattern` so a caller with **no first-party lintable JS** (everything ignored/vendored) exits 0 (PASS) instead of exit 1 (`No files found to lint`).

This does **not** weaken the gate: when lintable JS exists, `oxlint --deny-warnings` still runs and still fails on any warning.

Also added `**/*.min.js` to the oxlint ignore set (alongside the existing `node_modules`/`dist`/`build`/`out`/`.venv`/`vendor` excludes) so obvious minified build artifacts are never linted. Real source is **not** broadly ignored.

## Changes
- `.github/workflows/reusable-quality.yml` — `--no-error-on-unmatched-pattern` + `--ignore-pattern '**/*.min.js'` on the oxlint call (with explanatory comment).
- `docs/lean-gate/README.md` — round-4 FIX note documenting the flag and the minified-artifact exclusion.

## Verification
`bash scripts/verify` passes (72 node tests + Python coverage 100% + 15 repo profiles validated).