### PR TITLE
fix(ci): clear CodeQL #243 — remove literal ${{ }} token from opengrep gate comment

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -616,8 +616,11 @@ jobs:
           OPENGREP_PATHS: ${{ inputs.opengrep-paths }}
         run: |
           # OPENGREP_PATHS is an optional space-separated list of scan paths.
-          # Passed via env (not ${{ }} inline) to avoid GitHub Actions run-step
-          # expression injection, then split into a bash ARRAY so each path is a
+          # Passed via env (NOT an inline GHA expression in this run block) to
+          # avoid GitHub Actions run-step expression injection -- note that GHA
+          # expands expression tokens textually over the whole run string,
+          # comments included, so even a literal token here is a real sink.
+          # The value is then split into a bash ARRAY so each path is a
           # distinct argument WITHOUT an unquoted expansion (an unquoted $VAR of an
           # injectable input still trips CodeQL actions/code-injection). Empty
           # value => zero extra args (default = scan repo root via the config).


### PR DESCRIPTION
## Summary
Resolves the last open CodeQL code-scanning alert **#243** (`actions/code-injection/medium`) at `.github/workflows/reusable-quality.yml:619`.

## Root cause
GitHub Actions expands `${{ }}` expression tokens **textually over the entire `run:` string, comments included**. The explanatory comment in the `gate-sast opengrep` step contained a literal `${{ }}` token, which CodeQL's `actions/code-injection` query correctly flags as a run-step expression sink (alert columns 33–38 on line 619 land exactly on that token).

## Fix
Reword the comment to describe the env-indirection (`OPENGREP_PATHS` env var + `read -ra` array) **without embedding an expression token**. The actual injection-safe pattern (env var, not inline `${{ }}`, split into a bash array) is unchanged. No behavioral change to the gate.

## Verification
- Only the empty `${{ }}` token existed in a run block; all other `${{` are safe `with:`/`env:` mapping assignments.
- YAML validity confirmed.
- `test_workflow_contracts` + `test_reusable_quality_zero_bypass` pass locally (34 tests).
- Required merge checks: **Control Plane Verify** + **codeql / CodeQL**.