### PR TITLE
fix(ci): migrate platform self required-contexts to the lean gate

### DIFF
--- a/generated/rulesets/quality-zero-platform.json
+++ b/generated/rulesets/quality-zero-platform.json
@@ -28,37 +28,10 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "shared-scanner-matrix / Coverage 100 Gate"
-          },
-          {
-            "context": "shared-codecov-analytics / Codecov Analytics"
+            "context": "Control Plane Verify"
           },
           {
             "context": "codeql / CodeQL"
-          },
-          {
-            "context": "shared-scanner-matrix / QLTY Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / Sonar Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / Codacy Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / Semgrep Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / Sentry Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / DeepScan Zero"
-          },
-          {
-            "context": "shared-scanner-matrix / DeepSource Visible Zero"
-          },
-          {
-            "context": "SonarCloud Code Analysis"
           }
         ],
         "strict_required_status_checks_policy": true

--- a/profiles/repos/quality-zero-platform.yml
+++ b/profiles/repos/quality-zero-platform.yml
@@ -33,33 +33,25 @@ scanners:
   qlty_check: { severity: block }
 overrides: []
 verify_command: bash scripts/verify
+# LEAN GATE MIGRATION (2026-06-27): the retired SaaS strict-zero contexts
+# (Sonar/SonarCloud, Codacy, DeepScan, DeepSource, QLTY, Sentry, Codecov-as-gate
+# and the legacy "Coverage 100 Gate" scanner-matrix lane) are NO LONGER required
+# branch-protection checks on the platform's own main. The platform self-governs
+# via "Control Plane Verify" (bash scripts/verify = unittest + STRICT 100%
+# line+branch coverage + control-plane self-validation) and CodeQL code-scanning.
+# Archive of the full SaaS control plane: branch+tag archive/qzp-full-saas-control-plane.
+# The shared reusable SaaS workflows are kept (still consumed by enrolled repos
+# per the lean-gate charter migration runbook) — only the SELF required contexts
+# are migrated here.
 required_contexts_mode: replace
 required_contexts:
   always:
-  - shared-scanner-matrix / Coverage 100 Gate
-  - shared-codecov-analytics / Codecov Analytics
+  - Control Plane Verify
   - codeql / CodeQL
-  - shared-scanner-matrix / QLTY Zero
-  - shared-scanner-matrix / Sonar Zero
-  - shared-scanner-matrix / Codacy Zero
-  - shared-scanner-matrix / Semgrep Zero
-  - shared-scanner-matrix / Sentry Zero
-  - shared-scanner-matrix / DeepScan Zero
-  - shared-scanner-matrix / DeepSource Visible Zero
-  pull_request_only:
-  - SonarCloud Code Analysis
+  pull_request_only: []
   target:
-  - shared-scanner-matrix / Coverage 100 Gate
-  - shared-codecov-analytics / Codecov Analytics
+  - Control Plane Verify
   - codeql / CodeQL
-  - shared-scanner-matrix / QLTY Zero
-  - shared-scanner-matrix / Sonar Zero
-  - shared-scanner-matrix / Codacy Zero
-  - shared-scanner-matrix / Semgrep Zero
-  - shared-scanner-matrix / Sentry Zero
-  - shared-scanner-matrix / DeepScan Zero
-  - shared-scanner-matrix / DeepSource Visible Zero
-  - SonarCloud Code Analysis
 enabled_scanners:
   deepsource_visible: true
 coverage:

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -165,10 +165,14 @@ class ControlPlaneTests(unittest.TestCase, ControlPlaneAssertions):
         self.assertNotIn("qlty coverage", pr_contexts)
         self.assertNotIn("qlty coverage diff", pr_contexts)
 
-    def test_quality_zero_platform_requires_qlty_zero_context_on_push_and_ruleset(
+    def test_quality_zero_platform_requires_lean_contexts_on_push_and_ruleset(
         self,
     ) -> None:
-        """QLTY Zero must remain required on push and rulesets."""
+        """Lean gate (Control Plane Verify + CodeQL) must be required on push/ruleset.
+
+        Lean-gate migration (2026-06-27): the retired SaaS strict-zero contexts
+        are no longer required branch-protection checks on the platform's own main.
+        """
         inventory = load_inventory(ROOT / "inventory" / "repos.yml")
         profile = load_repo_profile(inventory, "Prekzursil/quality-zero-platform")
 
@@ -190,14 +194,21 @@ class ControlPlaneTests(unittest.TestCase, ControlPlaneAssertions):
         )
 
         self._assert_quality_zero_platform_contexts(
-            "shared-codecov-analytics / Codecov Analytics",
-            "shared-scanner-matrix / QLTY Zero",
-            "shared-scanner-matrix / DeepSource Visible Zero",
+            "Control Plane Verify",
+            "codeql / CodeQL",
             push_contexts=push_contexts,
             ruleset_contexts=ruleset_contexts,
             target_contexts=profile["required_contexts"]["target"],
             ruleset_status_checks=ruleset_status_checks,
         )
+        for retired in (
+            "shared-scanner-matrix / QLTY Zero",
+            "shared-codecov-analytics / Codecov Analytics",
+            "shared-scanner-matrix / Sonar Zero",
+            "shared-scanner-matrix / DeepSource Visible Zero",
+            "SonarCloud Code Analysis",
+        ):
+            self.assertNotIn(retired, ruleset_status_checks)
         self.assertEqual(ruleset_contexts, merge_group_contexts)
         self.assertNotIn("qlty coverage diff", ruleset_contexts)
         self.assertEqual(
@@ -210,8 +221,8 @@ class ControlPlaneTests(unittest.TestCase, ControlPlaneAssertions):
             ]
         )
 
-    def test_quality_zero_platform_requires_qlty_zero(self) -> None:
-        """The control-plane target contexts should keep the governed QLTY lane."""
+    def test_quality_zero_platform_requires_lean_gate(self) -> None:
+        """The control-plane target contexts are the lean gate, not the SaaS lanes."""
         inventory = load_inventory(ROOT / "inventory" / "repos.yml")
         profile = load_repo_profile(inventory, "Prekzursil/quality-zero-platform")
 
@@ -219,25 +230,19 @@ class ControlPlaneTests(unittest.TestCase, ControlPlaneAssertions):
         pr_contexts = active_required_contexts(profile, event_name="pull_request")
         target_contexts = set(profile["required_contexts"]["target"])
 
-        self.assertIn("shared-codecov-analytics / Codecov Analytics", push_contexts)
-        self.assertIn("shared-codecov-analytics / Codecov Analytics", pr_contexts)
-        self.assertIn(
-            "shared-codecov-analytics / Codecov Analytics", target_contexts
-        )
-        self.assertIn("shared-scanner-matrix / QLTY Zero", push_contexts)
-        self.assertIn("shared-scanner-matrix / QLTY Zero", pr_contexts)
-        self.assertIn("shared-scanner-matrix / QLTY Zero", target_contexts)
-        self.assertIn(
-            "shared-scanner-matrix / DeepSource Visible Zero", push_contexts
-        )
-        self.assertIn(
-            "shared-scanner-matrix / DeepSource Visible Zero", pr_contexts
-        )
-        self.assertIn(
-            "shared-scanner-matrix / DeepSource Visible Zero", target_contexts
-        )
-        self.assertNotIn("Codacy Static Code Analysis", target_contexts)
-        self.assertNotIn("DeepScan", target_contexts)
+        for lean in ("Control Plane Verify", "codeql / CodeQL"):
+            self.assertIn(lean, push_contexts)
+            self.assertIn(lean, pr_contexts)
+            self.assertIn(lean, target_contexts)
+        for retired in (
+            "shared-codecov-analytics / Codecov Analytics",
+            "shared-scanner-matrix / QLTY Zero",
+            "shared-scanner-matrix / DeepSource Visible Zero",
+            "shared-scanner-matrix / Sonar Zero",
+            "Codacy Static Code Analysis",
+            "DeepScan",
+        ):
+            self.assertNotIn(retired, target_contexts)
 
     def test_airline_target_contexts_include_deepsource_contracts(self) -> None:
         """Airline should enforce the owned DeepSource contexts in target rulesets."""

--- a/tests/test_control_plane_extra.py
+++ b/tests/test_control_plane_extra.py
@@ -370,7 +370,11 @@ invalid codacy.dashboard_url
         contexts_payload = cast(List[str], outputs[2])
         self.assertEqual(profile_payload["slug"], "Prekzursil/quality-zero-platform")
         self.assertEqual(ruleset_payload["repo_slug"], "Prekzursil/quality-zero-platform")
-        self.assertIn("shared-scanner-matrix / Coverage 100 Gate", contexts_payload)
+        self.assertIn("Control Plane Verify", contexts_payload)
+        self.assertIn("codeql / CodeQL", contexts_payload)
+        self.assertNotIn(
+            "shared-scanner-matrix / Coverage 100 Gate", contexts_payload
+        )
 
     def test_script_entrypoint_inserts_repo_root_when_missing(self) -> None:
         """Check the script entrypoint restores the repository root on sys.path."""
@@ -399,4 +403,4 @@ invalid codacy.dashboard_url
             runpy.run_path(str(CONTROL_PLANE_PATH), run_name="__main__")
 
         self.assertEqual(result.exception.code, 0)
-        self.assertIn("shared-scanner-matrix / Coverage 100 Gate", json.loads(buffer.getvalue()))
+        self.assertIn("Control Plane Verify", json.loads(buffer.getvalue()))

--- a/tests/test_control_plane_profiles.py
+++ b/tests/test_control_plane_profiles.py
@@ -152,10 +152,13 @@ class ControlPlaneProfileTests(unittest.TestCase, ControlPlaneAssertions):
             },
         )
 
-    def test_quality_zero_platform_requires_codecov_in_push_pr_and_target(
+    def test_quality_zero_platform_requires_lean_gate_in_push_pr_and_target(
         self,
     ) -> None:
-        """Codecov should be part of the self-governed merge and push contract."""
+        """The lean gate (not Codecov-as-gate) is the self-governed merge/push contract.
+
+        Lean-gate migration (2026-06-27): Codecov is retired as a required gate.
+        """
         inventory = load_inventory(ROOT / "inventory" / "repos.yml")
         profile = load_repo_profile(inventory, "Prekzursil/quality-zero-platform")
 
@@ -163,9 +166,11 @@ class ControlPlaneProfileTests(unittest.TestCase, ControlPlaneAssertions):
         pr_contexts = active_required_contexts(profile, event_name="pull_request")
         target_contexts = profile["required_contexts"]["target"]
 
-        self.assertIn("shared-codecov-analytics / Codecov Analytics", push_contexts)
-        self.assertIn("shared-codecov-analytics / Codecov Analytics", pr_contexts)
-        self.assertIn(
+        for lean in ("Control Plane Verify", "codeql / CodeQL"):
+            self.assertIn(lean, push_contexts)
+            self.assertIn(lean, pr_contexts)
+            self.assertIn(lean, target_contexts)
+        self.assertNotIn(
             "shared-codecov-analytics / Codecov Analytics", target_contexts
         )
 

--- a/tests/test_render_codex_prompt.py
+++ b/tests/test_render_codex_prompt.py
@@ -228,7 +228,7 @@ class RenderCodexPromptTests(unittest.TestCase):
                 os.chdir(previous)
 
         self.assertEqual(result.exception.code, 0)
-        self.assertIn("Coverage 100 Gate", buffer.getvalue())
+        self.assertIn("Control Plane Verify", buffer.getvalue())
 
     def test_parse_args_accepts_canonical_json(self) -> None:
         """Cover --canonical-json argument is accepted."""

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -123,5 +123,7 @@ class RulesetPayloadTests(unittest.TestCase):
             "DeepScan",
             profile["required_contexts"]["target"],
         )
-        self.assertIn("shared-codecov-analytics / Codecov Analytics", contexts)
-        self.assertIn("shared-scanner-matrix / QLTY Zero", contexts)
+        self.assertNotIn("shared-codecov-analytics / Codecov Analytics", contexts)
+        self.assertNotIn("shared-scanner-matrix / QLTY Zero", contexts)
+        self.assertIn("Control Plane Verify", contexts)
+        self.assertIn("codeql / CodeQL", contexts)


### PR DESCRIPTION
## What

Migrates the **platform's own** required branch-protection contexts from the retired QZP/SaaS strict-zero matrix to the lean gate, making the source-of-truth profile match the live ruleset (so drift-sync won't revert it).

Retired as required self-checks: Sonar/SonarCloud, Codacy, DeepScan, DeepSource Visible, QLTY, Sentry, Codecov-as-gate, and the legacy scanner-matrix `Coverage 100 Gate`.

New lean required contexts (both already green on the platform):
- `Control Plane Verify` — `bash scripts/verify` = unittest + STRICT 100% line+branch coverage + control-plane self-validation
- `codeql / CodeQL` — code-scanning

## Scope

- `profiles/repos/quality-zero-platform.yml` — source of truth (`required_contexts`)
- `generated/rulesets/quality-zero-platform.json` — regenerated lean ruleset
- 5 platform-self test files migrated to the new contract

The shared reusable SaaS workflows are **kept untouched** (still consumed by enrolled repos per the lean-gate charter migration runbook). Only the SELF required contexts are migrated. Archive of the full SaaS control plane: branch+tag `archive/qzp-full-saas-control-plane`.

## Verification

- 1501 tests pass, 100% line+branch coverage (`scripts/verify` gate).