### PR TITLE
test: close 5 Note-level CodeQL alerts in test files

### DIFF
--- a/tests/test_check_sentry_zero.py
+++ b/tests/test_check_sentry_zero.py
@@ -11,14 +11,10 @@ import unittest
 from argparse import Namespace
 from email.message import Message
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 from urllib.error import HTTPError
 
 from scripts.quality import check_sentry_zero as sentry_module
-
-if TYPE_CHECKING:
-    from importlib.machinery import ModuleSpec
 
 
 class SentryZeroTests(unittest.TestCase):
@@ -34,7 +30,7 @@ class SentryZeroTests(unittest.TestCase):
         )
         if spec is None or spec.loader is None:  # pragma: no cover
             self.fail("Expected a concrete module spec for check_sentry_zero")
-        module = importlib.util.module_from_spec(cast("ModuleSpec", spec))
+        module = importlib.util.module_from_spec(spec)
         original_path = list(sys.path)
         sys.path = [entry for entry in sys.path if entry != repo_root]
         try:

--- a/tests/test_fleet_inventory.py
+++ b/tests/test_fleet_inventory.py
@@ -815,7 +815,7 @@ class CoverageClosureTests(unittest.TestCase):
         import io
         from contextlib import redirect_stdout
 
-        import scripts.quality.fleet_inventory as module_under_test
+        from scripts.quality import fleet_inventory as module_under_test
 
         original_fetch_user = module_under_test.fetch_user_repos
         original_fetch_auth = module_under_test.fetch_authenticated_repos
@@ -858,7 +858,7 @@ class CoverageClosureTests(unittest.TestCase):
         import io
         from contextlib import redirect_stdout
 
-        import scripts.quality.fleet_inventory as module_under_test
+        from scripts.quality import fleet_inventory as module_under_test
 
         original_fetch_user = module_under_test.fetch_user_repos
 
@@ -900,7 +900,7 @@ class MainCLITests(unittest.TestCase):
                 "version: 1\nrepos:\n  - slug: Prekzursil/alpha\n",
                 encoding="utf-8",
             )
-            import scripts.quality.fleet_inventory as module_under_test
+            from scripts.quality import fleet_inventory as module_under_test
 
             original_fetch_user = module_under_test.fetch_user_repos
             original_fetch_auth = module_under_test.fetch_authenticated_repos
@@ -933,7 +933,7 @@ class MainCLITests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             inventory = Path(raw) / "repos.yml"
             inventory.write_text("version: 1\nrepos: []\n", encoding="utf-8")
-            import scripts.quality.fleet_inventory as module_under_test
+            from scripts.quality import fleet_inventory as module_under_test
 
             original_fetch_user = module_under_test.fetch_user_repos
             original_fetch_auth = module_under_test.fetch_authenticated_repos


### PR DESCRIPTION
Closes 5 Note-level CodeQL alerts, all in test files; import-style-only changes.

## Changes

**tests/test_fleet_inventory.py** (alerts #201/#202/#249/#250, `py/import-and-import-from`)
- The module was imported both via top-level `from scripts.quality.fleet_inventory import (...)` and via `import scripts.quality.fleet_inventory as module_under_test` at 4 in-method sites. All four in-method sites now use `from scripts.quality import fleet_inventory as module_under_test` — the same module object (monkeypatching unchanged), consistently from-import style.

**tests/test_check_sentry_zero.py** (alert #244, `py/unused-import`)
- `ModuleSpec` was imported under `TYPE_CHECKING` and used only as a string in `cast("ModuleSpec", spec)`, which CodeQL cannot trace. Instead of a runtime import (repo ruff config enables TC003, which forbids that), the cast is dropped entirely: `self.fail` is `NoReturn`, so the existing `spec is None or spec.loader is None` guard already narrows `spec` to `ModuleSpec`. basedpyright: 0 errors; ruff: clean.

## Verification
- `bash scripts/verify` green locally: full unittest suite, `coverage report --fail-under=100` passes, node provider_ui tests 72/72, control-plane validation OK.
- `ruff check` clean on both files.