### PR TITLE
ci: fix Actions code-injection + triage untrusted-checkout in reusable-scanner-matrix (CodeQL #245-248)

### DIFF
--- a/.github/workflows/reusable-scanner-matrix.yml
+++ b/.github/workflows/reusable-scanner-matrix.yml
@@ -594,6 +594,13 @@ jobs:
         working-directory: repo
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+          # Pass the profile output through the environment instead of
+          # interpolating ${{ ... }} straight into the run script — the value
+          # is externally influenced (repo-configured coverage globs) so a
+          # direct `<<< "${{ ... }}"` splice is an Actions code-injection sink
+          # (CodeQL actions/code-injection/medium #248). Mirrors the safe
+          # pattern already used by the "Stage Codacy coverage files" step.
+          COVERAGE_INPUT_FILES: ${{ steps.profile.outputs.coverage_input_files }}
         run: |
           set -euo pipefail
           if [ -z "${DEEPSOURCE_DSN:-}" ]; then
@@ -602,7 +609,7 @@ jobs:
             exit 1
           fi
           curl -sSL https://deepsource.io/cli | sh
-          IFS=',' read -ra FILES <<< "${{ steps.profile.outputs.coverage_input_files }}"
+          IFS=',' read -ra FILES <<< "$COVERAGE_INPUT_FILES"
           for f in "${FILES[@]}"; do
             f=$(echo "$f" | xargs)
             [ -z "$f" ] && continue


### PR DESCRIPTION
## Summary

Resolves the **code-injection** CodeQL Actions alert (**#248**) in
`.github/workflows/reusable-scanner-matrix.yml` and triages the three
**untrusted-checkout** alerts (**#245 / #246 / #247**) in the same file.

**Do not merge without review.** Scanner-matrix / lane logic is **unchanged** —
this is a security-hardening + triage PR only.

## Fixed — #248 `actions/code-injection/medium` (line 605)

The **Publish DeepSource coverage** step spliced a repo-configurable value
straight into its shell script:

```yaml
IFS=',' read -ra FILES <<< "${{ steps.profile.outputs.coverage_input_files }}"   # before
```

`coverage_input_files` is derived from each repo's own quality profile
(externally influenced), so the direct `${{ }}` splice is an Actions
code-injection sink. Fix routes it through the environment and references a
quoted shell variable — the canonical CodeQL-accepted pattern, identical to
the sibling **Stage Codacy coverage files** step in this same file:

```yaml
env:
  COVERAGE_INPUT_FILES: ${{ steps.profile.outputs.coverage_input_files }}   # after
run: |
  ...
  IFS=',' read -ra FILES <<< "$COVERAGE_INPUT_FILES"
```

Values passed via `env:` are literal environment variables, not shell-evaluated,
so the injection sink is removed. No behaviour change (same comma-split loop,
same `deepsource report ... --value-file "$f"` invocations).

## Triaged (not code-changed) — #245 / #246 / #247 `actions/untrusted-checkout/medium`

| Alert | Line | Checkout | `ref` / `repository` |
|-------|------|----------|----------------------|
| #245 | 102 | repo under test (`path: repo`) | `ref: ${{ inputs.sha != '' && inputs.sha \|\| github.sha }}` |
| #246 | 107 | platform tooling (`path: platform`) | `repository: ${{ inputs.platform_repository }}`, `ref: ${{ inputs.platform_ref }}` |
| #247 | 642 | platform tooling (rollup job) | `repository: ${{ inputs.platform_repository }}`, `ref: ${{ inputs.platform_ref }}` |

**Why they fire.** CodeQL's `actions/untrusted-checkout` heuristic
(`SimplePRHeadCheckoutStep`) flags **any** `actions/checkout` that has a `ref:`
argument (not containing the substring `base`) when the workflow trigger is in
`{pull_request_target, workflow_run, workflow_call, issue_comment}` and the job
is privileged. Because this is a **reusable (`workflow_call`) workflow** whose
scanner jobs legitimately carry secrets (SONAR/CODACY/etc.) and `id-token: write`
(OIDC) / `pull-requests: write`, all three checkouts trip the net purely for
having a `ref:`. `persist-credentials: false` — already present on all three —
does **not** clear this query (verified: the alerts remain open at the current
`main` HEAD, which already has it; that flag addresses credential-persistence,
a different query).

**Actual reachability by untrusted PRs.** Low / mitigated. The only caller is
the fleet template `templates/repo/.github/workflows/quality-zero-platform.yml`,
which triggers on **plain `pull_request`** (plus `push` / `merge_group` /
`workflow_dispatch`) — **not** `pull_request_target` or `workflow_run`. On
fork-PR `pull_request` runs GitHub withholds secrets and issues a read-only
token, so the "privileged checkout of untrusted code" scenario the query warns
about does not materialise. All three checkouts also set
`persist-credentials: false`.

**Why not code-fixed here.** No minimal, behaviour-preserving change clears them:

- **#245 (repo checkout):** checking out the exact PR-head `sha` is the entire
  purpose of scanning the PR; its `ref:` line is contract-locked by
  `tests/test_workflow_contracts.py::test_scanner_matrix_checks_out_repo_at_requested_sha`.
- **#246 / #247 (platform checkout):** the `repository:` + `ref:` come from the
  `platform_repository` / `platform_ref` inputs (the fleet parameterisation
  contract). Hardcoding/removing them would break the reusable-workflow
  interface and change behaviour. Even a hardcoded `ref:` would still trip the
  heuristic (only `ref` values containing `base`, or a missing `ref`, are
  exempt).

The only way to silence them is suppression (a repo-wide
`codeql-config.yml` `query-filters` exclude of `actions/untrusted-checkout/medium`,
or **per-alert dismissal** as documented false positives). Both are
security-posture decisions for the maintainer, so this PR **does not** apply
them — **recommended disposition: dismiss #245/#246/#247 as false positives**
(reason: reusable workflow only invoked via plain-`pull_request` caller; no
secrets exposed to untrusted forks; `persist-credentials: false` set). The
higher-severity `.../high` and `.../critical` variants remain active to catch a
genuinely dangerous future pattern (e.g. a `pull_request_target` caller that
executes head code).

## Verification

- `python -m pytest tests/test_workflow_contracts.py` → **25 passed**.
- Workflow YAML parses (`yaml.safe_load`).
- Diff is 8 insertions / 1 deletion, confined to the DeepSource publish step.

## Explicit scope statement

**No matrix or scanner logic was changed.** The `strategy.matrix` (9 lanes),
lane dispatch, job permissions, secrets wiring, and every scanner invocation are
untouched. The only change is moving one profile output through `env:` in the
DeepSource publish step.

https://claude.ai/code/session_01AMvR2PHoEEGaxgaciH5nFh
