### PR TITLE
fix(lean-gate): self-contained ruff+gitleaks lint gate (drop caller pre-commit dependency)

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -21,20 +21,32 @@
 #       uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@main
 #
 # ── The closed 6-gate charter this workflow enforces ────────────────────────
-#   1. Lint+format+imports+sec-lint (AUTOFIX, via pre-commit):
-#        Ruff[py] · Oxlint+Biome[ts/js] · clippy+rustfmt[rust] ·
-#        golangci-lint v2[go] · ErrorProne+Spotless[java] ·
-#        Roslyn+dotnet-format[c#] · clang-tidy+clang-format[c/c++]
+#   1. Lint+format (SELF-CONTAINED — the workflow's OWN pinned CLIs, NOT the
+#      caller's pre-commit): Ruff[py] · Oxlint+Biome[ts/js]
 #   2. Types:        tsc --noEmit[ts] · basedpyright (standard mode)[py]
 #   3. Tests+cov:    STRICT 100% line+branch (standing policy; ratchet retired)
 #   4. SAST:         Opengrep (Semgrep CE acceptable), pinned in-repo ruleset
-#   5. Secrets:      gitleaks (pinned + allowlist) + push-protection
+#   5. Secrets:      gitleaks (pinned + allowlist) — SELF-CONTAINED (always)
 #   6. Deps:         osv-scanner + Dependabot (no Renovate)
+#
+# round-6 FIX (self-contained gate 1+5): gate-1 lint/format and gate-5 secrets
+# NO LONGER run the caller's `.pre-commit-config.yaml` via `pre-commit run
+# --all-files`. That depended on each repo's BESPOKE hooks + environment (a root
+# npm lockfile for npm ci, the .NET SDK for dotnet-format, caller-local
+# eslint/tsc/prettier, ...), so it red-failed for CALLER-ENVIRONMENT reasons even
+# when the repo's REAL lean quality was fine. Instead the workflow now runs the
+# lean charter's OWN tools directly: ruff check + ruff format --check for Python
+# (honoring a caller [tool.ruff] / ruff.toml when present), and gitleaks for
+# secrets (honoring a caller .gitleaks.toml allowlist). oxlint + biome for ts/js
+# were ALREADY self-contained (gate-lint-format-jsts) and are unchanged. This is
+# NOT weakening: the SAME lean charter tools still gate (ruff issues + gitleaks
+# findings still FAIL) — they just no longer drag in the caller's pre-commit env.
 #
 # Auto-detection: the single `quality` job inspects the CALLER's checked-out
 # tree and runs ONLY the lanes whose language is present. A repo with no Python
-# skips the Python lanes, a repo with no JS/TS skips tsc, etc. Lane 1 (pre-commit)
-# and lanes 4/5/6 (opengrep/gitleaks/osv) run whenever their config is present.
+# skips the Python lanes, a repo with no JS/TS skips tsc, etc. The lint lanes run
+# whenever their language is present; gitleaks/opengrep/osv run when their config
+# is present (gitleaks runs whenever a .gitleaks.toml allowlist is shipped).
 #
 # No silent-pass: the coverage lane (gate 3) NEVER passes a language green
 # without measuring it. If a language has source AND test files but no coverage
@@ -46,9 +58,10 @@
 # tsc runs per-tsconfig so nested/monorepo projects are checked, not hard-failed.
 # Gate 3 installs the CALLER's Python runtime deps (requirements*/pyproject/
 # setup.*) before pytest so tests importing a runtime dep don't ModuleNotFoundError,
-# and runs `npm ci` before any node coverage. Gate 1's ts/js lint/format runs the
-# workflow's OWN pinned oxlint+biome SELF-CONTAINED, so a caller-local
-# frontend-eslint pre-commit hook (exit 127) cannot abort the lean gate.
+# and runs `npm ci` before any node coverage. Gate 1's lint/format runs the
+# workflow's OWN pinned CLIs SELF-CONTAINED (ruff[py], oxlint+biome[ts/js]), so a
+# caller-local frontend-eslint / dotnet-format / etc. pre-commit hook cannot abort
+# the lean gate — the caller's `.pre-commit-config.yaml` is no longer executed.
 #
 # round-5 FIX A (basedpyright standard): basedpyright's DEFAULT mode is stricter
 # than pyright (reportAny/reportUnknown*/reportUnusedCallResult), flooding untyped
@@ -58,13 +71,15 @@
 # basedpyrightconfig.json / pyproject [tool.(based)pyright]) when present, else
 # passes `--typecheckingmode standard`. Real type errors at standard still FAIL.
 #
-# round-5 FIX B (per-language toolchain setup): a gate that runs language X's
-# linter/formatter must install X's toolchain first or it hard-fails (codex-session:
-# dotnet-format -> "Restore operation failed", no .NET SDK). Conditional, detection-
-# gated setup is added BEFORE the gates: C#/.NET -> actions/setup-dotnet (SDK from
-# global.json when pinned); Java/Kotlin -> actions/setup-java (temurin); Rust ->
-# dtolnay/rust-toolchain (clippy+rustfmt). Go was already set up; python+node too.
-# Each runs ONLY when its language is detected; all new actions are SHA-pinned.
+# round-5 FIX B (per-language toolchain setup) — RETIRED in round-6: those setups
+# (setup-go / setup-dotnet / setup-java / rust-toolchain) existed ONLY so the
+# caller pre-commit's per-language autofixers (golangci-lint / dotnet-format /
+# spotless / clippy+rustfmt) had a toolchain. round-6 stopped running the caller
+# pre-commit, and NO remaining gate step invokes go/.NET/java/rust, so those four
+# toolchain setups were dropped as dead weight. Only Python and Node are set up —
+# they back gate-2 (basedpyright / tsc), gate-3 (coverage) and the self-contained
+# gate-1 lint/format (ruff / oxlint+biome). Each runs ONLY when its language is
+# detected; all actions are SHA-pinned.
 
 on:
   workflow_call:
@@ -166,12 +181,9 @@ jobs:
           # C#/.NET, Java/Kotlin, Rust and Go each need their toolchain set up
           # BEFORE the gate that runs their linter/formatter, else the lane hard-fails
           # (observed: codex-session — dotnet-format -> "Restore operation failed", no
-          # .NET SDK). The existing root-only `rust`/`go` detectors are broadened here
-          # to also catch sources/manifests anywhere in the tree.
-          csharp="$(has global.json '**/global.json' '*.csproj' '**/*.csproj' '*.sln' '**/*.sln' '*.cs' '**/*.cs')"
-          javakotlin="$(has pom.xml '**/pom.xml' 'build.gradle' '**/build.gradle' 'build.gradle.kts' '**/build.gradle.kts' '*.java' '**/*.java' '*.kt' '**/*.kt')"
-          # A global.json pins the .NET SDK version; feed it to setup-dotnet when present.
-          dotnet_globaljson="$(git ls-files global.json '**/global.json' 2>/dev/null | head -1)"
+          # .NET SDK). round-6 RETIRED those toolchains (the caller pre-commit that
+          # used them no longer runs), so the go/rust/csharp/javakotlin/dotnet detect
+          # outputs were dropped — no surviving gate step consumes them.
           # Test surface — if a language has source but ZERO test files, a missing
           # coverage config is "no test surface by design" (skip), not a hole (fail).
           py_tests="$(git ls-files 'test_*.py' '*_test.py' '**/test_*.py' '**/*_test.py' \
@@ -184,14 +196,7 @@ jobs:
             echo "python=$(has '*.py')"
             echo "ts=$(has '*.ts' '*.tsx')"
             echo "jsts=$(has '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')"
-            echo "rust=$(has Cargo.toml '**/Cargo.toml' '*.rs' '**/*.rs')"
-            echo "go=$(has go.mod '**/go.mod' '*.go' '**/*.go')"
-            echo "csharp=$csharp"
-            echo "javakotlin=$javakotlin"
-            echo "dotnetglobaljson=$(any "$dotnet_globaljson")"
             echo "pyrightcfg=$(any "$py_pyright_cfg")"
-            echo "frontend=$(has package.json '**/package.json')"
-            echo "precommit=$(file_exists .pre-commit-config.yaml)"
             echo "opengrep=$([ -d .quality/opengrep ] && echo true || echo false)"
             echo "gitleaks=$(file_exists .gitleaks.toml)"
             echo "osv=$(file_exists osv-scanner.toml)"
@@ -201,9 +206,6 @@ jobs:
             echo "pycovcfg=$(any "$py_cov_cfg")"
             echo "pytests=$(any "$py_tests")"
             echo "jststests=$(any "$jsts_tests")"
-            # round-5 FIX B: the global.json path (single value) for setup-dotnet's
-            # global-json-file input, so the SDK version is read from the caller's pin.
-            echo "dotnetglobaljsonpath=$dotnet_globaljson"
           } >> "$GITHUB_OUTPUT"
           # Multiline output (round-3 FIX 3): the newline-separated manifest paths
           # for setup-python's cache-dependency-path. Heredoc delimiter form is
@@ -231,7 +233,7 @@ jobs:
       # the `if:` still requires pymanifest == 'true', so this only runs when at
       # least one manifest exists; setup-python cannot hard-fail before the gates.)
       - name: Set up Python (cached)
-        if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'true'
+        if: steps.detect.outputs.python == 'true' && steps.detect.outputs.pymanifest == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
@@ -239,7 +241,7 @@ jobs:
           cache-dependency-path: ${{ steps.detect.outputs.pymanifestpaths }}
 
       - name: Set up Python (no cache)
-        if: (steps.detect.outputs.python == 'true' || steps.detect.outputs.precommit == 'true') && steps.detect.outputs.pymanifest == 'false'
+        if: steps.detect.outputs.python == 'true' && steps.detect.outputs.pymanifest == 'false'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
@@ -250,44 +252,19 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Set up Go
-        if: steps.detect.outputs.go == 'true'
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: stable
+      # round-6: setup-go / setup-dotnet / setup-java / rust-toolchain were REMOVED.
+      # They were added in round-5 FIX B solely so the caller pre-commit's
+      # per-language autofixers (golangci-lint / dotnet-format / spotless /
+      # clippy+rustfmt) had a toolchain. round-6 stopped running the caller
+      # pre-commit and no remaining gate step invokes go/.NET/java/rust, so those
+      # setups are dead weight. Python + Node (above) are the only toolchains the
+      # surviving gates need (basedpyright/tsc/coverage + the self-contained ruff
+      # and oxlint+biome lint/format lanes).
 
-      # round-5 FIX B — a gate that runs language X's linter/formatter MUST install
-      # X's toolchain first, else it hard-fails (observed: codex-session —
-      # dotnet-format -> "Restore operation failed", no .NET SDK). Each toolchain is
-      # set up ONLY when that language is detected, BEFORE gate-1 (pre-commit) runs
-      # its per-language autofixers. python + node are already set up above.
-      - name: Set up .NET (C#)
-        if: steps.detect.outputs.csharp == 'true'
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
-        with:
-          # Read the SDK version from the caller's global.json when it pins one;
-          # otherwise install the current LTS. (global-json-file is ignored by the
-          # action when the path is empty, so this is a no-op for callers w/o one.)
-          dotnet-version: ${{ steps.detect.outputs.dotnetglobaljson == 'true' && '' || '8.0.x' }}
-          global-json-file: ${{ steps.detect.outputs.dotnetglobaljson == 'true' && steps.detect.outputs.dotnetglobaljsonpath || '' }}
-
-      - name: Set up Java/Kotlin
-        if: steps.detect.outputs.javakotlin == 'true'
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Set up Rust
-        if: steps.detect.outputs.rust == 'true'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: clippy, rustfmt
-
-      # ── Pinned scanner CLIs (only when their config is present) ───────────
-      - name: Install pre-commit
-        if: steps.detect.outputs.precommit == 'true'
-        run: pip install pre-commit==4.6.0
+      # ── Pinned scanner CLIs (only when their language/config is present) ──────
+      - name: Install ruff
+        if: steps.detect.outputs.python == 'true'
+        run: pip install ruff==0.15.17
 
       - name: Install basedpyright
         if: steps.detect.outputs.python == 'true'
@@ -392,34 +369,38 @@ jobs:
           }
           echo "::endgroup::"
 
-      # ── GATE 1 + GATE 5 — lint/format/imports/sec-lint autofixers + secrets ─
-      # All lane-1 fixers (ruff / clippy+rustfmt / golangci-lint / spotless /
-      # clang-format / ...) AND the gitleaks secrets hook are wired in the caller's
-      # .pre-commit-config.yaml and verified clean here. The ts/js lint/format is
-      # NOT relied upon from pre-commit (it runs self-contained above) so a caller-
-      # local frontend hook cannot abort the lean gate.
-      #
-      # GAP 2 ROBUSTNESS — when the caller ships a JS/TS manifest, `npm ci` first
-      # so any caller-local pre-commit hooks (e.g. a `frontend-eslint` repo-local
-      # hook) can resolve their tool from node_modules instead of failing with
-      # exit 127. Best-effort: a failed install must not by itself red the gate, so
-      # any caller-local hook that STILL shells out to a tool it never installed is
-      # SKIP-ed (SKIP=frontend-eslint,eslint,prettier,tsc) — those are the caller's
-      # ad-hoc lanes, not the lean charter's self-contained gate-1. Ruff/gitleaks/
-      # the rest of the charter hooks still run and still gate.
-      - name: gate-lint-format-secrets (pre-commit run --all-files)
-        if: steps.detect.outputs.precommit == 'true'
+      # ── GATE 1 (py) — SELF-CONTAINED lint + format (Ruff) ───────────────────
+      # round-6 FIX — the lean charter's Python lint/format runs the workflow's OWN
+      # pinned ruff directly, NOT the caller's `.pre-commit-config.yaml`. The old
+      # `gate-lint-format-secrets` step ran `pre-commit run --all-files`, which
+      # dragged in each repo's BESPOKE pre-commit env (a root npm lockfile for the
+      # frontend-eslint hook's `npm ci`, the .NET SDK for dotnet-format, caller-
+      # local eslint/tsc/prettier, ...) and red-failed for caller-ENVIRONMENT
+      # reasons even when the repo's real lean quality was fine. We now run ruff
+      # ourselves: `ruff check` (lint) + `ruff format --check` (format), honoring a
+      # caller [tool.ruff] in pyproject.toml or a ruff.toml/.ruff.toml when present
+      # (ruff auto-discovers it from cwd); otherwise ruff's own defaults apply.
+      # This is NOT weakening — ruff is the SAME charter tool the pre-commit hook
+      # ran (pinned to Reframe's ruff 0.15.17); ruff lint issues or unformatted
+      # Python still FAIL. Pin: ruff 0.15.17 (mirrors Reframe). Keep in sync with
+      # docs/lean-gate/pre-commit-config.template.yaml.
+      - name: gate-lint-format-py (self-contained ruff)
+        if: steps.detect.outputs.python == 'true'
         shell: bash
-        env:
-          SKIP: frontend-eslint,eslint,eslint-local,prettier,tsc,frontend-tsc,frontend-prettier
         run: |
           set -euo pipefail
-          if [ "${{ steps.detect.outputs.frontend }}" = "true" ]; then
-            echo "::group::npm ci (resolve any caller-local frontend pre-commit hooks)"
-            ( npm ci || npm install ) || echo "WARN: frontend dep install failed; caller-local frontend hooks are SKIP-ed and the lean ts/js gate runs self-contained above."
-            echo "::endgroup::"
-          fi
-          pre-commit run --all-files --show-diff-on-failure
+          echo "::group::ruff check (lint)"
+          # --output-format=github surfaces findings as GH annotations. ruff honors
+          # a caller [tool.ruff]/ruff.toml automatically (cwd discovery); no caller
+          # pre-commit/eslint/SDK environment is touched.
+          ruff check --output-format=github .
+          echo "::endgroup::"
+          echo "::group::ruff format --check"
+          ruff format --check . || {
+            echo "FAIL gate-lint-format-py: ruff found unformatted Python (run 'ruff format' / the ruff pre-commit hook to fix)." >&2
+            exit 1
+          }
+          echo "::endgroup::"
 
       # ── GATE 2 — types ────────────────────────────────────────────────────
       # tsc per tsconfig.json so monorepo / nested-project shapes (e.g. an `ui/`
@@ -629,10 +610,13 @@ jobs:
             ${{ inputs.opengrep-paths }}
 
       # ── GATE 5 (verify) — secrets, gitleaks over working tree (0 findings) ─
-      # The autofixer-side secrets hook runs in pre-commit (gate 1+5); this is the
-      # standalone gitleaks verify when no pre-commit config is present.
-      - name: gate-secrets gitleaks
-        if: steps.detect.outputs.gitleaks == 'true' && steps.detect.outputs.precommit == 'false'
+      # round-6 FIX — gitleaks is now ALWAYS self-contained: it runs whenever the
+      # caller ships a .gitleaks.toml allowlist, regardless of any pre-commit config
+      # (the caller pre-commit is no longer executed). Honors the caller's
+      # .gitleaks.toml allowlist. Findings still FAIL the gate. Pin: gitleaks
+      # 8.30.1 (mirrors Reframe), installed above.
+      - name: gate-secrets gitleaks (self-contained)
+        if: steps.detect.outputs.gitleaks == 'true'
         run: gitleaks detect --no-banner --redact --config .gitleaks.toml
 
       # ── GATE 6 — deps (osv-scanner, 0 actionable CVEs) ───────────────────

--- a/.quality/charter.yml
+++ b/.quality/charter.yml
@@ -10,7 +10,7 @@
 
 charter_version: "2026-06-16"
 model:
-  prevent: true        # auto-fix at write time (gate 1 + pre-commit)
+  prevent: true        # auto-fix at write time (gate 1 + the caller's local pre-commit; CI gate 1 is self-contained ruff/oxlint/biome)
   binary: true         # every gate is pass/fail, no soft scores
   ratchet_retired: true # 100% coverage everywhere; no ratcheting baseline
 
@@ -20,15 +20,17 @@ gates:
   - id: 1
     name: lint-format-imports-seclint
     autofix: true
-    workflow_step: "gate-lint-format-secrets"
+    # round-6: gate 1 is now SELF-CONTAINED — the workflow runs its OWN pinned
+    # ruff (py) + oxlint+biome (ts/js) directly, NOT the caller's pre-commit.
+    # Steps: gate-lint-format-py (ruff) + gate-lint-format-jsts (oxlint+biome).
+    # The charter-check greps the `gate-lint-format` prefix, matching both.
+    workflow_step: "gate-lint-format"
     tools:
-      python: [ruff]
+      python: [ruff]           # ruff 0.15.17 (mirrors Reframe), self-contained
       ts_js: [oxlint, biome]   # oxlint = lint; biome = formatter-only (mirrors Reframe; round-3 swapped from oxfmt)
-      rust: [clippy, rustfmt]
-      go: ["golangci-lint-v2"]
-      java: [errorprone, spotless]
-      csharp: [roslyn, dotnet-format]
-      c_cpp: [clang-tidy, clang-format]
+    # round-6: rust/go/java/csharp/c_cpp lane-1 autofixers ran ONLY via the caller
+    # pre-commit, which is no longer executed; their toolchain setups were dropped.
+    # Re-add a self-contained step (like ruff/oxlint) before re-listing a language.
   - id: 2
     name: types
     workflow_step: "gate-types"
@@ -51,9 +53,9 @@ gates:
     note: "small pinned in-repo ruleset (.quality/opengrep)"
   - id: 5
     name: secrets
-    workflow_step: "gate-secrets"        # via pre-commit (gate-lint-format-secrets) or standalone
+    workflow_step: "gate-secrets"        # round-6: self-contained gitleaks (always; no longer via caller pre-commit)
     tools: [gitleaks]
-    note: "pinned + allowlist + push-protection"
+    note: "gitleaks 8.30.1 (mirrors Reframe) + caller .gitleaks.toml allowlist; self-contained"
   - id: 6
     name: deps
     workflow_step: "gate-deps"

--- a/docs/lean-gate/README.md
+++ b/docs/lean-gate/README.md
@@ -20,7 +20,7 @@ green/red model.
 | File | Role |
 |------|------|
 | `../../.github/workflows/reusable-quality.yml` | ONE `workflow_call` reusable workflow, single job `quality`, auto-detects the caller's languages and runs only the relevant lean lanes. |
-| `pre-commit-config.template.yaml` | The gate-1/gate-5 autofix lane (copy to the caller as `.pre-commit-config.yaml`, keep the hooks for languages present). |
+| `pre-commit-config.template.yaml` | LOCAL developer write-time auto-fix lane (copy to the caller as `.pre-commit-config.yaml`, keep the hooks for languages present). round-6: this is no longer the CI gate entrypoint — CI runs the SAME lean tools self-contained; keep this file for local `pre-commit install` auto-fix and keep its pins in sync with CI. |
 | `biome.template.json` | The bundled minimal Biome formatter config (the same style as Reframe's `biome.json`). A JS/TS caller may copy it to `biome.json`; if absent, the reusable workflow falls back to this config in-process for the gate-1 format check. |
 | `../../.quality/charter.yml` | The single source of truth for the closed 6-gate set + the banned (deleted) gates. |
 | `../../.quality/charter_check.sh` | Pure-bash check that FAILS CI if the active gate set drifts from the charter. |
@@ -29,11 +29,11 @@ green/red model.
 
 Model: **Prevent (auto-fix) - Binary green/red - Ratchet-retired (100% everywhere)**.
 
-1. **Lint + format + imports + sec-lint** (AUTOFIX): Ruff [py] - Oxlint+Biome [ts/js] (Oxlint = linter, Biome = formatter-only) - clippy+rustfmt [rust] - golangci-lint v2 [go] - ErrorProne+Spotless [java] - Roslyn+dotnet-format [c#] - clang-tidy+clang-format [c/c++].
+1. **Lint + format** (SELF-CONTAINED in CI — the workflow's OWN pinned CLIs, NOT the caller's pre-commit): Ruff [py] (`gate-lint-format-py`: `ruff check` + `ruff format --check`, honoring a caller `[tool.ruff]`/`ruff.toml`) - Oxlint+Biome [ts/js] (`gate-lint-format-jsts`; Oxlint = linter, Biome = formatter-only). The other-language autofixers (clippy+rustfmt [rust], golangci-lint v2 [go], ErrorProne+Spotless [java], Roslyn+dotnet-format [c#], clang-tidy+clang-format [c/c++]) run in the LOCAL pre-commit only; they are not yet self-contained in CI (round-6).
 2. **Types**: `tsc --noEmit` [ts] - basedpyright at the **standard** `typeCheckingMode` [py] (honors a caller basedpyright/pyright config when present; otherwise `--typecheckingmode standard`, mirroring Reframe).
 3. **Tests + coverage**: STRICT **100% line+branch** (standing user policy; ratchet retired). Reasoned, greppable pragma only. **No silent-pass** — a language with source *and* test files but no coverage config/script **FAILS** (the 100% gate cannot pass unmeasured); the only skip is the narrow *no-test-surface-by-design* case (source present with **zero** test files).
 4. **SAST**: Opengrep (Semgrep CE acceptable), small pinned in-repo ruleset (`.quality/opengrep`).
-5. **Secrets**: gitleaks (pinned + allowlist) + push-protection.
+5. **Secrets**: gitleaks (pinned + allowlist) + push-protection. round-6: SELF-CONTAINED — `gate-secrets` runs gitleaks directly whenever a `.gitleaks.toml` is present (no longer via the caller pre-commit).
 6. **Deps**: osv-scanner + Dependabot (**no** Renovate).
 
 **Deleted as gates** (must NOT reappear): Sonar, Codacy, DeepSource, DeepScan,
@@ -123,23 +123,28 @@ hard-fail *before* a gate can run:
   `npm ci` (or `npm install` if no lockfile) before any vitest/jest coverage so
   `node_modules` exists. The strict `--cov-fail-under=100` / 100% gate is
   unchanged.
-- **Caller-local frontend pre-commit hook (`eslint: not found`)** — gate 1's
-  ts/js lint+format is **self-contained in this workflow**: a dedicated
-  `gate-lint-format-jsts` step runs the workflow's OWN pinned **oxlint 1.69.0**
-  (linter) + **biome 2.5.0** (formatter-only) over the caller's ts/js (the
-  Reframe pattern), independent of the caller's `.pre-commit-config.yaml`. A
-  caller repo-local `frontend-eslint`-style hook that shells out to a
-  not-yet-installed tool (`sh: 1: eslint: not found`, exit 127) can therefore no
-  longer abort the lean ts/js gate (observed: `momentstudio`). The
-  `pre-commit run --all-files` step is additionally hardened: when a JS/TS
-  manifest is present it runs `npm ci` first so legitimate caller-local hooks
-  resolve their tool from `node_modules`, and any still-unresolvable ad-hoc
-  frontend hooks are `SKIP`-ed (`SKIP=frontend-eslint,eslint,…,prettier,tsc`) —
-  those are the caller's ad-hoc lanes, not the lean charter's gate-1; ruff,
-  gitleaks, and the rest of the charter hooks still run and still gate. **Chosen
-  approach: (b) self-contained oxlint/biome run directly + (a) `npm ci` before
-  pre-commit** — both, so the lean gate is correct whether or not the caller's
-  local hooks resolve.
+- **Caller pre-commit dependency removed (round-6 FIX).** Gate 1 (lint/format)
+  and gate 5 (secrets) NO LONGER run the caller's `.pre-commit-config.yaml` via
+  `pre-commit run --all-files`. That depended on each repo's BESPOKE pre-commit
+  hooks + environment (a root npm lockfile for a `frontend-eslint` hook's
+  `npm ci`, the .NET SDK for `dotnet-format`, caller-local eslint/tsc/prettier),
+  so it red-failed for caller-ENVIRONMENT reasons even when the repo's real lean
+  quality was fine. The workflow now runs the lean charter's OWN tools directly:
+  - `gate-lint-format-py` — `ruff check` + `ruff format --check` over the repo,
+    honoring a caller `[tool.ruff]` / `ruff.toml` when present (else ruff
+    defaults). Pinned **ruff 0.15.17** (mirrors Reframe).
+  - `gate-lint-format-jsts` — the workflow's OWN pinned **oxlint 1.69.0** (linter)
+    + **biome 2.5.0** (formatter-only) over the caller's ts/js (already
+    self-contained pre-round-6; unchanged).
+  - `gate-secrets` — **gitleaks 8.30.1** (mirrors Reframe) over the working tree
+    whenever a `.gitleaks.toml` allowlist is present.
+  This is **not** a weakening: the SAME lean charter tools still gate (ruff
+  issues + gitleaks findings still FAIL); they just no longer drag in the
+  caller's pre-commit env. The old `npm-ci-before-pre-commit` block and the
+  `SKIP=frontend-eslint,eslint,…,prettier,tsc` list were removed (no caller
+  pre-commit runs, so nothing to skip). A caller repo-local `frontend-eslint`
+  hook that shelled out to a not-yet-installed tool (`sh: 1: eslint: not found`,
+  exit 127; observed: `momentstudio`) can no longer affect the gate at all.
   - **No first-party lintable JS (round-4 FIX).** oxlint runs with
     `--no-error-on-unmatched-pattern` so a caller whose JS is entirely
     ignored/vendored (empty match set) PASSes (exit 0) instead of failing with
@@ -171,19 +176,18 @@ hard-fail *before* a gate can run:
   uses the proven standard bar instead of basedpyright's stricter default. This is
   **not** a weakening — standard is the proven bar and reportAny-everywhere is
   gold-plating; **real** type errors at standard level still **FAIL**.
-- **Per-language toolchain setup (round-5 FIX B).** A gate that runs language X's
-  linter/formatter must install X's toolchain first, or it hard-fails (observed:
-  `codex-session` — `dotnet-format` → *"Restore operation failed"*, no .NET SDK).
-  Using the detect step's language flags, the workflow now sets up — **only when
-  that language is detected**, and **before** gate-1 (pre-commit) runs its
-  per-language autofixers — the missing toolchains: **C#/.NET** (detected via
-  `global.json`/`*.csproj`/`*.sln`/`*.cs`) → `actions/setup-dotnet` (SDK version
-  read from `global.json` when the caller pins one, else 8.0.x); **Java/Kotlin**
-  (`pom.xml`/`build.gradle*`/`*.java`/`*.kt`) → `actions/setup-java` (temurin 21);
-  **Rust** (`Cargo.toml`/`*.rs`) → `dtolnay/rust-toolchain` (clippy+rustfmt). **Go**
-  (`go.mod`/`*.go`) was already set up via `actions/setup-go`; Python and Node too.
-  All new actions are SHA-pinned (`actions/setup-dotnet@…# v5.3.0`,
-  `actions/setup-java@…# v5.3.0`, `dtolnay/rust-toolchain@…# stable`).
+- **Per-language toolchain setup (round-5 FIX B) — RETIRED in round-6.** Round-5
+  added `actions/setup-dotnet` / `actions/setup-java` / `dtolnay/rust-toolchain` /
+  `actions/setup-go` so the caller pre-commit's per-language autofixers
+  (`dotnet-format` / spotless / clippy+rustfmt / golangci-lint) had a toolchain
+  (observed: `codex-session` — `dotnet-format` → *"Restore operation failed"*, no
+  .NET SDK). Round-6 stopped running the caller pre-commit, and **no remaining
+  gate step invokes go/.NET/java/rust** (gate-3 coverage is Python + Node only),
+  so those four toolchain setups were **dropped as dead weight**. Only **Python**
+  and **Node** are set up now — they back gate-2 (basedpyright / tsc), gate-3
+  (coverage), and the self-contained gate-1 lint/format (ruff / oxlint+biome). To
+  re-enable a dropped language in CI, add a self-contained gate-1 step for it
+  (like `gate-lint-format-py`) AND restore its toolchain setup.
 
 ## Charter drift guard
 

--- a/docs/lean-gate/pre-commit-config.template.yaml
+++ b/docs/lean-gate/pre-commit-config.template.yaml
@@ -3,12 +3,21 @@
 # TEMPLATE — copy to `.pre-commit-config.yaml` in the CALLER repo and keep only
 # the hooks for languages it actually has (uncomment the relevant blocks).
 #
-# `pre-commit run --all-files` is the gate-1/gate-5 entrypoint used by the
-# reusable workflow (.github/workflows/reusable-quality.yml). Every rev is
-# PINNED; bump versions here together with docs/lean-gate/README.md, .quality/
-# charter.yml, and reusable-quality.yml so the charter-check stays green. The
-# pins mirror the PROVEN lean gate in Prekzursil/Reframe. Pre-commit's own
-# `language` runners handle each tool's toolchain install.
+# round-6 CHANGE — this pre-commit config is now a LOCAL developer write-time
+# auto-fixer ONLY. It is NO LONGER the CI gate entrypoint: reusable-quality.yml
+# stopped running `pre-commit run --all-files` (it dragged in each repo's bespoke
+# pre-commit env — root npm lockfile, .NET SDK, caller-local eslint/tsc — and
+# red-failed for caller-environment reasons). CI now runs the SAME lean tools
+# SELF-CONTAINED: ruff (gate-lint-format-py) + oxlint+biome (gate-lint-format-jsts)
+# + gitleaks (gate-secrets). Keep this file so `pre-commit install` auto-fixes on
+# commit locally; the pins MUST still match CI. Every rev is PINNED; bump versions
+# here together with docs/lean-gate/README.md, .quality/charter.yml, and
+# reusable-quality.yml. The pins mirror the PROVEN lean gate in Prekzursil/Reframe
+# (ruff 0.15.17, oxlint 1.69.0, biome 2.5.0, gitleaks 8.30.1). Pre-commit's own
+# `language` runners handle each tool's toolchain install locally. NOTE: the CI
+# gate-1 currently covers Python + ts/js self-contained; rust/go/java/csharp/c_cpp
+# auto-fix here locally but are NOT yet self-contained in CI (their toolchain
+# setups were dropped in round-6 when the caller pre-commit stopped running).
 minimum_pre_commit_version: "3.5.0"
 
 default_language_version:


### PR DESCRIPTION
## Problem

The lean reusable workflow's `gate-lint-format-secrets` step ran the **caller's** `.pre-commit-config.yaml` via `pre-commit run --all-files`. That depended on each repo's BESPOKE pre-commit hooks + environment — a root npm lockfile for a `frontend-eslint` hook's `npm ci`, the .NET SDK for `dotnet-format`, caller-local eslint/tsc/prettier — so it red-failed for **caller-environment** reasons even when the repo's real lean quality was fine (basedpyright reports 0 errors; oxlint+biome pass self-contained in `gate-types`).

## Fix — make gate 1 + gate 5 SELF-CONTAINED

Stop running the caller pre-commit; run the lean charter's own pinned tools directly:

- **`gate-lint-format-py` (new)** — `ruff check` + `ruff format --check` over the repo, honoring a caller `[tool.ruff]` / `ruff.toml` when present (else ruff defaults). Pinned **ruff 0.15.17** (mirrors Reframe).
- **`gate-lint-format-jsts`** — oxlint 1.69.0 + biome 2.5.0, already self-contained; unchanged.
- **`gate-secrets gitleaks (self-contained)`** — runs **gitleaks 8.30.1** (mirrors Reframe) whenever a `.gitleaks.toml` allowlist is present, regardless of any pre-commit config.

Removed: the `npm-ci-before-pre-commit` block, the `SKIP=frontend-eslint,...` list, and the old `gate-lint-format-secrets` pre-commit step.

**Not weakening** — the SAME lean charter tools still gate (ruff issues + gitleaks findings still FAIL); they just no longer drag in the caller's bespoke pre-commit environment.

## Toolchains dropped

`setup-go` / `setup-dotnet` / `setup-java` / `dtolnay/rust-toolchain` (round-5 FIX B) existed ONLY so the caller pre-commit's per-language autofixers (golangci-lint / dotnet-format / spotless / clippy+rustfmt) had a toolchain. Since the caller pre-commit no longer runs and **no surviving gate step invokes go/.NET/java/rust** (gate-3 coverage is Python + Node only — verified), these four toolchain setups + their now-orphaned detect outputs (`go`/`rust`/`csharp`/`javakotlin`/`dotnetglobaljson(path)`/`precommit`/`frontend`) were dropped as dead weight. **Python + Node setups kept** (back gate-2 types, gate-3 coverage, and the self-contained gate-1 lint/format).

## Preserved

All prior fixes intact: silent-pass coverage holes (gate-3 python/jsts), per-tsconfig tsc, basedpyright standard-bar (round-5 FIX A), osv exit-128 to PASS, opengrep SAST. Charter-check updated (gate-1 `workflow_step` to `gate-lint-format` prefix, matches both py + jsts steps; gate-5 note) and **passes**.

## Docs

Updated `.quality/charter.yml`, `docs/lean-gate/README.md`, and `docs/lean-gate/pre-commit-config.template.yaml` (pre-commit is now a LOCAL write-time auto-fixer, no longer the CI entrypoint; pins still mirror CI).

## Verification

- `bash scripts/verify` — **PASS** (72 node tests, control-plane unittest suite, **100% line+branch coverage**, validators).
- `bash .quality/charter_check.sh` — **SUCCESS** (active gate set matches the lean 6-gate charter).
- YAML parse OK for both edited YAML files.
- No test asserts on `reusable-quality.yml` step names; the rust-toolchain assertion in `test_workflow_contracts.py` targets `reusable-scanner-matrix.yml` (untouched).
