### PR TITLE
fix(inventory): whitelist the two private observe members in the fleet filter

### DIFF
--- a/scripts/quality/fleet_inventory.py
+++ b/scripts/quality/fleet_inventory.py
@@ -31,9 +31,19 @@ ProcessRunner = Callable[..., subprocess.CompletedProcess[str]]
 # The canonical list of private-repo exceptions. Kept tiny and explicit
 # so adding a new private repo to the fleet requires a code change + PR,
 # rather than a silent data-only edit.
+#
+# ``PrimariRo`` and ``agent-skills-toolchain`` are the two private
+# ``rollout: observe`` members. PR #274 enrolled them in
+# ``inventory/repos.yml`` with profiles and generated ruleset payloads but
+# never made the matching code change here, so the filter kept excluding
+# them and every sweep reported both as ``dead`` — the enrollment record
+# and the fleet filter disagreeing about the roster. This is the code half
+# of that enrollment.
 PRIVATE_INCLUDE_SLUGS: FrozenSet[str] = frozenset(
     {
         "Prekzursil/pbinfo-get-unsolved",
+        "Prekzursil/PrimariRo",
+        "Prekzursil/agent-skills-toolchain",
     }
 )
 

--- a/tests/test_fleet_inventory.py
+++ b/tests/test_fleet_inventory.py
@@ -88,6 +88,33 @@ class BuildExpectedFleetTests(unittest.TestCase):
             ["Prekzursil/pbinfo-get-unsolved"],
         )
 
+    def test_private_observe_members_included_as_explicit_exceptions(self) -> None:
+        """The two private ``rollout: observe`` members must survive the filter.
+
+        Real-fleet bug surfaced 2026-08-11: PR #274 enrolled
+        ``PrimariRo`` and ``agent-skills-toolchain`` in
+        ``inventory/repos.yml`` (with profiles and generated ruleset
+        payloads) but never touched this module, so the private-repo
+        filter kept excluding them. A live
+        ``fleet_inventory.py --json`` sweep therefore reported both
+        governed repos in ``dead`` — i.e. the enrollment record and the
+        fleet filter disagreed about the roster, permanently.
+
+        The module contract is that adding a private repo takes a data
+        edit AND a code change + PR; only the data half had happened.
+        """
+        repos = [
+            _repo(name="PrimariRo", private=True),
+            _repo(name="agent-skills-toolchain", private=True),
+        ]
+        self.assertEqual(
+            build_expected_fleet(repos),
+            [
+                "Prekzursil/PrimariRo",
+                "Prekzursil/agent-skills-toolchain",
+            ],
+        )
+
     def test_dedupes_and_sorts_output(self) -> None:
         """Duplicate slugs collapse; output is stable sorted."""
         repos = [
@@ -104,6 +131,31 @@ class BuildExpectedFleetTests(unittest.TestCase):
         """The exception list must be immutable to prevent silent edits."""
         self.assertIsInstance(PRIVATE_INCLUDE_SLUGS, frozenset)
         self.assertIn("Prekzursil/pbinfo-get-unsolved", PRIVATE_INCLUDE_SLUGS)
+        self.assertIn("Prekzursil/PrimariRo", PRIVATE_INCLUDE_SLUGS)
+        self.assertIn("Prekzursil/agent-skills-toolchain", PRIVATE_INCLUDE_SLUGS)
+
+    def test_visibility_exceptions_are_all_enrolled(self) -> None:
+        """Every whitelisted slug must actually be in ``inventory/repos.yml``.
+
+        The two lists are only meaningful as a pair. A whitelist entry
+        for a slug nobody enrolls is dead config, and — the direction
+        that actually bit on 2026-08-11 — an enrolled repo missing from
+        the whitelist is silently reported as ``dead`` by every sweep.
+        This closes the stale-whitelist half; the membership assertions
+        above close the missing-whitelist half.
+
+        Repo visibility is not recorded anywhere on disk, so the
+        enrolled-private-but-unlisted direction cannot be derived
+        offline; it is asserted explicitly per slug instead.
+        """
+        root = Path(__file__).resolve().parents[1]
+        inventoried = set(load_inventory_slugs(root / "inventory" / "repos.yml"))
+        for whitelist in (PRIVATE_INCLUDE_SLUGS, FORK_INCLUDE_SLUGS):
+            self.assertEqual(
+                whitelist - inventoried,
+                set(),
+                f"whitelisted but not enrolled: {sorted(whitelist - inventoried)}",
+            )
 
     def test_fork_pbinfo_included_as_explicit_exception(self) -> None:
         """``pbinfo-get-unsolved`` is included even when GitHub reports it as a fork.


### PR DESCRIPTION
## What

Adds `Prekzursil/PrimariRo` and `Prekzursil/agent-skills-toolchain` to
`PRIVATE_INCLUDE_SLUGS` in `scripts/quality/fleet_inventory.py`, plus tests.

## Why — the enrollment record and the fleet filter disagreed about the roster

PR #274 enrolled both repos: `inventory/repos.yml` entries, `profiles/repos/*.yml`,
and `generated/rulesets/*.json`. It did **not** touch `fleet_inventory.py`.

That module drops private repos unless they are whitelisted (`:96-97`), and its own
comment states the intended process:

> Kept tiny and explicit so adding a new private repo to the fleet requires a code
> change + PR, rather than a silent data-only edit.

Only the data half happened. `git show --name-only b1f5476` confirms PR #274 touched
9 files and none of them was `fleet_inventory.py`.

### Measured, before

```
$ python scripts/quality/fleet_inventory.py --json      # 2026-08-11
"dead": [
  "Prekzursil/PrimariRo",
  "Prekzursil/agent-skills-toolchain",
  "Prekzursil/codex-session-manager"
]
```

Two of those three are healthy, actively governed repos — `PrimariRo` is enforced by
live ruleset `20663544` and `agent-skills-toolchain` by `18297434`. They were reported
as orphan inventory purely because the filter could not see them.

Second, mechanically independent signal (`gh api repos/Prekzursil/<slug>`, not the
sweep): both return `private=true, fork=false, archived=false`. Only
`codex-session-manager` is genuinely gone (HTTP 404), and #283 already removes it.

### Measured, after

```
"dead": ["Prekzursil/codex-session-manager"]
```

## Tests — written first, observed failing for the right reason

| test | red output before the fix |
|---|---|
| `test_private_observe_members_included_as_explicit_exceptions` (new) | `AssertionError: Lists differ: [] != ['Prekzursil/PrimariRo', 'Prekzursil/agent-skills-toolchain']` |
| `test_private_include_frozen_set` (extended) | `AssertionError: 'Prekzursil/PrimariRo' not found in frozenset({'Prekzursil/pbinfo-get-unsolved'})` |
| `test_visibility_exceptions_are_all_enrolled` (new guard) | passed before **and** after — see below |

The third test guards the inverse direction (a whitelist entry nobody enrolls is dead
config). Because it is green in both states it proves nothing on its own, so it was
mutation-checked separately: injecting an unenrolled slug into `PRIVATE_INCLUDE_SLUGS`
turns it **RED**, and reverting the injection turns it green again. It is not a no-op.

Repo visibility is not recorded anywhere on disk, so the general
enrolled-private-but-unlisted invariant cannot be derived offline. It is asserted
explicitly per slug and the docstring says so rather than implying wider cover.

## Blast radius

None on CI. `fleet_inventory.py` has **zero workflow callers** — `grep -rln
fleet_inventory .github/` finds nothing (positive control: `validate_control_plane`
resolves to `control-plane-admin.yml`), and GitHub code search across the owner's
repos returns only `docs/`, `tests/`, `scripts/` and `known-issues/` hits, no `uses:`.
So this changes the output of a manually-run script and nothing else. The script's
exit code stays `1`, because six unenrolled public repos remain in `missing` — that is
a separate policy question, deliberately not addressed here.

## Verification

```
bash scripts/verify
  exit 0
  Ran 1490 tests in 57.408s
  OK
  TOTAL   2093 stmts   0 miss   524 branch   0 partial   100.00%
  Validated 18 repo profiles.
```

No overlap with the files in #283, so the two stack cleanly.
