### PR TITLE
fix(gate-deps): distinguish an osv-scanner scan failure from a vulnerability finding

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -648,10 +648,39 @@ jobs:
       # resolvable deps, or only files osv treats as non-lockfiles), so the scanner
       # still exits 128 (observed fleet red: star-wars, a zero-dependency repo).
       # The authoritative "nothing to scan" signal is osv-scanner's OWN exit 128.
-      # We therefore: (1) keep the cheap pre-check skip, AND (2) run the scanner
-      # without aborting the step on its exit, then map exit 128 ("no package
-      # sources found") to PASS. Any OTHER non-zero exit (e.g. 1 = vulnerabilities
-      # found) still fails the gate. "Nothing to scan" is not a failure.
+      #
+      # Round-4: osv-scanner's exit codes are NOT a 0-vs-non-zero split. Verbatim
+      # from cmd/osv-scanner/internal/cmd/run.go at the pinned tag v2.3.8:
+      #     130 = HasErroredBecauseInvalidConfig()   (checked FIRST, takes priority)
+      #       1 = ErrVulnerabilitiesFound            <- the ONLY vulnerability code
+      #     128 = ErrNoPackagesFound                 <- nothing to scan
+      #     129 = ErrAPIFailed                       <- OSV.dev API unreachable
+      #     127 = HasErrored()                       <- generic "an error was logged"
+      #       0 = success, no vulnerabilities
+      # Round-3 mapped 128 -> PASS but funnelled EVERY other non-zero code into one
+      # "FAIL gate-deps ... (vulnerabilities found or scanner error)" branch, so a
+      # third-party outage was indistinguishable from a security regression.
+      # Observed fleet red: momentstudio run 30144541486 (both attempts) printed
+      # "FAIL gate-deps: osv-scanner exited 127" because the deps.dev gRPC resolver
+      # was down for its Python manifests ("rpc error: code = Unavailable desc =
+      # service unavailable"), while the scanner's own report in the same log said
+      # "Total 0 packages affected by 0 known vulnerabilities".
+      #
+      # Measured with the pinned 2.3.8 binary: a tree holding BOTH a vulnerable
+      # lockfile AND an unextractable one exits 1, not 127 — the switch returns on
+      # ErrVulnerabilitiesFound before the HasErrored() check at run.go:113 is ever
+      # reached. So exit 127 provably means "no vulnerability was detected in
+      # whatever WAS scanned"; it cannot mask a finding the scanner actually made.
+      # What it DOES leave unknown is the manifests that failed to resolve, so the
+      # scan-error class still BLOCKS: an incomplete scan is not evidence of a
+      # clean tree, and auto-passing it would fail open exactly where this gate
+      # exists to fail closed. It is reported with an unmistakably different
+      # message and its own exit code (75 = EX_TEMPFAIL, "temporary failure, retry
+      # later") so it is never read — or dashboarded — as a CVE. Short transient
+      # resolver blips are absorbed first by a bounded retry (3 attempts, 20s then
+      # 40s backoff); 130 is deterministic so it is not retried. For a prolonged
+      # upstream outage the escape hatch stays the audited quality-zero:break-glass
+      # label path, NOT a silent pass here.
       - name: gate-deps osv-scanner
         if: steps.detect.outputs.osv == 'true'
         shell: bash
@@ -663,15 +692,49 @@ jobs:
             echo "No dependency manifests or lockfiles present - nothing for osv-scanner to scan; deps gate passes."
             exit 0
           fi
+
+          # "The scan itself did not complete" — none of these is a vuln finding.
+          is_scan_error() { case "$1" in 127|129|130) return 0 ;; *) return 1 ;; esac; }
+          # Of those, the ones a transient upstream outage produces. 130 (invalid
+          # config) is deterministic, so retrying it only burns runner minutes.
+          is_retryable() { case "$1" in 127|129) return 0 ;; *) return 1 ;; esac; }
+
+          attempt=1
+          max_attempts=3
           rc=0
-          osv-scanner scan source --config=osv-scanner.toml --recursive . || rc=$?
+          while : ; do
+            rc=0
+            osv-scanner scan source --config=osv-scanner.toml --recursive . || rc=$?
+            if ! is_retryable "$rc" || [ "$attempt" -ge "$max_attempts" ]; then
+              break
+            fi
+            backoff=$(( attempt * 20 ))
+            echo "RETRY gate-deps: osv-scanner exited $rc without completing the scan (attempt ${attempt}/${max_attempts}) - this is NOT a vulnerability finding; retrying in ${backoff}s." >&2
+            sleep "$backoff"
+            attempt=$(( attempt + 1 ))
+          done
+
           if [ "$rc" -eq 0 ]; then
             echo "PASS gate-deps: osv-scanner found 0 actionable CVEs."
           elif [ "$rc" -eq 128 ]; then
             echo "osv-scanner exited 128 (no package sources found) - nothing to scan; deps gate passes."
+          elif [ "$rc" -eq 1 ]; then
+            echo "FAIL gate-deps: osv-scanner found actionable vulnerabilities (exit 1). This IS a security finding - fix or triage the CVEs listed above." >&2
+            exit 1
+          elif is_scan_error "$rc"; then
+            why='an unexpected scanner failure'
+            case "$rc" in
+              127) why='the scanner logged an error - commonly a deps.dev / registry resolver outage ("rpc error: code = Unavailable desc = service unavailable")' ;;
+              129) why='the OSV.dev API was unreachable (ErrAPIFailed)' ;;
+              130) why='the osv-scanner config file was rejected (invalid config)' ;;
+            esac
+            echo "ERROR gate-deps: osv-scanner could not complete the scan (exit $rc) - this is NOT a vulnerability finding." >&2
+            echo "ERROR gate-deps: exit $rc means $why." >&2
+            echo "ERROR gate-deps: attempts made ${attempt}/${max_attempts}. The dependency tree was NOT fully scanned, so this gate cannot certify it clean; it blocks rather than passing silently. Re-run the job once upstream recovers, or use the quality-zero:break-glass label for a prolonged outage." >&2
+            exit 75
           else
-            echo "FAIL gate-deps: osv-scanner exited $rc (vulnerabilities found or scanner error)." >&2
-            exit "$rc"
+            echo "ERROR gate-deps: osv-scanner exited $rc, which is not a documented exit code for the pinned 2.3.8 (0/1/127/128/129/130) - treating it as a scan failure, NOT a vulnerability finding." >&2
+            exit 75
           fi
 
       # ── Charter ↔ active-gate consistency (fails if gate set != 6-charter) ─


### PR DESCRIPTION
## The defect

`gate-deps` cannot distinguish a third-party outage from a real vulnerability, so an
infrastructure failure renders as a **security regression** in every consumer repo.

Re-verified today from the real CI log, not from a report. `Prekzursil/momentstudio` run
[30144541486](https://github.com/Prekzursil/momentstudio/actions/runs/30144541486), attempt 2
(attempt 1 identical):

```
2026-07-25T06:01:04.9350629Z failed resolution for .../backend/requirements.txt: rpc error: code = Unavailable desc = service unavailable
2026-07-25T06:01:04.9768854Z failed resolution for .../backend/requirements-ci.txt: rpc error: code = Unavailable desc = service unavailable
2026-07-25T06:01:04.9783028Z Error during extraction: (extracting as transitivedependency/requirements) failed resolution for .../backend/requirements.txt: rpc error: code = Unavailable desc = service unavailable
2026-07-25T06:01:06.3661372Z FAIL gate-deps: osv-scanner exited 127 (vulnerabilities found or scanner error).
```

deps.dev's gRPC resolver was down for the Python manifests. The operator was told the repo has
a failing **security** gate.

## Exit-code contract for the pinned version

Consumers install `v2.3.8` (`reusable-quality.yml:291`). Quoted verbatim from that tag's
[`cmd/osv-scanner/internal/cmd/run.go`](https://github.com/google/osv-scanner/blob/v2.3.8/cmd/osv-scanner/internal/cmd/run.go)
(fetched via `gh api repos/google/osv-scanner/contents/...?ref=v2.3.8`, line numbers from the
decoded blob):

```go
 91  // if the config is invalid, it's possible that is why any other errors
 92  // happened so that exit code takes priority
 93  if logHandler.HasErroredBecauseInvalidConfig() {
 94      return 130
 96  if err != nil {
 98      switch {
 99      case errors.Is(err, osvscanner.ErrVulnerabilitiesFound):
100          return 1
101      case errors.Is(err, osvscanner.ErrNoPackagesFound):
102          cmdlogger.Errorf("No package sources found, --help for usage information.")
103          return 128
104      case errors.Is(err, osvscanner.ErrAPIFailed):
106          return 129
111  // if we've been told to print an error, and not already exited with
112  // a specific error code, then exit with a generic non-zero code
113  if logHandler.HasErrored() {
114      return 127
117  return 0
```

| exit | meaning | class |
|---|---|---|
| 0 | success, no vulnerabilities | clean |
| **1** | `ErrVulnerabilitiesFound` — **the only vulnerability code** | finding |
| 127 | `HasErrored()` — generic "an error was logged" | scan failed |
| 128 | `ErrNoPackagesFound` | nothing to scan |
| 129 | `ErrAPIFailed` — OSV.dev API unreachable | scan failed |
| 130 | `HasErroredBecauseInvalidConfig()`, takes priority | scan failed |

Note 129 and 130 exist and were **not** handled at all before this change.

Independently reproduced with the pinned 2.3.8 binary rather than taken on faith:

| fixture | exit | scanner said |
|---|---|---|
| lockfile, no advisories | **0** | `No issues found` |
| `lodash 4.17.15` | **1** | `Total 1 package affected by 4 known vulnerabilities` |
| no manifests | **128** | `No package sources found` |
| unextractable lockfile only | **128** | extraction error, then no packages |
| bad config key | **127** | `Failed to read config file: unknown keys` |
| **good lockfile + unextractable lockfile** | **127** | `Total 0 packages affected by 0 known vulnerabilities` |

The last row is the momentstudio shape: **exit 127 while reporting zero vulnerabilities.**

## Before / after

Before (`reusable-quality.yml:666-675` on `main`) — one branch for everything non-zero:

```bash
rc=0
osv-scanner scan source --config=osv-scanner.toml --recursive . || rc=$?
if [ "$rc" -eq 0 ]; then
  echo "PASS gate-deps: osv-scanner found 0 actionable CVEs."
elif [ "$rc" -eq 128 ]; then
  echo "osv-scanner exited 128 (no package sources found) - nothing to scan; deps gate passes."
else
  echo "FAIL gate-deps: osv-scanner exited $rc (vulnerabilities found or scanner error)." >&2
  exit "$rc"
fi
```

After — the classes are separated, and the transient class is retried first:

```bash
is_scan_error() { case "$1" in 127|129|130) return 0 ;; *) return 1 ;; esac; }
is_retryable()  { case "$1" in 127|129)     return 0 ;; *) return 1 ;; esac; }
# ... bounded retry loop: 3 attempts, 20s then 40s backoff ...
if   [ "$rc" -eq 0 ];   then echo "PASS gate-deps: ..."
elif [ "$rc" -eq 128 ]; then echo "... nothing to scan; deps gate passes."
elif [ "$rc" -eq 1 ];   then echo "FAIL gate-deps: osv-scanner found actionable vulnerabilities (exit 1). This IS a security finding ..." >&2; exit 1
elif is_scan_error "$rc"; then echo "ERROR gate-deps: osv-scanner could not complete the scan (exit $rc) - this is NOT a vulnerability finding." >&2; ...; exit 75
else echo "ERROR gate-deps: osv-scanner exited $rc, which is not a documented exit code ... NOT a vulnerability finding." >&2; exit 75
fi
```

## The choice: the scan-error class still BLOCKS. Why.

**Decision: block, with a distinct label, a distinct exit code (75 = `EX_TEMPFAIL`), and a
bounded retry.** Not warn-and-pass.

The load-bearing measurement: a tree holding **both** a vulnerable lockfile **and** an
unextractable one exits **1, not 127** — the switch returns on `ErrVulnerabilitiesFound`
before the `HasErrored()` check at `run.go:113` is ever reached. So:

* exit 127 provably **cannot mask a finding the scanner actually made**. That is what makes
  relabelling it safe and honest.
* but it **does** leave the manifests that failed to resolve entirely unscanned. In
  momentstudio, `backend/requirements*.txt` were never examined. Passing there converts
  *unknown* into *clean* — fail-open in the one gate whose job is to fail closed. It would
  also mean an induced extraction error can suppress the gate.

The two harms in the report — a false security alarm and the alarm fatigue it breeds — are
caused by the **mislabelling**, not by the blocking. Fixing the label removes both without
fail-open. The third harm (fleet-wide merge block on something nobody can fix) is genuinely
mitigated only partially: the retry absorbs short blips, and `quality-zero:break-glass`
remains the audited escape hatch for a prolonged outage. **Honest limit:** the observed outage
did not clear within ~90 minutes, so this change would have *relabelled* — not unblocked —
that specific run.

If you would rather have the scan-error class be non-blocking, that is a one-line change to
the `is_scan_error` branch and I would rather you make that call explicitly than have me bake
it in. I did not add a workflow input for it, to keep the diff scoped and avoid shipping a
knob that can silently disable the deps gate.

## Both-states demonstration

The test extracts this step's **actual `run:` block from the shipped YAML** (not a paraphrase)
and drives it against a stub `osv-scanner` emitting a chosen exit-code sequence; `sleep` is
stubbed so the retry path is instant and observable. `scans` is the measured number of scanner
invocations.

| case | exit | want | scans | want | new logic | pre-fix logic |
|---|---|---|---|---|---|---|
| clean (0) | 0 | 0 | 1 | 1 | PASS | PASS |
| **real vulnerability (1)** | **1** | 1 | 1 | 1 | **PASS** | FAIL (no explicit finding wording) |
| nothing to scan (128) | 0 | 0 | 1 | 1 | PASS | PASS |
| **scan error, rpc (127)** | **75** | 75 | 3 | 3 | **PASS** | **FAIL — `FORBIDDEN [FAIL gate-deps]`** |
| scan error, api (129) | 75 | 75 | 3 | 3 | PASS | **FAIL — `FORBIDDEN [FAIL gate-deps]`** |
| scan error, bad config (130) | 75 | 75 | 1 | 1 | PASS | **FAIL — `FORBIDDEN [FAIL gate-deps]`** |
| undocumented (42) | 75 | 75 | 1 | 1 | PASS | **FAIL — `FORBIDDEN [FAIL gate-deps]`** |
| 127 then clears | 0 | 0 | 2 | 2 | PASS | FAIL (no retry) |
| 127 then vulnerability found | 1 | 1 | 2 | 2 | PASS | FAIL (no retry) |
| no manifests, skip | 0 | 0 | 0 | 0 | PASS | PASS |
| | | | | | **10/10** | **3/10** |

The pre-fix column is the point: the suite **fires against the known-broken state**, so the
green is meaningful rather than a silent detector failure.

Verbatim, the two states that matter.

**(a) A real vulnerability still FAILS** — after:

```
FAIL gate-deps: osv-scanner found actionable vulnerabilities (exit 1). This IS a security finding - fix or triage the CVEs listed above.
```
(exit 1, same blocking behaviour as before; before it read `FAIL gate-deps: osv-scanner exited 1 (vulnerabilities found or scanner error).`)

**(b) An infrastructure failure is reported differently** — before:

```
FAIL gate-deps: osv-scanner exited 127 (vulnerabilities found or scanner error).
```

after:

```
RETRY gate-deps: osv-scanner exited 127 without completing the scan (attempt 1/3) - this is NOT a vulnerability finding; retrying in 20s.
RETRY gate-deps: osv-scanner exited 127 without completing the scan (attempt 2/3) - this is NOT a vulnerability finding; retrying in 40s.
ERROR gate-deps: osv-scanner could not complete the scan (exit 127) - this is NOT a vulnerability finding.
ERROR gate-deps: exit 127 means the scanner logged an error - commonly a deps.dev / registry resolver outage ("rpc error: code = Unavailable desc = service unavailable").
ERROR gate-deps: attempts made 3/3. The dependency tree was NOT fully scanned, so this gate cannot certify it clean; it blocks rather than passing silently. Re-run the job once upstream recovers, or use the quality-zero:break-glass label for a prolonged outage.
```

`PASS`/`FAIL`/`ERROR`/`RETRY` are now four distinct, greppable prefixes.

## Scope and non-regression

* 1 file, +70/-7, every hunk inside the GATE 6 block (`@@ -651..736`).
* No `name: gate-` line added or removed — the step name `gate-deps osv-scanner` is unchanged,
  which matters because `.quality/charter_check.sh:35` matches on `name:\s*gate-deps`.
  `bash .quality/charter_check.sh` -> `SUCCESS: charter-check — active gate set matches the
  lean 6-gate charter`, all 6 gates still wired.
* The `osvsources` pre-check and the exit-128 mapping are untouched; no other gate touched.
* `actionlint -shellcheck= -pyflakes=` -> rc 0, no output. Verified the detector fires: the
  same binary reports two errors on a deliberately broken control workflow, so the silence is
  meaningful.
* `shellcheck -s bash -S style` -> rc 0 on the extracted step.

## Consumer rollout — a tag move is required, and I have not made it

Consumers pin the tag, e.g. `momentstudio/.github/workflows/quality.yml:35`:

```yaml
uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@v1
```

`v1` currently points at `b950330`, which is **19 commits behind `main`**. So merging this to
`main` changes nothing for any consumer until `v1` is moved. That is an owner action — I have
not touched the tag. Verified with `git rev-list -n 1 v1` and
`git rev-list --count v1..origin/main`.

## CI: pre-existing vs mine

Control established on `main` before pushing. Recent merged PR #276 was **all 9 checks green**,
so this repo's PR checks are not currently all-red; I will report any red on this PR against
that control rather than dismissing it as pre-existing.
