### PR TITLE
fix(control-plane): retire the phantom CodeQL required context (tracelines profile + fleet sweep + gate)

### DIFF
--- a/docs/codeql-required-context-sweep.md
+++ b/docs/codeql-required-context-sweep.md
@@ -1,0 +1,118 @@
+# CodeQL required-context sweep — measured fleet state (2026-08-11)
+
+A required status check that the repo can never report is not a strict gate, it is a
+**permanent red**. GitHub offers two ways to run CodeQL and they emit *different* check
+names, so migrating a repo from one to the other silently invalidates any required
+context pinned to the old spelling.
+
+| setup | how it is configured | check names it emits |
+|---|---|---|
+| **advanced** | a `.github/workflows/codeql.yml` in the repo (the QZP-managed wrapper) | `codeql / CodeQL` (+ `codeql / Resolve CodeQL Profile`) |
+| **default** | GitHub-managed, Security tab → Code scanning → Default setup | aggregate **`CodeQL`** from the GitHub Advanced Security app (`app_id 57789`), plus `Analyze (<language>)` on *some* events only |
+
+Default setup **never** emits `codeql / CodeQL`. That is the whole defect class.
+
+## Which spelling to require
+
+Require the **aggregate `CodeQL`**, not the per-language `Analyze (<lang>)` names.
+
+Measured 2026-08-11 across all 16 open pull-request heads of `Prekzursil/WebCoder`
+(`GET /repos/.../commits/<head>/check-runs?per_page=100`):
+
+| context | present on |
+|---|---|
+| `CodeQL` | **16 / 16** |
+| `Analyze (<lang>)` | **1 / 16** (only PR #102) |
+| `codeql / CodeQL` | **0 / 16** |
+
+Detector control: the same probe reported `True` for `CodeQL` and `quality / quality` on
+every row, so a `False` for the other two is a measurement, not a broken matcher.
+
+`Analyze (<lang>)` is therefore unsafe to require — it would wedge 15 of 16 PRs. The
+fleet's already-deployed default-setup repos agree with the aggregate choice:
+`DevExtreme-Filter-Go-Language`'s classic protection requires `CodeQL`@57789 (its PR #40
+merged under exactly that requirement) and `env-inspector`'s **active** ruleset requires
+`CodeQL` with no app pin.
+
+## Fleet measurement
+
+Probe: `GET /repos/Prekzursil/<slug>/actions/workflows?per_page=100` for the state of
+`.github/workflows/codeql.yml` and of `dynamic/github-code-scanning/codeql`, corroborated
+against the CodeQL-related check-run names actually emitted on `main`'s HEAD commit.
+
+| repo | `codeql.yml` | default setup | emitted on main HEAD | setup |
+|---|---|---|---|---|
+| pbinfo-get-unsolved | active | active | `codeql / CodeQL` | advanced |
+| quality-zero-platform | active | active | `codeql / CodeQL` | advanced |
+| Airline-Reservations-System | active | active | `codeql / CodeQL` | advanced |
+| DevExtreme-Filter-Go-Language | **disabled_manually** | active | `Analyze (actions\|go\|python)` | **default** |
+| event-link | active | active | `codeql / CodeQL` | advanced |
+| Personal-Finance-Management | active | — | `codeql / CodeQL` | advanced |
+| momentstudio | active | active | `codeql / CodeQL` | advanced |
+| Reframe | **absent** | active | `Analyze (actions\|javascript-typescript\|python)` | **default** |
+| SWFOC-Mod-Menu | active | active | `codeql / CodeQL` | advanced |
+| Star-Wars-…-Save-Game-Editor | active | — | `codeql / CodeQL` | advanced |
+| TanksFlashMobile | active | active | `codeql / CodeQL` | advanced |
+| WebCoder | **disabled_manually** | active | `Analyze (…)` + a pre-disable `codeql / CodeQL` | **default** |
+| env-inspector | **disabled_manually** | active | `Analyze (actions\|python)` | **default** |
+| codeblocks-pretty-prints-stable | active | — | `codeql / CodeQL` | advanced |
+| PrimariRo | **absent** | — | *(none)* | **default, not yet reporting** |
+| tracelines | **absent** | active | `Analyze (actions\|javascript-typescript\|python)` | **default** |
+| llm-anthology | active | — | `analyze (javascript-typescript\|python)` | advanced (own wrapper job names) |
+| agent-skills-toolchain | **absent** | — | *(none)* | **default, not yet reporting** |
+
+WebCoder's `main` HEAD is `477b7aec` (2026-06-27), which predates the disable, so the
+`codeql / CodeQL` runs on it are historical. No PR head carries it — see the 16/16 table
+above.
+
+## What was fixed, and what is still pending
+
+**Fixed live (2026-08-11): `Prekzursil/WebCoder` classic branch protection.**
+
+```
+before: strict=true  checks=[{codeql / CodeQL, app:any}, {quality / quality, 15368}]
+after : strict=true  checks=[{quality / quality, 15368}, {CodeQL, 57789}]
+```
+
+Applied with `PATCH /repos/Prekzursil/WebCoder/branches/main/protection/required_status_checks`
+(the narrow sub-resource, not the whole-object `PUT`). A before/after diff of the *full*
+protection object shows `required_status_checks` as the only changed key — reviews,
+`enforce_admins`, force-push, deletions, linear history, conversation resolution, lock and
+fork-syncing are byte-identical. Net effect: one **never-emitted** requirement removed, and
+`CodeQL` added — which WebCoder's own **active** ruleset `quality-zero-platform / WebCoder`
+(id 14488879) already required, so the effective requirement set gained nothing and the
+"required ⊆ enabled" invariant is discharged by construction.
+
+Both-states evidence: PR #102 (`fix(deps): clear the critical websocket-driver advisory`)
+was `mergeStateStatus: BLOCKED` with every check green before the change and `CLEAN` /
+`MERGEABLE` immediately after, with no other edit. The other 15 open PRs stayed `BLOCKED`
+— correctly: their `quality / quality` genuinely fails. The phantom was removed without
+weakening anything real.
+
+**Fixed in this repo: `profiles/repos/tracelines.yml`** now requires `CodeQL` instead of
+`codeql / CodeQL`, with `generated/rulesets/tracelines.json` and the `inventory/repos.yml`
+note updated in the same commit (the inventory ↔ profile ↔ generated-ruleset triple).
+Membership is unchanged, so the count assertion in `tests/test_control_plane.py` stays 18.
+
+**Pending — five profiles still require the unreportable spelling:** `WebCoder`,
+`Reframe`, `env-inspector`, `PrimariRo`, `agent-skills-toolchain`. Three of them
+(`WebCoder`, `env-inspector`, `Reframe`) inherit `codeql / CodeQL` from the shared
+`profiles/stacks/quality-zero-phase1-common.yml`, so de-listing it is a cohort-wide change
+that the ADDITIVE-ONLY lean-gate charter defers to a coordinated fleet runbook. None of
+them is *live*-wedged by its profile today, because generated rulesets are **not**
+auto-applied: WebCoder's live ruleset requires `{quality / quality, CodeQL}` while
+`generated/rulesets/webcoder.json` still renders 15 retired-SaaS contexts, and
+env-inspector diverges the same way. Two independent repos, same conclusion.
+
+## The guard
+
+`tests/test_security_baseline_profiles.py` carries the registry
+`CODEQL_DEFAULT_SETUP_REPOS` and the assertion
+`test_default_setup_repos_never_require_the_advanced_codeql_context`. For every registered
+slug it requires **both** halves — the advanced-only spelling is absent, *and* a
+default-setup spelling is present — so the check can only be satisfied by substitution,
+never by deletion.
+
+Add a slug to the registry in the same commit that fixes its profile. The gate was proven
+both-states on `tracelines`: with `codeql / CodeQL` in the profile it exits 1
+(`FAILED (failures=1)`), and with `CodeQL` it exits 0 (`OK`).

--- a/generated/rulesets/tracelines.json
+++ b/generated/rulesets/tracelines.json
@@ -49,7 +49,7 @@
             "context": "test 3.12 / macos-latest"
           },
           {
-            "context": "codeql / CodeQL"
+            "context": "CodeQL"
           }
         ],
         "strict_required_status_checks_policy": true

--- a/inventory/repos.yml
+++ b/inventory/repos.yml
@@ -79,7 +79,7 @@ repos:
     profile: tracelines
     rollout: observe
     default_branch: main
-    notes: Lean member (public repo). Ruleset models the repo's own ci.yml checks (mypy + 6-leg test matrix) plus the platform CodeQL baseline context; matrix-derived context names are brittle across Python-version changes; coverage measured but informational; CodeQL runs today via GitHub default setup, which does not emit the managed workflow context.
+    notes: 'Lean member (public repo). Ruleset models the repo''s own ci.yml checks (mypy + 6-leg test matrix, both emitted on push AND pull_request) plus the CodeQL baseline. PHANTOM CONTEXT REMOVED 2026-08-11: the profile required `codeql / CodeQL`, the ADVANCED-setup spelling, but this repo has no codeql.yml and runs CodeQL via GitHub DEFAULT setup, which never emits that name (main@99257f05 emits Analyze (actions|javascript-typescript|python) and zero `codeql / CodeQL`) - it now requires the aggregate `CodeQL` context instead, the spelling DevExtreme and env-inspector already deploy and the only one reliably present on a pull_request event (16/16 WebCoder PR heads vs 1/16 for Analyze (<lang>)). build/deploy/publish-*/canary are deliberately NOT required: they come from pages.yml, release.yml and nightly-canary.yml and never fire on a PR. codeql.languages gained javascript-typescript to match what default setup actually scans. Matrix-derived `test <py> / <os>` names stay brittle across Python-version/OS changes - re-measure after any ci.yml matrix edit. Coverage measured but informational. No branch protection and no ruleset on main today (observe): GET /branches/main/protection -> 404, GET /rulesets -> [].'
   - slug: Prekzursil/llm-anthology
     profile: llm-anthology
     rollout: observe

--- a/profiles/repos/tracelines.yml
+++ b/profiles/repos/tracelines.yml
@@ -11,17 +11,59 @@ issue_policy:
   mode: zero
   pr_behavior: absolute
   main_behavior: absolute
-# Lean member: the ruleset requires ONLY the repo's own CI checks
-# (.github/workflows/ci.yml on push main + all PRs) plus the
-# platform-mandated `codeql / CodeQL` security-baseline context (enrollment
-# invariant, same lean-gate shape as the QZP self-profile). No
-# shared-scanner-matrix / Sonar / Codacy / qlty / Codecov contexts — this
-# repo does not produce those artifacts. CAVEAT: the matrix-derived
-# `test <py> / <os>` context names are brittle — adding or dropping a
-# Python version renames them. CodeQL runs TODAY via GitHub DEFAULT setup
-# (GitHub-managed; it does NOT emit the `codeql / CodeQL` workflow
-# context) — the context goes live when the fleet CodeQL sweep seeds the
-# managed codeql.yml wrapper (rulesets are not auto-synced).
+# Lean member (public repo, rollout: observe). NOTHING is enforced on main today
+# and this ruleset is the DESIGN of record, not a deployed artifact -- measured
+# 2026-08-11: `GET /repos/Prekzursil/tracelines/branches/main/protection` returns
+# HTTP 404 "Branch not protected" and `GET .../rulesets` returns `[]`.
+#
+# The required set models the repo's OWN `.github/workflows/ci.yml`, which
+# triggers on `push: branches [main]` AND `pull_request`, and has exactly two
+# jobs: `types` (name: mypy) and a 6-leg `test ${{ matrix.python }} / ${{
+# matrix.os }}` matrix (3.10-3.13 on ubuntu, plus 3.12 on windows and macos).
+# Plus the CodeQL security baseline. No shared-scanner-matrix / Sonar / Codacy /
+# qlty / Codecov / Sentry contexts: this repo produces none of those artifacts
+# (same lean-gate shape as llm-anthology / the QZP self-profile).
+#
+# DELIBERATELY EXCLUDED: `build`, `deploy`, `github-release`, `publish-*` and
+# `canary` all appear as check-runs on main@99257f05 but come from pages.yml
+# (push-to-main + workflow_dispatch), release.yml (tag push) and
+# nightly-canary.yml (schedule). None of them fires on a `pull_request` event,
+# so requiring any of them would be unreportable on every PR. Emitted-on-main is
+# NOT the same set as emitted-on-a-PR, and only the latter can be required.
+#
+# CodeQL -- PHANTOM CONTEXT REMOVED (2026-08-11). This profile previously
+# required `codeql / CodeQL`, the ADVANCED-setup workflow context. tracelines has
+# NO `.github/workflows/codeql.yml` at all; CodeQL runs via GitHub DEFAULT setup
+# (`dynamic/github-code-scanning/codeql` = active), which never emits that name.
+# Measured on main@99257f05, the CodeQL-related check-runs are `Analyze
+# (actions)`, `Analyze (javascript-typescript)` and `Analyze (python)`, and
+# `codeql / CodeQL` appears zero times. A required context that cannot be
+# reported strands the branch permanently red the moment the ruleset is applied
+# ("required is a SUBSET of enabled" -- the lean-gate charter invariant). This is
+# not hypothetical: the identical defect was live on WebCoder's CLASSIC branch
+# protection and held all 16 of its open PRs at BLOCKED, including the one that
+# clears its critical websocket-driver advisory. Removing it there flipped that
+# PR to CLEAN with no other change.
+#
+# The replacement is the AGGREGATE `CodeQL` context (GitHub Advanced Security,
+# app 57789) and NOT the per-language `Analyze (<lang>)` names. Measured across
+# WebCoder's 16 open PR heads: `CodeQL` present 16/16, `Analyze (<lang>)` present
+# 1/16 -- the per-language runs are not reliably emitted on a pull_request event,
+# so requiring them would wedge 15 of 16 PRs. The fleet's already-deployed
+# default-setup repos agree: DevExtreme-Filter-Go-Language's classic protection
+# requires `CodeQL`@57789 (PR #40 merged under it on 2026-08-11) and
+# env-inspector's ACTIVE ruleset requires `CodeQL` with no app pin.
+# UNVERIFIED for tracelines specifically: this repo has never had a pull request
+# (`gh pr list --state all` returns `[]`), so the aggregate `CodeQL` context has
+# not been observed on a tracelines PR head. Settling experiment: open one
+# throwaway PR against main and list its head check-runs before flipping
+# `rollout` off `observe`.
+#
+# CAVEAT (unchanged, and the reason this profile is re-measured rather than
+# assumed): the matrix-derived `test <py> / <os>` context names are BRITTLE --
+# adding or dropping a Python version or an OS renames them, and a renamed
+# required context is an unreportable one, i.e. the same defect class as the
+# phantom above. Re-measure the emitted names after any change to ci.yml.
 enabled_scanners:
   coverage: false
   codecov: false
@@ -51,7 +93,7 @@ required_contexts:
   - test 3.13 / ubuntu-latest
   - test 3.12 / windows-latest
   - test 3.12 / macos-latest
-  - codeql / CodeQL
+  - CodeQL
   pull_request_only: []
   target:
   - mypy
@@ -61,10 +103,16 @@ required_contexts:
   - test 3.13 / ubuntu-latest
   - test 3.12 / windows-latest
   - test 3.12 / macos-latest
-  - codeql / CodeQL
+  - CodeQL
 codeql:
+  # `javascript-typescript` added 2026-08-11: the repo's live DEFAULT setup
+  # analyses actions + javascript-typescript + python (measured on
+  # main@99257f05), and the repo does ship JS/TS under `web/` and `npm/`. The
+  # declared language set now matches what is actually scanned, so seeding a
+  # managed wrapper later would not silently drop a language.
   languages:
   - actions
+  - javascript-typescript
   - python
 dependabot:
   updates: []

--- a/tests/test_security_baseline_profiles.py
+++ b/tests/test_security_baseline_profiles.py
@@ -17,6 +17,36 @@ from scripts.quality.render_repo_baseline import (
     render_security_policy,
 )
 
+#: Governed repos MEASURED to run CodeQL via GitHub **default setup** rather than a
+#: managed ``codeql.yml`` wrapper, and therefore physically unable to report the
+#: advanced-setup ``codeql / CodeQL`` context. Membership is a measurement, not a
+#: preference: probe ``GET /repos/{slug}/actions/workflows`` for
+#: ``.github/workflows/codeql.yml`` (absent, or ``disabled_manually``) together with
+#: ``dynamic/github-code-scanning/codeql`` (``active``), then corroborate against the
+#: check-run names actually emitted on ``main``.
+#:
+#: Measured 2026-08-11 across all 18 inventory members. SIX are on default setup:
+#:
+#:   * ``Prekzursil/tracelines``            -- codeql.yml ABSENT            (registered)
+#:   * ``Prekzursil/WebCoder``              -- codeql.yml disabled_manually (PENDING)
+#:   * ``Prekzursil/Reframe``               -- codeql.yml ABSENT            (PENDING)
+#:   * ``Prekzursil/env-inspector``         -- codeql.yml disabled_manually (PENDING)
+#:   * ``Prekzursil/PrimariRo``             -- codeql.yml ABSENT            (PENDING)
+#:   * ``Prekzursil/agent-skills-toolchain``-- codeql.yml ABSENT            (PENDING)
+#:
+#: The five PENDING entries are deliberately NOT registered yet. WebCoder,
+#: env-inspector and Reframe inherit ``codeql / CodeQL`` from the shared
+#: ``profiles/stacks/quality-zero-phase1-common.yml`` stack, so de-listing it is a
+#: cohort-wide change that the ADDITIVE-ONLY lean-gate charter defers to a
+#: coordinated fleet runbook. Add a slug here in the same commit that fixes its
+#: profile -- the gate then makes the phantom impossible to reintroduce.
+CODEQL_DEFAULT_SETUP_REPOS = frozenset({"Prekzursil/tracelines"})
+
+#: The ADVANCED-setup spelling, lowercased for comparison. GitHub default setup
+#: never emits it, so requiring it in a default-setup repo is an unreportable
+#: context that strands the branch permanently red.
+ADVANCED_ONLY_CODEQL_CONTEXT = "codeql / codeql"
+
 
 class SecurityBaselineProfileTests(unittest.TestCase):
     """Protect the managed CodeQL, Dependabot, SECURITY, and QLTY baseline contract."""
@@ -31,21 +61,33 @@ class SecurityBaselineProfileTests(unittest.TestCase):
           * ADVANCED setup -- a `codeql.yml` workflow in the repo -- emits
             ``codeql / CodeQL``.
           * DEFAULT setup -- GitHub-managed, configured in the Security tab -- emits
-            one ``analyze (<language>)`` per analysed language and NEVER emits the
-            workflow-style name.
+            an aggregate ``CodeQL`` check from the GitHub Advanced Security app
+            (app 57789) plus, on some events only, one ``analyze (<language>)`` per
+            analysed language. It NEVER emits the workflow-style name.
 
         This assertion previously accepted only the advanced spelling, which silently
         wedges any repo migrated to default setup: the required context can never be
         reported, so no PR can ever merge. That is not hypothetical -- Prekzursil/WebCoder
-        requires ``codeql / CodeQL`` while emitting only ``Analyze (...)``, and has been
-        unmergeable since its CodeQL moved to default setup.
+        required ``codeql / CodeQL`` while emitting only ``CodeQL`` / ``Analyze (...)``,
+        and was unmergeable from the day its CodeQL moved to default setup until the
+        classic protection was corrected on 2026-08-11.
 
-        This is a recognition fix, not a relaxation: a repo that requires NEITHER form
-        still fails. Match is case-insensitive because the ruleset context and the
+        The bare aggregate ``CodeQL`` is accepted because it is the spelling the fleet
+        actually deploys for default-setup repos -- measured 2026-08-11,
+        DevExtreme-Filter-Go-Language's classic protection requires ``CodeQL``@57789 and
+        env-inspector's active ruleset requires ``CodeQL`` with no app pin. It is also
+        the only default-setup spelling that is reliably present on a pull_request
+        event: across WebCoder's 16 open PR heads, ``CodeQL`` appeared 16/16 while
+        ``Analyze (<lang>)`` appeared 1/16.
+
+        This is a recognition fix, not a relaxation: a repo that requires NONE of the
+        three forms still fails, and :func:`test_default_setup_repos_never_require_the_advanced_codeql_context`
+        additionally forbids the advanced spelling wherever it is known to be
+        unreportable. Match is case-insensitive because the ruleset context and the
         emitted check-run name differ in capitalisation (``analyze`` vs ``Analyze``).
         """
         lowered = {str(c).lower() for c in contexts}
-        if "codeql / codeql" in lowered:
+        if ADVANCED_ONLY_CODEQL_CONTEXT in lowered or "codeql" in lowered:
             return True
         return any(c.startswith("analyze (") for c in lowered)
 
@@ -71,6 +113,48 @@ class SecurityBaselineProfileTests(unittest.TestCase):
                 f"{entry['slug']} (target): no CodeQL context is required under either "
                 f"setup; got {sorted(profile['required_contexts']['target'])}",
             )
+
+    def test_default_setup_repos_never_require_the_advanced_codeql_context(self) -> None:
+        """A default-setup repo must not require a context its CodeQL cannot emit.
+
+        ``test_all_governed_repos_declare_codeql_and_dependabot`` only asks whether
+        *some* CodeQL context is required. It accepts ``codeql / CodeQL`` from any
+        repo, including repos whose ``codeql.yml`` is absent or disabled -- which is
+        exactly how a phantom context survives review. Measured 2026-08-11 on
+        Prekzursil/WebCoder: ``codeql / CodeQL`` appeared on **0 of 16** open PR heads
+        while ``CodeQL`` appeared on **16 of 16**, and the unreportable context alone
+        held every one of those PRs at ``mergeStateStatus: BLOCKED`` -- including the
+        PR that clears the repo's critical websocket-driver advisory.
+
+        So for every repo in :data:`CODEQL_DEFAULT_SETUP_REPOS` this asserts both
+        halves: the advanced-only spelling is absent, AND a default-setup spelling is
+        present, so the check is a substitution rather than a deletion.
+        """
+        inventory = load_inventory(ROOT / "inventory" / "repos.yml")
+        registered = {entry["slug"] for entry in inventory["repos"]}
+        self.assertLessEqual(
+            CODEQL_DEFAULT_SETUP_REPOS,
+            registered,
+            "CODEQL_DEFAULT_SETUP_REPOS names a slug that is not in the inventory",
+        )
+
+        for slug in sorted(CODEQL_DEFAULT_SETUP_REPOS):
+            profile = load_repo_profile(inventory, slug)
+            for event in ("push", "ruleset"):
+                contexts = active_required_contexts(profile, event_name=event)
+                lowered = {str(context).lower() for context in contexts}
+                self.assertNotIn(
+                    ADVANCED_ONLY_CODEQL_CONTEXT,
+                    lowered,
+                    f"{slug} ({event}) runs CodeQL via GitHub default setup, which never "
+                    f"emits 'codeql / CodeQL'; requiring it strands main permanently red. "
+                    f"Require the aggregate 'CodeQL' context instead; got {sorted(contexts)}",
+                )
+                self.assertTrue(
+                    self._enforces_codeql(contexts),
+                    f"{slug} ({event}): the advanced context was removed without putting a "
+                    f"default-setup CodeQL context in its place; got {sorted(contexts)}",
+                )
 
     def test_render_dependabot_config_includes_github_actions_and_repo_updates(self) -> None:
         """Dependabot rendering should include repo ecosystems plus github-actions."""


### PR DESCRIPTION
## What this is

Unit `webcoder-tracelines`. Two repos with protection defects, and they turned out to be
**the same defect**: a required status check whose name the repo can never report.

GitHub runs CodeQL two ways and they emit different check names. A repo that moves from a
`codeql.yml` wrapper to **default setup** silently invalidates any required context pinned
to the advanced spelling.

| setup | how it is configured | emits |
|---|---|---|
| advanced | `.github/workflows/codeql.yml` | `codeql / CodeQL` |
| default | GitHub-managed, Security tab | aggregate **`CodeQL`** (app 57789), plus `Analyze (<lang>)` on *some* events only |

## Corrections to the briefed premises — read these first

Four load-bearing premises I was handed were wrong. Each is refuted by a probe that is
mechanically different from the one that produced it.

1. **"WebCoder uses classic branch protection; consider migrating it to a managed ruleset
   for consistency."** WebCoder already **has** a managed ruleset — `quality-zero-platform /
   WebCoder`, id `14488879`, `enforcement: active`, updated 2026-07-18 — and it already
   requires the correct `{quality / quality, CodeQL}`. WebCoder was **double-governed**:
   classic protection AND ruleset, ANDed by GitHub. Nothing needed migrating; the stale
   half was the classic protection. Probe: `GET /repos/Prekzursil/WebCoder/rulesets` and
   `GET .../rulesets/14488879`.

2. **"`quality / quality` FAILED on all 5 recent runs."** Not universally. On PR #102's
   head (`f9c2b998`) `quality / quality` is **success**, as are `CodeQL`, `verify`,
   `build (3.10)`, `build (3.11)` and all three `Analyze (…)`. PR #102 was green on
   everything and blocked *solely* by the phantom context.

3. **"gate-deps is dominated by DEV dependencies (undici dev, webpack-dev-server,
   websocket-driver)."** Refuted by running the shipped T0 classifier over WebCoder's real
   `main` lockfile with the CI-pinned `osv-scanner 2.3.8`: **18 blocking findings, every
   one `[prod]`, zero dev-only.** The dev-only findings (undici, ip-address, sharp) are all
   already demoted to T2. `react-scripts@5.0.1` sits in `dependencies`, not
   `devDependencies`, so npm and GitHub both classify the whole CRA build toolchain —
   `webpack-dev-server`, `websocket-driver` — as **runtime**. The #286 severity floor would
   therefore **not** unblock WebCoder; it would take it from "any advisory blocks" to
   "18 production High/Critical-with-a-fix block". (And #286 is not deployed anyway: the
   `v1` tag every caller pins is unmoved. No claim here depends on it.)

4. **"tracelines needs enrolling."** tracelines is already enrolled — inventory row,
   profile and generated ruleset all present since before today, `rollout: observe`. What
   it needed was the *context list corrected against measurement*.

## (a) WebCoder classic protection — fixed live, one atomic change

```
before: strict=true  checks=[{codeql / CodeQL, app:any}, {quality / quality, 15368}]
after : strict=true  checks=[{quality / quality, 15368}, {CodeQL, 57789}]
```

Applied with `PATCH /repos/Prekzursil/WebCoder/branches/main/protection/required_status_checks`
— the narrow sub-resource, deliberately not the whole-object `PUT`. A before/after diff of
the **full** protection object shows `required_status_checks` as the only changed key:
reviews, `enforce_admins`, force-push, deletions, linear history, conversation resolution,
lock and fork-syncing are byte-identical. `app_id` was left unspecified for `CodeQL` and
GitHub resolved it to `57789`, which is exactly DevExtreme's working configuration.

**required ⊆ enabled, by construction.** The removed context is emitted on **0 of 16** open
PR heads; the added one is emitted on **16 of 16** *and* was already required by WebCoder's
own active ruleset — so the effective requirement set gained nothing and lost one dead
entry. It is not possible for this change to redden a branch.

**Both-states, live:** PR #102 `fix(deps): clear the critical websocket-driver advisory`
was `BLOCKED` with every check green before, and `CLEAN` / `MERGEABLE` immediately after,
with no other edit. The other 15 open PRs stayed `BLOCKED` — correctly, their
`quality / quality` genuinely fails. The phantom was removed without weakening anything
real. **Nothing was merged.**

Why `CodeQL` and not `Analyze (<lang>)` — measured across WebCoder's 16 open PR heads:

| context | present on |
|---|---|
| `CodeQL` | **16 / 16** |
| `Analyze (<lang>)` | **1 / 16** |
| `codeql / CodeQL` | **0 / 16** |

Detector control: the same probe returned `True` for `CodeQL` and `quality / quality` on
every row, so the zeros are a measurement, not a broken matcher. Requiring the per-language
names would wedge 15 of 16 PRs.

## (b) websocket-driver 9.2 — genuine production Critical, fix exists, bump it

Measured, not inferred. `GHSA-xv26-6w52-cph6` / `CVE-2026-54466`:

- **scope: `runtime`** — GitHub Dependabot alert #141, `manifest frontend/webcoder_ui/package-lock.json`.
- **severity: critical, CVSS v4 9.2** — and *only* v4: the OSV record carries a single
  `CVSS_V4` vector and no v3, so `cvss.score` reads `null` / `0` in the GitHub advisory
  API. I expected that to make the T0 floor mis-demote it; **it does not.** Running the
  workflow's own embedded `osv_severity_gate.py` over the real report,
  `websocket-driver 0.7.4 [prod] severity 9.2 | GHSA-xv26-6w52-cph6 | fixed in 0.7.5` lands
  in **BLOCKING**. osv-scanner 2.3.8 parses the v4 vector.
- **fix exists: `0.7.5`**, vulnerable range `< 0.7.5`.

So it *should* block, and the answer is to bump — which **PR #102 already does**, along with
the other 17 blocking findings; its own run drove osv-scanner to `No issues found`. That PR
is now `CLEAN` and waiting on the owner. The sibling medium advisory
`GHSA-mp7j-qc5w-4988` scores 6.3 `[prod]` and correctly demotes to T2.

Caveat worth stating: the `runtime` classification is an artifact of CRA shipping
`react-scripts` in `dependencies`. websocket-driver is only reachable through
`webpack-dev-server`'s sockjs transport, i.e. `react-scripts start`, not the built bundle.
A dev/prod filter reading npm's manifest groups — which is what the gate does — will keep
calling it production, and given a one-line fix exists that is the right outcome. It should
be **bumped, never demoted**.

## tracelines — profile corrected the way #277 did llm-anthology

The full inventory ↔ profile ↔ generated-ruleset triple, in one commit:

- `profiles/repos/tracelines.yml`: `codeql / CodeQL` → `CodeQL` in both `always` and
  `target`. tracelines has **no** `codeql.yml`; `dynamic/github-code-scanning/codeql` is
  active; `main@99257f05` emits `Analyze (actions|javascript-typescript|python)` and
  `codeql / CodeQL` **zero** times. `codeql.languages` gains `javascript-typescript` to
  match what default setup actually scans.
- The seven repo-own contexts (`mypy` + the 6-leg `test <py> / <os>` matrix) are kept —
  re-read from `ci.yml`, which triggers on `push: branches [main]` **and**
  `pull_request`. `build`, `deploy`, `github-release`, `publish-*` and `canary` all appear
  as check-runs on main but are **deliberately not required**: they come from `pages.yml`
  (push + dispatch), `release.yml` (tag) and `nightly-canary.yml` (schedule) and never fire
  on a pull request. Emitted-on-main is not the requireable set.
- `generated/rulesets/tracelines.json` regenerated by `scripts/verify` — one context
  substitution.
- `inventory/repos.yml` note rewritten with the measurement, the brittleness caveat kept
  and sharpened: matrix-derived names rename on any Python/OS change, and a renamed
  required context is an unreportable one — the same defect class as the phantom.
- **Membership is unchanged**, so the count assertion in `tests/test_control_plane.py`
  stays **18**.

Inline `UNVERIFIED`, recorded in the profile itself: tracelines has never had a pull
request (`gh pr list --state all` → `[]`), so the aggregate `CodeQL` context has not been
observed on a *tracelines* PR head. Settling experiment: open one throwaway PR against main
and list its head check-runs before flipping `rollout` off `observe`. Confidence that it
will appear: **almost certain (90-99%)** — DevExtreme merged PR #40 under a required
`CodeQL`@57789, and env-inspector's active ruleset requires `CodeQL`; both are default-setup
repos in this fleet.

## The gate (TDD, both-states)

`tests/test_security_baseline_profiles.py` already contained a *recognition* fix that
accepts either spelling, so it could never catch a phantom — it only asks whether *some*
CodeQL context is required. Added:

- `CODEQL_DEFAULT_SETUP_REPOS` — a registry of repos **measured** to be on default setup.
- `test_default_setup_repos_never_require_the_advanced_codeql_context` — for every
  registered slug, asserts **both** halves: the advanced-only spelling is absent, *and* a
  default-setup spelling is present. So it can only be satisfied by substitution, never by
  deletion.
- `_enforces_codeql` now recognises the aggregate `CodeQL` — the spelling the fleet actually
  deploys, and the only default-setup one reliably present on a `pull_request`.

Proven both-states on the real profile: `codeql / CodeQL` → exit 1, `FAILED (failures=1)`,
message naming the phantom; `CodeQL` → exit 0, `OK`.

Honest about its reach: the registry currently binds on **one** repo. The other five
measured default-setup members (`WebCoder`, `Reframe`, `env-inspector`, `PrimariRo`,
`agent-skills-toolchain`) are listed as PENDING in the constant's docstring and in
`docs/codeql-required-context-sweep.md`, because three of them inherit
`codeql / CodeQL` from the shared `profiles/stacks/quality-zero-phase1-common.yml` and
de-listing it there is a cohort-wide change the ADDITIVE-ONLY charter defers to a
coordinated runbook. None is *live*-wedged by its profile today: generated rulesets are not
auto-applied — WebCoder's live ruleset requires `{quality / quality, CodeQL}` while
`generated/rulesets/webcoder.json` still renders 15 retired-SaaS contexts, and
env-inspector diverges the same way. Two independent repos, same conclusion.

## Fleet sweep, measured (the residual item from the last wave)

`docs/codeql-required-context-sweep.md` records all 18 members with the probe used.
Six run default setup: **DevExtreme** (fixed earlier), **WebCoder** (fixed live today),
**Reframe**, **env-inspector**, **tracelines** (fixed here), **PrimariRo** and
**agent-skills-toolchain** emit no CodeQL context on main at all.

## Verification

`bash scripts/verify` under Git Bash: **exit 0**, `Ran 1623 tests in 135.439s`,
`OK (skipped=1)`, `TOTAL 2328 0 632 0 100.00%` (line **and** branch),
`Validated 18 repo profiles.`, working tree clean — the tree-churn guard did not fire, and
`generated/rulesets/tracelines.json` is committed.

Disclosed environment gap: run through **WSL** bash instead, verify exits 1 with 5 failures
in `test_lean_gate_compiled_coverage_lane` — `go: command not found`. A control run of that
same module on pristine `origin/main` (`3009dca`) in the same WSL fails the **identical
five**, so it is a pre-existing missing-toolchain gap, not this change. Go is on the Windows
PATH (`C:\Program Files\Go\bin\go.exe`) and visible to Git Bash, and CI's ubuntu runner
ships it.

## Scope

No git tag moved, created or deleted — `v1` is untouched, so nothing here changes what the
fleet executes. No secret or token read, printed, rotated or revoked. No force-push, no
`--no-verify`. The owner's shared checkout was never touched: this ran in a fresh clone at
`D:\qzp-wct` off `origin/main`. Nothing was merged, in this repo or in WebCoder.
