### PR TITLE
fix(dashboard): tolerate per-repo GitHub 404s in admin dashboard build

### DIFF
--- a/scripts/quality/build_admin_dashboard.py
+++ b/scripts/quality/build_admin_dashboard.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Sequence, Set
+from urllib.error import HTTPError
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -190,6 +191,28 @@ def _github_payload(url: str, token: str) -> Any:
     return payload
 
 
+def _github_payload_or_none(url: str, token: str) -> Any:
+    """Fetch ``url``; return ``None`` when GitHub reports the resource 404.
+
+    A newly-registered governed repo can be PRIVATE and/or lack the fetched
+    resource entirely (no Pages site, no rulesets, or a repo the workflow
+    token cannot read at all) — GitHub reports every one of those as HTTP
+    404. That is a per-repo "resource is absent" signal, not a build-stopping
+    error: the caller degrades that repo's row (health ``unknown``, redacted
+    slug) instead of aborting the whole dashboard publish, mirroring how
+    ``redact_private_repos`` already tolerates private repos. Any other
+    ``HTTPError`` (403 rate-limit, 5xx, ...) still propagates. The SSRF
+    hardening in ``scripts.security_helpers`` keeps raising unconditionally;
+    only this caller decides a 404 is tolerable.
+    """
+    try:
+        return _github_payload(url, token)
+    except HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
 def _select_runs(workflow_runs: Sequence[Mapping[str, Any]], *, filter_fn=None) -> List[Mapping[str, Any]]:
     """Handle select runs."""
     if filter_fn is None:
@@ -213,20 +236,29 @@ def _compute_health(workflow_runs: Sequence[Mapping[str, Any]], *, filter_fn=Non
 
 def _live_health(token: str, repo_slug: str, default_branch: str) -> Dict[str, Any]:
     """Handle live health."""
-    runs = _github_payload(
+    # Every per-repo fetch is 404-tolerant: a 404 means "this repo has no
+    # such resource visible to the token" (private repo, no runs, no
+    # rulesets) and must degrade that ONE row, never abort the whole
+    # dashboard build.
+    runs = _github_payload_or_none(
         (f"{GITHUB_API_BASE}/repos/{repo_slug}/actions/runs?branch={default_branch}&per_page=20"),
         token,
     )
-    rulesets = _github_payload(f"{GITHUB_API_BASE}/repos/{repo_slug}/rulesets", token)
+    rulesets = _github_payload_or_none(f"{GITHUB_API_BASE}/repos/{repo_slug}/rulesets", token)
     # Fetch repo metadata to capture visibility for the redaction step
     # in ``build_dashboard_payload``. Using the same token lets private
     # repos (where the bot has read access) report their true visibility;
-    # repos visible only as public report ``"public"``. Defaults to
-    # ``"public"`` on any failure so a missing/erroring metadata fetch
-    # cannot accidentally redact (or leak via mis-default).
-    repo_meta = _github_payload(f"{GITHUB_API_BASE}/repos/{repo_slug}", token)
+    # repos visible only as public report ``"public"``. A 404 here means
+    # the token cannot see the repo AT ALL — a public repo's metadata is
+    # visible to any token, so an unreadable governed repo is private (or
+    # gone). Worst-case default to ``"private"`` so ``redact_private_repos``
+    # masks the slug on the public dashboard instead of leaking it
+    # (Phase 5 §8). Reachable-but-unusable metadata keeps ``"public"``.
+    repo_meta = _github_payload_or_none(f"{GITHUB_API_BASE}/repos/{repo_slug}", token)
     visibility = "public"
-    if isinstance(repo_meta, dict):
+    if repo_meta is None:
+        visibility = "private"
+    elif isinstance(repo_meta, dict):
         raw_visibility = repo_meta.get("visibility")
         if isinstance(raw_visibility, str) and raw_visibility.strip():
             visibility = raw_visibility.strip().lower()

--- a/tests/test_build_admin_dashboard_extra.py
+++ b/tests/test_build_admin_dashboard_extra.py
@@ -8,8 +8,20 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any, List, Mapping
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 from scripts.quality import build_admin_dashboard
+
+
+def _http_error(code: int, reason: str) -> HTTPError:
+    """Build an ``HTTPError`` like ``security_helpers._read_json_response`` raises."""
+    return HTTPError(
+        "https://api.github.com/repos/Prekzursil/agent-skills-toolchain",
+        code,
+        reason,
+        hdrs=None,
+        fp=None,
+    )
 
 
 class BuildAdminDashboardExtraTests(unittest.TestCase):
@@ -95,6 +107,76 @@ class BuildAdminDashboardExtraTests(unittest.TestCase):
             live = build_admin_dashboard._live_health("token", "Prekzursil/example", "main")
         self.assertEqual(live["default_branch_health"], "success")
         self.assertEqual(live["open_pr_health"], "success")
+        self.assertTrue(live["ruleset_present"])
+        self.assertEqual(live["visibility"], "public")
+
+    def test_live_health_treats_404_resources_as_absent_and_redacts(self) -> None:
+        """A private governed repo with no visible resources must not abort the build.
+
+        Regression test for the Publish Admin Dashboard failure: a
+        newly-registered PRIVATE repo (agent-skills-toolchain — no Pages
+        site, unreadable by the workflow token) 404s on every per-repo
+        GitHub fetch. Each 404 must be treated as "resource absent" —
+        health ``unknown``, no ruleset — and the repo marked ``private``
+        so ``redact_private_repos`` masks the slug instead of leaking it.
+        """
+        with patch.object(
+            build_admin_dashboard,
+            "_github_payload",
+            side_effect=[
+                _http_error(404, "Not Found"),  # actions/runs
+                _http_error(404, "Not Found"),  # rulesets
+                _http_error(404, "Not Found"),  # repo metadata
+            ],
+        ) as payload_mock:
+            live = build_admin_dashboard._live_health("token", "Prekzursil/agent-skills-toolchain", "main")
+        self.assertEqual(payload_mock.call_count, 3)
+        self.assertEqual(live["default_branch_health"], "unknown")
+        self.assertEqual(live["open_pr_health"], "unknown")
+        self.assertFalse(live["ruleset_present"])
+        self.assertEqual(live["visibility"], "private")
+
+    def test_live_health_reraises_non_404_http_errors(self) -> None:
+        """Only 404 is tolerated; rate-limits/server errors still abort loudly."""
+        with (
+            patch.object(
+                build_admin_dashboard,
+                "_github_payload",
+                side_effect=_http_error(403, "rate limited"),
+            ),
+            self.assertRaises(HTTPError) as caught,
+        ):
+            build_admin_dashboard._live_health("token", "Prekzursil/example", "main")
+        self.assertEqual(caught.exception.code, 403)
+
+    def test_live_health_partial_404_keeps_reachable_data_and_public_default(self) -> None:
+        """A 404 on one resource degrades only that field; unusable metadata stays public."""
+        runs_payload = {"workflow_runs": [{"event": "push", "conclusion": "success"}]}
+        with patch.object(
+            build_admin_dashboard,
+            "_github_payload",
+            side_effect=[
+                runs_payload,  # actions/runs reachable
+                _http_error(404, "Not Found"),  # rulesets absent
+                ["unexpected"],  # metadata reachable but not a dict
+            ],
+        ):
+            live = build_admin_dashboard._live_health("token", "Prekzursil/tracelines", "main")
+        self.assertEqual(live["default_branch_health"], "success")
+        self.assertFalse(live["ruleset_present"])
+        self.assertEqual(live["visibility"], "public")
+
+        with patch.object(
+            build_admin_dashboard,
+            "_github_payload",
+            side_effect=[
+                _http_error(404, "Not Found"),  # actions/runs absent
+                [{"id": 1}],  # rulesets reachable
+                {"visibility": "   "},  # metadata dict with blank visibility
+            ],
+        ):
+            live = build_admin_dashboard._live_health("token", "Prekzursil/tracelines", "main")
+        self.assertEqual(live["default_branch_health"], "unknown")
         self.assertTrue(live["ruleset_present"])
         self.assertEqual(live["visibility"], "public")
 


### PR DESCRIPTION
## Problem

The **Publish Admin Dashboard** build aborts entirely when any governed repo 404s on a per-repo GitHub fetch. A newly-registered repo that is **private and/or has no Pages site** (concretely: `agent-skills-toolchain`) 404s on all three fetches in `_live_health` — `/actions/runs`, `/rulesets`, and `/repos/{slug}` metadata — killing the whole dashboard publish for every repo.

## Fix

New `_github_payload_or_none(url, token)`: wraps `_github_payload`, returns `None` **iff** `HTTPError.code == 404`, re-raises everything else (403 rate-limit / 5xx still abort loudly). `_live_health` routes all three per-repo fetches through it and degrades per-row:

| 404 on | Degrades to |
| --- | --- |
| `/actions/runs` | health `unknown` |
| `/rulesets` | `ruleset_present: False` |
| `/repos/{slug}` metadata | visibility `private` (worst-case default) |

The metadata default is deliberately `private`, not `public`: a 404 **with a token** means the token cannot see the repo at all (a public repo's metadata is visible to any token), so `redact_private_repos` masks the slug on the public Pages site instead of leaking it (Phase 5 §8). Reachable-but-unusable metadata (non-dict, blank visibility) keeps the existing `public` default.

`scripts/security_helpers.py` is untouched — SSRF hardening still raises unconditionally; 404 tolerance lives only in this caller.

## Tests

3 new tests in `tests/test_build_admin_dashboard_extra.py`:
- all-three-fetches-404 (the `agent-skills-toolchain` regression): `unknown`/`unknown`/`False`/`private`, no abort
- non-404 `HTTPError` (403) still propagates
- partial-404 + unusable-metadata branches

## Verification

- `bash scripts/verify` green end-to-end: full unittest suite, `coverage report --fail-under=100` (100.00%), node provider-ui tests 72/72, control-plane validation (18 repo profiles)
- End-to-end `main()` smoke with a fake inventory (one repo OK + one all-404): exit 0, site built, private slug redacted (`<private>` placeholder), no leak in `dashboard.json`/`index.html`