### PR TITLE
feat(cve): standing scheduled dependency-CVE surface, one tracked issue per repo

### DIFF
--- a/.github/workflows/scheduled-cve-scan.yml
+++ b/.github/workflows/scheduled-cve-scan.yml
@@ -1,0 +1,146 @@
+name: Scheduled CVE Scan
+
+# The STANDING dependency-advisory surface for the governed fleet.
+#
+# WHY THIS EXISTS (it is not a duplicate of gate 6):
+#   Every other lane in the lean gate answers a question about the CODE, so a
+#   per-PR diff gate is sufficient: no diff, no new finding. A dependency
+#   advisory is different in kind - it is TIME-VARYING. Measured 2026-08-11 on
+#   DevExtreme's unchanged `go 1.25.11` directive: the CI run of 2026-07-25
+#   reported ONE Go stdlib advisory; the identical scan with the identical
+#   pinned binary reported TWO. The finding set grew 100% with ZERO code change.
+#
+#   A PR-diff gate cannot fire without a diff, so a NEW advisory published
+#   against UNCHANGED code stays invisible until somebody happens to touch that
+#   repo. PR #286 correctly demoted dev-only / unscored / unfixable findings out
+#   of gate 6's blocking tier - but nothing surfaced the demoted tier, so those
+#   findings went nowhere at all. This workflow is that surface.
+#
+# DELIBERATE NON-GOALS (do not "fix" these):
+#   * It is NOT a required status check and must never become one. Its value is
+#     that it can report freely without reddening anybody's branch - which is
+#     exactly what lets it show the T2 tier honestly. A contract test asserts
+#     its name appears in no ruleset's required_status_checks.
+#   * It does NOT re-implement the classifier. It calls the SAME
+#     scripts/quality/osv_severity_gate.py classifier and the SAME pinned
+#     osv-scanner v2.3.8 that gate 6 uses, so its T0 tier is a faithful
+#     "this would block a PR today" prediction rather than a second opinion.
+#   * It opens ONE tracking issue per repo and UPDATES IT IN PLACE. An
+#     issue-per-run is a notification spammer that gets muted inside a week.
+#
+# HONESTY CONTRACT: osv-scanner's exit codes are NOT a 0-vs-non-zero split
+# (0 clean / 1 findings / 128 nothing to scan / 127,129,130 scan error). A scan
+# error is NOT a vulnerability finding and NOT a clean result: on one the sweep
+# leaves the tracking issue untouched and exits non-zero, so an incomplete run
+# is visible in the Actions tab and can never silently close a real finding.
+#
+# TOKEN SCOPE: the default GITHUB_TOKEN is scoped to THIS repo, so it can read
+# public fleet repos but not the private ones (pbinfo-get-unsolved, PrimariRo,
+# agent-skills-toolchain). Those clone-fail -> SCAN ERROR -> reported, never
+# reported clean. Setting the OPTIONAL, already-conventional
+# CODEX_FLEET_READ_PAT (Contents: Read across the fleet) closes that gap. This
+# workflow neither creates nor rotates any credential.
+
+permissions: {}
+
+# checkov:skip=CKV_GHA_7:dry_run/only are control-plane flags (they gate gh writes and narrow the roster), not build-output mutators
+on:
+  schedule:
+    # Daily at 05:41 UTC. Daily because the input is an externally refreshed
+    # advisory feed, so a weekly cadence would leave a new Critical invisible
+    # for up to seven days. The odd minute keeps it off the top-of-hour spike
+    # when every scheduled workflow in the fleet fires at once.
+    - cron: "41 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "When true, compute every issue action but make no gh write call."
+      only:
+        type: string
+        required: false
+        default: ""
+        description: "Scan only this repo (owner/name or bare name). Blank = the whole fleet."
+
+concurrency:
+  group: scheduled-cve-scan
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    # 18 shallow clones plus scans; generous so a slow registry cannot truncate
+    # the roster silently.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install platform dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      # Same version, same URL shape as reusable-quality.yml gate 6. Pinning the
+      # TOOL does not pin the DATA (a CVE feed cannot be pinned) - but it does
+      # guarantee this sweep and the gate agree on how a report is parsed and
+      # scored, which is what makes the T0 tier a prediction instead of a guess.
+      - name: Install osv-scanner (pinned, gate-6 parity)
+        run: |
+          set -euo pipefail
+          curl -sSL -o /usr/local/bin/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
+          chmod +x /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      # Every dispatch input arrives through env: and is quoted into an argv
+      # array - never spliced into a shell line (CWE-78).
+      - name: Sweep the fleet + reconcile tracking issues
+        shell: bash
+        env:
+          # Scheduled runs are the real thing; workflow_dispatch defaults to
+          # dry-run so a manual click can never flood the tracker.
+          QZ_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          QZ_ONLY: ${{ inputs.only }}
+          QZ_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Issues live on this repo, so github.token is sufficient for the
+          # write half. The read half (cloning other fleet repos) prefers the
+          # optional fleet-scoped read PAT; without it, private members are
+          # reported as SCAN ERROR rather than as clean.
+          GH_TOKEN: ${{ secrets.CODEX_FLEET_READ_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          # GITHUB_STEP_SUMMARY is a runner-provided env var. There is no
+          # `step_summary` member on the `github` expression context, so it can
+          # only be read as a shell variable here.
+          args=(
+            --inventory inventory/repos.yml
+            --platform-slug "$GITHUB_REPOSITORY"
+            --run-url "$QZ_RUN_URL"
+            --summary-file "$GITHUB_STEP_SUMMARY"
+          )
+          if [ "${QZ_DRY_RUN:-false}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          if [ -n "${QZ_ONLY:-}" ]; then
+            args+=(--only "$QZ_ONLY")
+          fi
+          rc=0
+          python -m scripts.quality.scheduled_cve_scan "${args[@]}" || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "PASS scheduled-cve-scan: every governed repo was scanned and its tracking issue reconciled."
+          elif [ "$rc" -eq 2 ]; then
+            echo "ERROR scheduled-cve-scan: the fleet roster could not be resolved, so NOTHING was scanned. This is not a clean-fleet result." >&2
+            exit 2
+          else
+            echo "ERROR scheduled-cve-scan: the sweep was INCOMPLETE (exit $rc) - at least one repo could not be scanned, or its issue could not be reconciled. Findings alone never fail this job, so a red run here always means an unestablished repo, never a CVE." >&2
+            exit "$rc"
+          fi

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Beyond the original strict-zero gate flow, v2 adds:
 - **Bumps recipe pipeline** — fleet-wide bumps (Node 20→24, Python minor versions, etc.) flow through staged dispatch with rollback, see [`reusable-bumps.yml`](.github/workflows/reusable-bumps.yml).
 - **Admin dashboard** at `https://prekzursil.github.io/quality-zero-platform/` — repo heatmap, coverage trend, drift status, bypass audit feed.
 - **Alerts subsystem** — every operationally relevant condition (drift, secret-missing, fleet-bump-fail, etc.) dispatches a labelled GitHub issue via [`alerts.py`](scripts/quality/alerts.py); cron sweep in [`scheduled-alerts.yml`](.github/workflows/scheduled-alerts.yml).
+- **Standing dependency-CVE surface** — a dependency advisory is *time-varying*, so a PR-diff gate cannot fire for one published against unchanged code. [`scheduled-cve-scan.yml`](.github/workflows/scheduled-cve-scan.yml) sweeps the whole roster daily with the same pinned `osv-scanner` gate 6 uses and maintains one auto-updated `alert:cve-watch` issue per repo, split into **T0** (would block a PR today) and **T2** (inventory only). Observability, never a required check — see [`scheduled_cve_scan.py`](scripts/quality/scheduled_cve_scan.py) and the [runbook](docs/OPERATOR-RUNBOOK.md).
 
 ## Admin Dashboard
 

--- a/docs/OPERATOR-RUNBOOK.md
+++ b/docs/OPERATOR-RUNBOOK.md
@@ -198,6 +198,56 @@ Default `dry_run=true` is the safe default for the cron schedule
 (no surprise `alert:*` issue creation from a cron firing on
 incomplete fleet state).
 
+### `scheduled-cve-scan.yml` (cron)
+
+The standing dependency-advisory surface. Runs daily at 05:41 UTC, reads the
+roster from `inventory/repos.yml`, scans every governed repo with the **same
+pinned `osv-scanner v2.3.8` gate 6 uses**, and maintains **one auto-updated
+`alert:cve-watch` issue per repo** — updated in place, closed when the findings
+clear.
+
+Why it exists, and why it is not gate 6 again: a dependency advisory is
+**time-varying**, so a PR-diff gate cannot fire for one published against
+unchanged code. Measured 2026-08-11, DevExtreme's unchanged `go 1.25.11`
+directive returned ONE advisory on 2026-07-25 and TWO on a same-binary re-scan.
+Gate 6's T0 floor (PR #286) correctly stopped dev-only / unscored / unfixable
+findings from reddening a branch — this workflow is what makes the demoted T2
+tier visible instead of discarded.
+
+```bash
+# Real sweep of the whole fleet (the cron default)
+gh workflow run scheduled-cve-scan.yml --ref main -f dry_run=false
+
+# Preview one repo without touching any issue
+gh workflow run scheduled-cve-scan.yml --ref main -f dry_run=true -f only=momentstudio
+
+# Same thing locally
+python -m scripts.quality.scheduled_cve_scan --only momentstudio --dry-run
+```
+
+Reading the result:
+
+| exit | meaning |
+| --- | --- |
+| `0` | every governed repo was scanned **and** its issue reconciled. Findings alone still exit 0 — see below. |
+| `1` | the sweep was **INCOMPLETE**: a repo could not be scanned (`osv-scanner` 127/129/130, or a clone failure) or its issue could not be reconciled. **Not a clean-fleet result.** |
+| `2` | the roster itself could not be resolved, so nothing was scanned. |
+
+Two invariants worth knowing before you touch this workflow:
+
+- **It must never become a required status check.** Its whole value is that it
+  can report freely without reddening a branch — which is what lets it show the
+  T2 tier at all. `tests/test_scheduled_cve_scan.py` asserts its name appears in
+  no `generated/rulesets/*.json` `required_status_checks`.
+- **A scan error never clears anything.** On 127/129/130 the tracking issue is
+  left completely untouched (no create, no update, no close) and the run exits
+  non-zero. An incomplete scan is not evidence of a clean tree.
+
+Private fleet members (`pbinfo-get-unsolved`, `PrimariRo`,
+`agent-skills-toolchain`) are unreachable with the default `GITHUB_TOKEN` and
+are therefore reported as `scan-error`, never as clean. Setting the optional
+`CODEX_FLEET_READ_PAT` (Contents: Read across the fleet) closes that gap.
+
 ---
 
 ## Verification gates before emitting completion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ source = [
   # 100%-covered here — the workflow copy is byte-identical by contract test.
   "scripts.quality.osv_severity_gate",
   "scripts.quality.jsts_coverage_assert",
+  # The standing dependency-CVE surface. NOT embedded in the reusable gate (it
+  # runs from this repo's own scheduled workflow), but it reuses the tiering
+  # classifier above and is the only thing that surfaces the T2 tier at all, so
+  # it is held to the same 100% line+branch bar.
+  "scripts.quality.scheduled_cve_scan",
 ]
 branch = true
 omit = [

--- a/scripts/quality/scheduled_cve_scan.py
+++ b/scripts/quality/scheduled_cve_scan.py
@@ -1,0 +1,952 @@
+#!/usr/bin/env python3
+"""Standing dependency-CVE surface — the scheduled fleet-wide osv-scanner sweep.
+
+Every other lane in the lean gate answers a question about the CODE, so a
+PR-diff gate is sufficient for it: no diff, no new finding. A dependency
+advisory is different in kind. It is **time-varying** — the finding set changes
+with the upstream feed while the tree stands still. Measured 2026-08-11 on
+DevExtreme's unchanged ``go 1.25.11`` directive: the CI run of 2026-07-25
+reported ONE Go stdlib advisory, and the identical scan with the identical
+pinned binary reported TWO. The finding set grew 100% with zero code change.
+
+Two consequences follow, and this module is the second one:
+
+1. A per-PR gate must apply a severity floor or it is non-convergent by
+   construction. That is gate 6's T0 tier
+   (``scripts/quality/osv_severity_gate.py``, PR #286).
+2. A per-PR gate **cannot fire without a diff**, so a NEW advisory published
+   against UNCHANGED code stays invisible until somebody happens to touch that
+   repo. PR #286 correctly demoted dev-only / unscored / unfixable findings out
+   of the blocking tier — but nothing surfaced the demoted tier, so those
+   findings went nowhere at all. This module is the standing surface that
+   catches both classes.
+
+Shape:
+
+* The roster is read from ``inventory/repos.yml`` — never a hardcoded list, so
+  enrolling a repo enrolls it here too.
+* Each repo is shallow-cloned, scanned with the **same pinned osv-scanner
+  binary gate 6 uses**, and the report is split by the **same classifier** gate
+  6 uses. T0 is therefore a faithful "this would block a PR today" prediction,
+  and T2 is the inventory nothing else was showing.
+* Findings land in **ONE tracking issue per repo, updated in place**. An
+  issue-per-run is a notification spammer that gets muted inside a week, which
+  would defeat the entire purpose. The issue is closed when the findings clear.
+* Exit codes are handled exactly as gate 6 handles them. ``0`` clean, ``1``
+  findings, ``128`` nothing to scan, ``127``/``129``/``130`` a SCAN ERROR that
+  is **not** a vulnerability verdict. **A scan error is never reported as a
+  clean result and never closes a tracking issue** — an incomplete scan is not
+  evidence of a clean tree.
+
+This is observability, not a gate. It must never become a required status
+check: its whole value is that it can go red without blocking anybody, which
+is precisely what lets it report the T2 tier honestly.
+
+CLI exit codes: ``0`` every repo scanned AND reconciled, ``1`` at least one
+repo could not be scanned or its issue could not be reconciled, ``2`` the
+roster itself could not be resolved.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import contextlib
+import datetime as dt
+import enum
+import json
+import subprocess  # nosec B404 — gh / osv-scanner CLI wrapper; every arg is controlled
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+from scripts.quality import fleet_inventory
+from scripts.quality import osv_severity_gate as severity
+
+OSV_SCANNER_VERSION = "v2.3.8"
+"""The pinned scanner. MUST match ``reusable-quality.yml``'s gate-6 download.
+
+A T0 "would block" prediction computed by a different scanner version is not a
+prediction of anything — advisory matching and severity plumbing both change
+between releases. A contract test asserts the two pins are equal.
+"""
+
+WORKFLOW_NAME = "scheduled-cve-scan.yml"
+OSV_CONFIG_NAME = "osv-scanner.toml"
+
+ALERT_LABEL = "alert:cve-watch"
+LABEL_COLOR = "B60205"
+LABEL_DESCRIPTION = "Standing dependency-CVE surface (observability, never a gate)."
+
+BODY_MARKER = "<!-- qzp:cve-watch -->"
+"""Stable marker so a human (or a later tool) can recognise a body we own."""
+
+DEFAULT_PLATFORM_SLUG = "Prekzursil/quality-zero-platform"
+DEFAULT_MAX_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 20
+
+MAX_ROWS_PER_TIER = 40
+MAX_BODY_CHARS = 60000
+"""Body cap. GitHub rejects an issue body over 65536 characters, and a rejected
+update is a silent gap in exactly the surface this module exists to provide."""
+
+TRUNCATION_NOTICE = "\n\n_(truncated)_\n"
+
+# osv-scanner exit codes, verbatim from cmd/osv-scanner/internal/cmd/run.go at
+# the pinned tag. These are NOT a 0-vs-non-zero split, and conflating them is
+# how a third-party outage becomes indistinguishable from a security regression.
+OSV_CLEAN = 0
+OSV_VULNS = 1
+OSV_GENERIC_ERROR = 127
+OSV_NO_PACKAGES = 128
+OSV_API_FAILED = 129
+OSV_INVALID_CONFIG = 130
+
+RETRYABLE_EXITS = frozenset((OSV_GENERIC_ERROR, OSV_API_FAILED))
+"""Transient upstream failures. ``130`` (invalid config) is deterministic, so
+retrying it only burns runner minutes.
+
+Measured against the real pinned 2.3.8 binary (2026-08-11): a *malformed* TOML
+config surfaced as **127**, not 130 - so 130 alone cannot be relied on to catch
+a bad config, and the retry costs one wasted round on that input. This is why
+the whole ``{127, 129, 130}`` set maps to ``SCAN_ERROR`` rather than the code
+branching on 130 specifically: the classification stays correct either way.
+Whether 130 is reserved for a config that PARSES but is semantically invalid is
+**UNVERIFIED** - settling experiment: feed a syntactically valid
+``osv-scanner.toml`` containing an unknown key or a malformed ``IgnoredVulns``
+entry and record the exit code.
+"""
+
+EXIT_OK = 0
+EXIT_INCOMPLETE = 1
+EXIT_CONFIG_ERROR = 2
+
+ProcessRunner = Callable[..., "subprocess.CompletedProcess[str]"]
+Sleeper = Callable[[float], None]
+
+
+class FleetRosterError(RuntimeError):
+    """The fleet roster could not be resolved.
+
+    Raised instead of returning an empty roster: "no repositories" and "the
+    inventory file is missing" must never be the same observable outcome.
+    """
+
+
+class GhCommandError(RuntimeError):
+    """A ``gh`` invocation failed, so the tracking-issue state is UNKNOWN.
+
+    Never downgraded to "no issue exists" — that would open a duplicate on
+    every failed lookup, which is the spam mode this module is built to avoid.
+    """
+
+
+class ScanStatus(enum.Enum):
+    """What the scan of one repository actually established."""
+
+    CLEAN = "clean"
+    FINDINGS = "findings"
+    NOTHING_TO_SCAN = "nothing-to-scan"
+    SCAN_ERROR = "scan-error"
+
+    @property
+    def is_clean_result(self) -> bool:
+        """True only when the scan COMPLETED and had nothing to report.
+
+        A ``SCAN_ERROR`` is deliberately excluded: the tree was not fully
+        scanned, so it is not evidence of a clean tree and must not clear an
+        issue.
+        """
+        return self in CLEAN_RESULT_STATUSES
+
+
+CLEAN_RESULT_STATUSES = frozenset((ScanStatus.CLEAN, ScanStatus.NOTHING_TO_SCAN))
+
+
+class IssueAction(enum.Enum):
+    """What the sweep did to a repository's tracking issue."""
+
+    CREATED = "created"
+    UPDATED = "updated"
+    CLOSED = "closed"
+    NOOP = "noop"
+    SKIPPED_SCAN_ERROR = "skipped-scan-error"
+    FAILED = "failed"
+
+
+INCOMPLETE_ACTIONS = frozenset((IssueAction.SKIPPED_SCAN_ERROR, IssueAction.FAILED))
+"""Actions that mean the sweep did not fully establish the fleet's state."""
+
+
+_EXIT_MEANING = {
+    OSV_CLEAN: (
+        ScanStatus.CLEAN,
+        "osv-scanner completed and matched no advisory.",
+    ),
+    OSV_VULNS: (
+        ScanStatus.FINDINGS,
+        "osv-scanner matched at least one advisory (exit 1 is the ONLY vulnerability code).",
+    ),
+    OSV_NO_PACKAGES: (
+        ScanStatus.NOTHING_TO_SCAN,
+        "osv-scanner exited 128 (ErrNoPackagesFound): no dependency manifests or lockfiles to scan.",
+    ),
+    OSV_GENERIC_ERROR: (
+        ScanStatus.SCAN_ERROR,
+        "osv-scanner exited 127 (HasErrored): the scanner logged an error - commonly a "
+        "deps.dev / registry resolver outage. The tree was NOT fully scanned.",
+    ),
+    OSV_API_FAILED: (
+        ScanStatus.SCAN_ERROR,
+        "osv-scanner exited 129 (ErrAPIFailed): the OSV.dev API was unreachable.",
+    ),
+    OSV_INVALID_CONFIG: (
+        ScanStatus.SCAN_ERROR,
+        f"osv-scanner exited 130 (HasErroredBecauseInvalidConfig): the {OSV_CONFIG_NAME} config was rejected.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RepoScan:
+    """The outcome of scanning one repository."""
+
+    slug: str
+    status: ScanStatus
+    exit_code: int
+    detail: str
+    blocking: Tuple[severity.Finding, ...] = ()
+    demoted: Tuple[severity.Finding, ...] = ()
+    attempts: int = 1
+    config_applied: bool = False
+
+
+@dataclass(frozen=True)
+class RepoOutcome:
+    """The scan of one repository plus what happened to its tracking issue."""
+
+    slug: str
+    status: ScanStatus
+    action: IssueAction
+    issue_number: int
+    detail: str
+    dry_run: bool
+    t0: int = 0
+    t2: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Exit-code contract (gate 6's, verbatim).
+# ---------------------------------------------------------------------------
+
+
+def classify_exit_code(code: int) -> Tuple[ScanStatus, str]:
+    """Map an osv-scanner exit code onto a status plus a human explanation.
+
+    An undocumented code fails CLOSED as a scan error rather than being read as
+    a clean tree: auto-passing an exit nobody has characterised would fail open
+    exactly where this surface exists to stay honest.
+    """
+    known = _EXIT_MEANING.get(int(code))
+    if known is not None:
+        return known
+    return (
+        ScanStatus.SCAN_ERROR,
+        f"osv-scanner exited {code}, which is not a documented exit code for the pinned "
+        f"{OSV_SCANNER_VERSION} (0/1/127/128/129/130) - treated as a scan failure, NOT a vulnerability finding.",
+    )
+
+
+def is_retryable_exit(code: int) -> bool:
+    """True for the exits a transient upstream outage produces (127 / 129)."""
+    return int(code) in RETRYABLE_EXITS
+
+
+# ---------------------------------------------------------------------------
+# Roster.
+# ---------------------------------------------------------------------------
+
+
+def load_fleet_slugs(inventory_path: Path, *, only: Sequence[str] = ()) -> List[str]:
+    """Return the governed fleet from ``inventory/repos.yml``.
+
+    ``only`` narrows the sweep for a manual dispatch and accepts either the
+    full ``owner/name`` slug or the bare repository name. An ``only`` value
+    that matches nothing raises rather than quietly sweeping zero repos, and a
+    blank value (the shape an empty ``workflow_dispatch`` input arrives as) is
+    ignored rather than treated as a filter.
+    """
+    try:
+        slugs = fleet_inventory.load_inventory_slugs(Path(inventory_path))
+    except OSError as exc:
+        raise FleetRosterError(f"cannot read the fleet inventory '{inventory_path}': {exc}") from exc
+    if not slugs:
+        raise FleetRosterError(
+            f"the fleet inventory '{inventory_path}' declares no repository slugs; "
+            "refusing to report an empty sweep as a clean fleet",
+        )
+    wanted = [str(item).strip() for item in only if str(item).strip()]
+    if not wanted:
+        return slugs
+    selected: List[str] = []
+    for value in wanted:
+        matches = [slug for slug in slugs if value in (slug, slug.rsplit("/", 1)[-1])]
+        if not matches:
+            raise FleetRosterError(f"--only {value!r} matches no repository in '{inventory_path}'")
+        selected.extend(matches)
+    return sorted(set(selected))
+
+
+# ---------------------------------------------------------------------------
+# Command construction + process plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _run(args: Sequence[str], *, runner: ProcessRunner) -> "subprocess.CompletedProcess[str]":
+    """Invoke ``args`` through the injected runner, capturing text output."""
+    return runner(list(args), capture_output=True, text=True, check=False)
+
+
+def _tail(text: str) -> str:
+    """Return the last line of ``text``, or an empty string."""
+    return " ".join(str(text).strip().splitlines()[-1:])
+
+
+def clone_command(slug: str, dest: Path) -> List[str]:
+    """Build the shallow single-branch clone for one fleet repository.
+
+    A full clone of the whole fleet every night is wasted minutes and disk, and
+    osv-scanner only ever reads the checked-out manifests.
+    """
+    return [
+        "gh",
+        "repo",
+        "clone",
+        slug,
+        str(dest),
+        "--",
+        "--depth=1",
+        "--single-branch",
+        "--no-tags",
+    ]
+
+
+def osv_command(repo_dir: Path, *, config: Optional[Path] = None) -> List[str]:
+    """Build the osv-scanner invocation, mirroring gate 6's scan shape.
+
+    ``--config`` is passed only when the caller actually ships the file:
+    osv-scanner rejects a missing config with exit 130, and gate 6 likewise
+    only runs when the file exists. Passing it where present keeps T0 a
+    faithful prediction of the gate's own verdict, since the caller's
+    hand-written ignores apply first in both places.
+    """
+    args = ["osv-scanner", "scan", "source", "--recursive", "--format", "json"]
+    if config is not None:
+        args.append(f"--config={config}")
+    args.append(str(repo_dir))
+    return args
+
+
+def _scan_with_retries(
+    command: Sequence[str],
+    *,
+    runner: ProcessRunner,
+    sleeper: Sleeper,
+    max_attempts: int,
+) -> Tuple["subprocess.CompletedProcess[str]", int]:
+    """Run the scan, retrying ONLY the transient exits, with gate 6's backoff."""
+    attempts_allowed = max(1, int(max_attempts))
+    completed = _run(command, runner=runner)
+    attempt = 1
+    while attempt < attempts_allowed and is_retryable_exit(completed.returncode):
+        sleeper(attempt * RETRY_BACKOFF_SECONDS)
+        attempt += 1
+        completed = _run(command, runner=runner)
+    return completed, attempt
+
+
+def scan_repo(
+    slug: str,
+    *,
+    workdir: Path,
+    floor: float,
+    runner: ProcessRunner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> RepoScan:
+    """Clone and scan one repository, splitting its report into T0 and T2.
+
+    A repository that could not be cloned, or whose report could not be
+    parsed, is a ``SCAN_ERROR``: we did not establish anything about it, so we
+    must not claim it is clean.
+    """
+    dest = Path(workdir) / slug.replace("/", "__")
+    clone = _run(clone_command(slug, dest), runner=runner)
+    if clone.returncode != 0:
+        return RepoScan(
+            slug=slug,
+            status=ScanStatus.SCAN_ERROR,
+            exit_code=clone.returncode,
+            detail=(
+                f"`gh repo clone` exited {clone.returncode}, so the repository was never scanned - "
+                f"this is NOT a vulnerability verdict. {_tail(clone.stderr)}"
+            ),
+        )
+
+    config_path = dest / OSV_CONFIG_NAME
+    config_applied = config_path.is_file()
+    completed, attempts = _scan_with_retries(
+        osv_command(dest, config=config_path if config_applied else None),
+        runner=runner,
+        sleeper=sleeper,
+        max_attempts=max_attempts,
+    )
+    code = completed.returncode
+    status, detail = classify_exit_code(code)
+    blocking: Tuple[severity.Finding, ...] = ()
+    demoted: Tuple[severity.Finding, ...] = ()
+    if status is ScanStatus.FINDINGS:
+        try:
+            document = json.loads(completed.stdout)
+        except ValueError as exc:
+            status = ScanStatus.SCAN_ERROR
+            detail = (
+                f"osv-scanner exited 1 (findings) but its JSON report could not be parsed ({exc}), so the "
+                "findings could not be classified - this is NOT a clean result."
+            )
+        else:
+            found_blocking, found_demoted = severity.classify(severity.iter_findings(document), floor)
+            blocking = tuple(found_blocking)
+            demoted = tuple(found_demoted)
+    return RepoScan(
+        slug=slug,
+        status=status,
+        exit_code=code,
+        detail=detail,
+        blocking=blocking,
+        demoted=demoted,
+        attempts=attempts,
+        config_applied=config_applied,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering.
+# ---------------------------------------------------------------------------
+
+
+def issue_title(slug: str) -> str:
+    """Canonical, dedupable tracking-issue title. This IS the dedupe key."""
+    return f"[{ALERT_LABEL}] {slug}"
+
+
+def _rows(findings: Sequence[severity.Finding], *, with_reasons: bool) -> List[str]:
+    """Render one tier's rows, capped, with any remainder disclosed."""
+    if not findings:
+        return ["_none_"]
+    rows: List[str] = []
+    for finding in findings[:MAX_ROWS_PER_TIER]:
+        prefix = "[" + "+".join(finding.reasons) + "] " if with_reasons else ""
+        rows.append("- " + prefix + severity.format_finding(finding))
+    remainder = len(findings) - MAX_ROWS_PER_TIER
+    if remainder > 0:
+        rows.append(f"- _... and {remainder} more (see the workflow run log for the full report)_")
+    return rows
+
+
+def _findings_section(scan: RepoScan) -> List[str]:
+    """Render the two-tier body for a repository with findings."""
+    section = [f"## T0 - WOULD BLOCK ({len(scan.blocking)})", ""]
+    section.append("Production dependency, at or above the CVSS floor, and a published fix exists.")
+    section.append("Gate 6 reds a PR on each of these today, so each is closable by a bump you control.")
+    section.append("")
+    section.extend(_rows(scan.blocking, with_reasons=False))
+    section.extend(
+        [
+            "",
+            f"## T2 - INVENTORY ({len(scan.demoted)})",
+            "",
+            "Demoted, not hidden: dev-only, unscored, below the floor, or no published fix.",
+            "These never block a PR. This section is the only place they are visible.",
+            "",
+        ]
+    )
+    section.extend(_rows(scan.demoted, with_reasons=True))
+    section.append("")
+    section.append("This issue closes automatically on the first sweep that finds nothing.")
+    return section
+
+
+def _status_section(scan: RepoScan) -> List[str]:
+    """Render the body section that corresponds to the scan's status."""
+    if scan.status is ScanStatus.FINDINGS:
+        return _findings_section(scan)
+    if scan.status is ScanStatus.CLEAN:
+        return [
+            "## No dependency advisories",
+            "",
+            "The scan completed and matched nothing. This issue is being closed.",
+        ]
+    if scan.status is ScanStatus.NOTHING_TO_SCAN:
+        return [
+            "## Nothing to scan",
+            "",
+            "osv-scanner found no dependency manifests or lockfiles here, so there is no advisory "
+            "surface to track. This issue is being closed.",
+        ]
+    return [
+        "## SCAN ERROR - this is NOT a vulnerability verdict",
+        "",
+        scan.detail,
+        "",
+        "The dependency tree was not fully scanned, so the run is **not a clean result**. No tracking "
+        "issue was opened, updated or closed on this evidence - a failed scan must never clear a finding.",
+    ]
+
+
+def render_issue_body(
+    scan: RepoScan,
+    *,
+    floor: float,
+    generated_at: dt.datetime,
+    run_url: str = "",
+    max_body_chars: int = MAX_BODY_CHARS,
+) -> str:
+    """Render the tracking-issue body (or close comment) for one scan.
+
+    ``generated_at`` is injected rather than read from the clock so the output
+    is deterministic and the body's timestamp is the sweep's, not the
+    renderer's.
+    """
+    lines = [
+        BODY_MARKER,
+        f"# Dependency-CVE watch - `{scan.slug}`",
+        "",
+        "A dependency advisory is time-varying, so a PR-diff gate cannot see one published against",
+        "unchanged code. This issue is that standing surface. **It is not a gate**: it blocks nothing,",
+        f"it is updated in place by `{WORKFLOW_NAME}`, and it closes itself when the findings clear.",
+        "",
+        f"- Scanner: `osv-scanner {OSV_SCANNER_VERSION}` - the same pinned binary gate 6 runs",
+        f"- Last scanned (UTC): `{generated_at.isoformat()}`",
+        f"- Scan result: `{scan.status.value}` (osv-scanner exit `{scan.exit_code}`, {scan.attempts} attempt(s))",
+        f"- Caller `{OSV_CONFIG_NAME}` ignores applied: `{'yes' if scan.config_applied else 'no'}`",
+        f"- T0 floor: production dependency AND CVSS >= {format(floor, 'g')} AND a published fix",
+    ]
+    if run_url:
+        lines.append(f"- Produced by: {run_url}")
+    lines.append("")
+    lines.extend(_status_section(scan))
+    body = "\n".join(lines) + "\n"
+    if len(body) <= max_body_chars:
+        return body
+    return body[: max_body_chars - len(TRUNCATION_NOTICE)] + TRUNCATION_NOTICE
+
+
+def render_summary(outcomes: Sequence[RepoOutcome]) -> str:
+    """Render the markdown block the workflow appends to its step summary."""
+    lines = ["## Scheduled dependency-CVE sweep", ""]
+    if not outcomes:
+        lines.append("_No repositories were scanned._")
+        return "\n".join(lines) + "\n"
+    lines.extend(
+        [
+            f"`osv-scanner {OSV_SCANNER_VERSION}`. T0 = would block gate 6 today. T2 = inventory only, "
+            "never blocking. A `scan-error` row is NOT a clean result.",
+            "",
+            "| repo | status | T0 | T2 | issue | detail |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for outcome in outcomes:
+        reference = f"#{outcome.issue_number}" if outcome.issue_number else "-"
+        detail = outcome.detail.replace("|", "/").replace("\n", " ") or "-"
+        lines.append(
+            f"| `{outcome.slug}` | {outcome.status.value} | {outcome.t0} | {outcome.t2} | "
+            f"{outcome.action.value} {reference} | {detail} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Issue reconciliation.
+# ---------------------------------------------------------------------------
+
+
+def _require_ok(completed: "subprocess.CompletedProcess[str]", *, what: str) -> None:
+    """Raise ``GhCommandError`` when a ``gh`` call did not succeed."""
+    if completed.returncode != 0:
+        raise GhCommandError(f"{what} exited {completed.returncode}: {_tail(completed.stderr)}")
+
+
+def _issue_number(issue: Mapping[str, Any]) -> int:
+    """Read the issue number out of a ``gh issue list`` record."""
+    raw = issue.get("number")
+    return int(raw) if isinstance(raw, int) else 0
+
+
+def _issue_number_from_url(stdout: str) -> int:
+    """Parse the trailing ``/<n>`` of ``gh issue create`` output (0 if absent)."""
+    tail = str(stdout).rstrip().rsplit("/", 1)[-1]
+    try:
+        return int(tail)
+    except ValueError:
+        return 0
+
+
+def find_open_issue(
+    platform_slug: str,
+    *,
+    slug: str,
+    runner: ProcessRunner = subprocess.run,
+) -> Optional[Mapping[str, Any]]:
+    """Return the open tracking issue for ``slug``, or ``None``.
+
+    A failed or unparseable lookup RAISES. Returning ``None`` there would read
+    as "no issue exists" and open a duplicate on every transient gh failure.
+    """
+    completed = _run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            platform_slug,
+            "--label",
+            ALERT_LABEL,
+            "--state",
+            "open",
+            "--search",
+            slug,
+            "--json",
+            "number,title,state",
+            "--limit",
+            "100",
+        ],
+        runner=runner,
+    )
+    _require_ok(completed, what="`gh issue list`")
+    try:
+        payload = json.loads(completed.stdout or "[]")
+    except ValueError as exc:
+        raise GhCommandError(f"`gh issue list` returned unparseable JSON for {slug}: {exc}") from exc
+    if not isinstance(payload, list):
+        raise GhCommandError(f"`gh issue list` returned {type(payload).__name__}, expected a list, for {slug}")
+    expected = issue_title(slug)
+    for issue in payload:
+        if isinstance(issue, Mapping) and issue.get("title") == expected:
+            return issue
+    return None
+
+
+def ensure_label(platform_slug: str, *, runner: ProcessRunner = subprocess.run) -> bool:
+    """Create or refresh the tracking label. A failure here is non-fatal.
+
+    ``gh issue create --label`` fails outright on an unknown label, so the
+    label is ensured first; but losing a finding because of a label race would
+    be a worse outcome than an unlabelled issue.
+    """
+    completed = _run(
+        [
+            "gh",
+            "label",
+            "create",
+            ALERT_LABEL,
+            "--repo",
+            platform_slug,
+            "--color",
+            LABEL_COLOR,
+            "--description",
+            LABEL_DESCRIPTION,
+            "--force",
+        ],
+        runner=runner,
+    )
+    if completed.returncode != 0:
+        print(
+            f"WARN scheduled-cve-scan: could not ensure label {ALERT_LABEL} "
+            f"(exit {completed.returncode}): {_tail(completed.stderr)}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def reconcile(
+    scan: RepoScan,
+    *,
+    platform_slug: str,
+    floor: float,
+    generated_at: dt.datetime,
+    runner: ProcessRunner = subprocess.run,
+    run_url: str = "",
+    dry_run: bool = False,
+) -> RepoOutcome:
+    """Bring one repository's tracking issue in line with its scan.
+
+    Findings create the issue or update it IN PLACE; a clean result closes it;
+    a scan error touches nothing at all.
+    """
+    counts = (len(scan.blocking), len(scan.demoted))
+    if scan.status is ScanStatus.SCAN_ERROR:
+        return RepoOutcome(
+            scan.slug,
+            scan.status,
+            IssueAction.SKIPPED_SCAN_ERROR,
+            0,
+            scan.detail,
+            dry_run,
+            *counts,
+        )
+
+    body = render_issue_body(scan, floor=floor, generated_at=generated_at, run_url=run_url)
+    existing = find_open_issue(platform_slug, slug=scan.slug, runner=runner)
+
+    if scan.status.is_clean_result:
+        if existing is None:
+            return RepoOutcome(scan.slug, scan.status, IssueAction.NOOP, 0, scan.detail, dry_run, *counts)
+        number = _issue_number(existing)
+        if not dry_run:
+            _require_ok(
+                _run(
+                    ["gh", "issue", "close", str(number), "--repo", platform_slug, "--comment", body],
+                    runner=runner,
+                ),
+                what="`gh issue close`",
+            )
+        return RepoOutcome(scan.slug, scan.status, IssueAction.CLOSED, number, scan.detail, dry_run, *counts)
+
+    if existing is not None:
+        number = _issue_number(existing)
+        if not dry_run:
+            _require_ok(
+                _run(
+                    ["gh", "issue", "edit", str(number), "--repo", platform_slug, "--body", body],
+                    runner=runner,
+                ),
+                what="`gh issue edit`",
+            )
+        return RepoOutcome(scan.slug, scan.status, IssueAction.UPDATED, number, scan.detail, dry_run, *counts)
+
+    if dry_run:
+        return RepoOutcome(scan.slug, scan.status, IssueAction.CREATED, 0, scan.detail, dry_run, *counts)
+
+    ensure_label(platform_slug, runner=runner)
+    completed = _run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            platform_slug,
+            "--title",
+            issue_title(scan.slug),
+            "--label",
+            ALERT_LABEL,
+            "--body",
+            body,
+        ],
+        runner=runner,
+    )
+    _require_ok(completed, what="`gh issue create`")
+    return RepoOutcome(
+        scan.slug,
+        scan.status,
+        IssueAction.CREATED,
+        _issue_number_from_url(completed.stdout),
+        scan.detail,
+        dry_run,
+        *counts,
+    )
+
+
+def run_sweep(
+    slugs: Sequence[str],
+    *,
+    workdir: Path,
+    platform_slug: str,
+    floor: float,
+    generated_at: dt.datetime,
+    runner: ProcessRunner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+    run_url: str = "",
+    dry_run: bool = False,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> List[RepoOutcome]:
+    """Scan and reconcile every slug. One repo's failure never aborts the rest."""
+    outcomes: List[RepoOutcome] = []
+    root = Path(workdir)
+    for slug in slugs:
+        scan = scan_repo(
+            slug,
+            workdir=root,
+            floor=floor,
+            runner=runner,
+            sleeper=sleeper,
+            max_attempts=max_attempts,
+        )
+        try:
+            outcome = reconcile(
+                scan,
+                platform_slug=platform_slug,
+                floor=floor,
+                generated_at=generated_at,
+                runner=runner,
+                run_url=run_url,
+                dry_run=dry_run,
+            )
+        except GhCommandError as exc:
+            outcome = RepoOutcome(
+                slug,
+                scan.status,
+                IssueAction.FAILED,
+                0,
+                str(exc),
+                dry_run,
+                len(scan.blocking),
+                len(scan.demoted),
+            )
+        outcomes.append(outcome)
+    return outcomes
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _resolve_workdir(value: str) -> Iterator[Path]:
+    """Yield the requested clone root, or a self-cleaning temporary one."""
+    if value:
+        yield Path(value)
+        return
+    with tempfile.TemporaryDirectory(prefix="qzp-cve-scan-") as temp_dir:
+        yield Path(temp_dir)
+
+
+def _json_payload(outcomes: Sequence[RepoOutcome], *, generated_at: dt.datetime) -> Mapping[str, Any]:
+    """Build the machine-readable sweep result."""
+    return {
+        "generated_at": generated_at.isoformat(),
+        "osv_scanner_version": OSV_SCANNER_VERSION,
+        "repos": [
+            {
+                "slug": outcome.slug,
+                "status": outcome.status.value,
+                "action": outcome.action.value,
+                "issue": outcome.issue_number,
+                "t0": outcome.t0,
+                "t2": outcome.t2,
+                "detail": outcome.detail,
+                "dry_run": outcome.dry_run,
+            }
+            for outcome in outcomes
+        ],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan the governed fleet for dependency advisories and maintain one auto-updated "
+            "tracking issue per repository. Observability, not a gate."
+        ),
+    )
+    parser.add_argument(
+        "--inventory",
+        default=str(Path(__file__).resolve().parents[2] / "inventory" / "repos.yml"),
+        help="Path to the fleet roster (inventory/repos.yml).",
+    )
+    parser.add_argument("--platform-slug", default=DEFAULT_PLATFORM_SLUG, help="Repo that hosts the tracking issues.")
+    parser.add_argument(
+        "--only",
+        action="append",
+        default=[],
+        help="Scan only this repo (owner/name or bare name). Repeatable; blank values are ignored.",
+    )
+    parser.add_argument(
+        "--min-severity",
+        type=float,
+        default=severity.SEVERITY_FLOOR,
+        help=f"CVSS floor separating T0 from T2 (default {severity.SEVERITY_FLOOR}).",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"Scan attempts per repo before a transient exit is final (default {DEFAULT_MAX_ATTEMPTS}).",
+    )
+    parser.add_argument("--workdir", default="", help="Clone root. Default: a self-cleaning temporary directory.")
+    parser.add_argument("--run-url", default="", help="Workflow-run URL recorded in each issue body as provenance.")
+    parser.add_argument("--summary-file", default="", help="Append the markdown summary here (GITHUB_STEP_SUMMARY).")
+    parser.add_argument("--dry-run", action="store_true", help="Compute everything; make no gh write call.")
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit the machine-readable payload instead of the markdown summary.",
+    )
+    return parser
+
+
+def main(
+    argv: Optional[List[str]] = None,
+    *,
+    runner: ProcessRunner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+    now: Optional[dt.datetime] = None,
+) -> int:
+    """Sweep the fleet and reconcile every tracking issue.
+
+    Findings alone exit ``0``: this is observability, and turning a new upstream
+    advisory into a red required check is precisely the treadmill the tiering
+    was introduced to end. Only an INCOMPLETE sweep - a repo that could not be
+    scanned, or an issue that could not be reconciled - exits non-zero.
+    """
+    args = _build_parser().parse_args(argv)
+    try:
+        slugs = load_fleet_slugs(Path(args.inventory), only=args.only)
+    except FleetRosterError as exc:
+        print(f"ERROR scheduled-cve-scan: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    generated_at = now if now is not None else dt.datetime.now(dt.UTC)
+    with _resolve_workdir(args.workdir) as workdir:
+        outcomes = run_sweep(
+            slugs,
+            workdir=workdir,
+            platform_slug=args.platform_slug,
+            floor=args.min_severity,
+            generated_at=generated_at,
+            runner=runner,
+            sleeper=sleeper,
+            run_url=args.run_url,
+            dry_run=args.dry_run,
+            max_attempts=args.max_attempts,
+        )
+
+    summary = render_summary(outcomes)
+    if args.summary_file:
+        with open(args.summary_file, "a", encoding="utf-8") as handle:
+            handle.write(summary)
+    if args.json_output:
+        print(json.dumps(_json_payload(outcomes, generated_at=generated_at), indent=2, sort_keys=True))
+    else:
+        print(summary, end="")
+
+    incomplete = [outcome for outcome in outcomes if outcome.action in INCOMPLETE_ACTIONS]
+    if incomplete:
+        print(
+            f"INCOMPLETE scheduled-cve-scan: {len(incomplete)} of {len(outcomes)} repo(s) were not fully "
+            "established (scan error or unreconciled issue). This is NOT a clean-fleet result.",
+            file=sys.stderr,
+        )
+        return EXIT_INCOMPLETE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scheduled_cve_scan.py
+++ b/tests/test_scheduled_cve_scan.py
@@ -1,0 +1,1172 @@
+"""Tests for the scheduled fleet-wide dependency-CVE sweep.
+
+``scripts/quality/scheduled_cve_scan.py`` closes a STRUCTURAL gap, not a code
+defect. A dependency advisory is not a function of the code: it is time-varying.
+A PR-diff gate cannot fire without a diff, so a NEW advisory published against
+UNCHANGED code stays invisible until somebody happens to touch that repo. PR
+#286 correctly demoted dev-only / unscored / unfixable findings out of the
+blocking tier - but nothing surfaced the demoted tier, so those findings went
+nowhere at all.
+
+The tests below pin four things the sweep must never get wrong:
+
+1. **The osv-scanner exit-code contract is gate 6's, verbatim.** ``0`` clean,
+   ``1`` findings, ``128`` nothing to scan, ``127``/``129``/``130`` a SCAN
+   ERROR that is *not* a vulnerability verdict. A scan error must never be
+   reported as a clean result, and must never close a tracking issue.
+2. **One issue per repo, updated in place.** An issue-per-run is a notification
+   spammer that gets muted within a week, which defeats the entire purpose.
+3. **T0 / T2 are separated** so a reader can tell "act now" from "for
+   information", reusing the same classifier the gate uses so T0 is a faithful
+   "would block" prediction.
+4. **It is observability, not a gate** - its check context appears in no
+   ruleset's ``required_status_checks``.
+
+BOTH-STATES coverage is explicit throughout: every predicate is fed a
+known-BAD input and asserted non-clean, and a known-GOOD input and asserted
+clean. A gate never seen red is indistinguishable from a no-op.
+"""
+
+from __future__ import absolute_import
+
+import datetime as dt
+import io
+import json
+import subprocess  # nosec B404 — CompletedProcess is used to build fake runner results
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import yaml  # type: ignore[import-untyped]
+from tests.workspace_isolation import isolated_cwd
+
+from scripts.quality import osv_severity_gate as severity
+from scripts.quality import scheduled_cve_scan as sweep
+
+ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = ROOT / "inventory" / "repos.yml"
+WORKFLOW = ROOT / ".github" / "workflows" / "scheduled-cve-scan.yml"
+REUSABLE_QUALITY = ROOT / ".github" / "workflows" / "reusable-quality.yml"
+GENERATED_RULESETS = ROOT / "generated" / "rulesets"
+
+FIXED_NOW = dt.datetime(2026, 8, 11, 5, 41, 0, tzinfo=dt.UTC)
+
+VULNERABLE_REPORT: Dict[str, Any] = {
+    "results": [
+        {
+            "source": {"path": "/repo/package-lock.json", "type": "lockfile"},
+            "packages": [
+                {
+                    "package": {"name": "@angular/common", "version": "17.0.0", "ecosystem": "npm"},
+                    "groups": [{"ids": ["GHSA-jhpw-976m-542j"], "max_severity": "8.8"}],
+                    "vulnerabilities": [
+                        {
+                            "id": "GHSA-jhpw-976m-542j",
+                            "affected": [{"ranges": [{"events": [{"introduced": "0"}, {"fixed": "17.3.12"}]}]}],
+                        }
+                    ],
+                },
+                {
+                    "package": {"name": "brace-expansion", "version": "1.1.11", "ecosystem": "npm"},
+                    "dependency_groups": ["dev"],
+                    "groups": [{"ids": ["GHSA-rgw5-rvv9-x895"], "max_severity": "3.1"}],
+                    "vulnerabilities": [
+                        {
+                            "id": "GHSA-rgw5-rvv9-x895",
+                            "affected": [{"ranges": [{"events": [{"introduced": "0"}, {"fixed": "1.1.12"}]}]}],
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+}
+
+CLEAN_REPORT: Dict[str, Any] = {"results": []}
+
+
+def _completed(
+    args: Sequence[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> "subprocess.CompletedProcess[str]":
+    """Build a ``CompletedProcess`` the way ``subprocess.run`` would."""
+    return subprocess.CompletedProcess(list(args), returncode, stdout, stderr)
+
+
+class FakeRunner:
+    """Records every argv and replays scripted results.
+
+    ``gh repo clone`` genuinely creates the destination directory (and, when
+    ``config_repos`` names the repo, an ``osv-scanner.toml`` inside it) so the
+    module's real filesystem probe for the caller's ignore file is exercised
+    rather than mocked away.
+    """
+
+    def __init__(
+        self,
+        *,
+        osv_results: Optional[List[Tuple[int, str]]] = None,
+        clone_returncode: int = 0,
+        issue_list: Optional[List[Any]] = None,
+        issue_list_returncode: int = 0,
+        create_stdout: str = "https://github.com/Prekzursil/quality-zero-platform/issues/512\n",
+        label_returncode: int = 0,
+        edit_returncode: int = 0,
+        close_returncode: int = 0,
+        config_repos: Sequence[str] = (),
+    ) -> None:
+        """Script the fake ``gh`` / ``osv-scanner`` responses for one test."""
+        self.calls: List[List[str]] = []
+        self.osv_results = list(osv_results or [(0, json.dumps(CLEAN_REPORT))])
+        self.clone_returncode = clone_returncode
+        self.issue_list = issue_list
+        self.issue_list_returncode = issue_list_returncode
+        self.create_stdout = create_stdout
+        self.label_returncode = label_returncode
+        self.edit_returncode = edit_returncode
+        self.close_returncode = close_returncode
+        self.config_repos = set(config_repos)
+        self._osv_index = 0
+
+    def __call__(self, args: Sequence[str], **_kwargs: Any) -> "subprocess.CompletedProcess[str]":
+        """Dispatch on the argv shape, exactly as the real binaries would be."""
+        argv = list(args)
+        self.calls.append(argv)
+        if argv[0] == "osv-scanner":
+            return self._osv(argv)
+        if argv[:3] == ["gh", "repo", "clone"]:
+            return self._clone(argv)
+        if argv[:3] == ["gh", "label", "create"]:
+            return _completed(argv, returncode=self.label_returncode)
+        if argv[:3] == ["gh", "issue", "list"]:
+            payload = json.dumps(self.issue_list) if self.issue_list is not None else "[]"
+            return _completed(argv, returncode=self.issue_list_returncode, stdout=payload)
+        if argv[:3] == ["gh", "issue", "create"]:
+            return _completed(argv, stdout=self.create_stdout)
+        if argv[:3] == ["gh", "issue", "edit"]:
+            return _completed(argv, returncode=self.edit_returncode)
+        if argv[:3] == ["gh", "issue", "close"]:
+            return _completed(argv, returncode=self.close_returncode)
+        raise AssertionError(f"unscripted command: {argv}")  # pragma: no cover — test guard
+
+    def _clone(self, argv: List[str]) -> "subprocess.CompletedProcess[str]":
+        """Create the destination tree so the config probe has something to see."""
+        if self.clone_returncode != 0:
+            return _completed(argv, returncode=self.clone_returncode, stderr="clone failed\n")
+        slug = argv[3]
+        dest = Path(argv[4])
+        dest.mkdir(parents=True, exist_ok=True)
+        if slug in self.config_repos:
+            (dest / "osv-scanner.toml").write_text("[[IgnoredVulns]]\n", encoding="utf-8")
+        return _completed(argv)
+
+    def _osv(self, argv: List[str]) -> "subprocess.CompletedProcess[str]":
+        """Replay the next scripted scan result, holding the last one."""
+        index = min(self._osv_index, len(self.osv_results) - 1)
+        self._osv_index += 1
+        code, stdout = self.osv_results[index]
+        return _completed(argv, returncode=code, stdout=stdout)
+
+    def argv_starting(self, *prefix: str) -> List[List[str]]:
+        """Every recorded argv whose leading tokens match ``prefix``."""
+        size = len(prefix)
+        return [argv for argv in self.calls if argv[:size] == list(prefix)]
+
+
+class NoopSleeper:
+    """Records the requested backoff instead of blocking the test suite."""
+
+    def __init__(self) -> None:
+        """Start with an empty record."""
+        self.slept: List[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        """Record, never sleep."""
+        self.slept.append(seconds)
+
+
+def _scan(status: sweep.ScanStatus, **overrides: Any) -> sweep.RepoScan:
+    """Build a ``RepoScan`` in the given status with sensible defaults."""
+    blocking, demoted = severity.classify(
+        severity.iter_findings(VULNERABLE_REPORT),
+        severity.SEVERITY_FLOOR,
+    )
+    defaults: Dict[str, Any] = {
+        "slug": "Prekzursil/momentstudio",
+        "status": status,
+        "exit_code": 0,
+        "detail": "",
+        "blocking": (),
+        "demoted": (),
+        "attempts": 1,
+        "config_applied": False,
+    }
+    if status is sweep.ScanStatus.FINDINGS:
+        defaults.update({"exit_code": 1, "blocking": tuple(blocking), "demoted": tuple(demoted)})
+    defaults.update(overrides)
+    return sweep.RepoScan(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. The exit-code contract — gate 6's mapping, verbatim, both states.
+# ---------------------------------------------------------------------------
+
+
+class ExitCodeContractTests(unittest.TestCase):
+    """A scan error is never a vulnerability verdict and never a clean result."""
+
+    def test_zero_is_clean(self) -> None:
+        """Exit 0 = the scan completed and found nothing."""
+        status, detail = sweep.classify_exit_code(0)
+        self.assertIs(status, sweep.ScanStatus.CLEAN)
+        self.assertTrue(detail)
+
+    def test_one_is_findings(self) -> None:
+        """Exit 1 is the ONLY vulnerability code."""
+        status, _detail = sweep.classify_exit_code(1)
+        self.assertIs(status, sweep.ScanStatus.FINDINGS)
+
+    def test_one_two_eight_is_nothing_to_scan(self) -> None:
+        """Exit 128 (ErrNoPackagesFound) is not a finding and not an error."""
+        status, _detail = sweep.classify_exit_code(128)
+        self.assertIs(status, sweep.ScanStatus.NOTHING_TO_SCAN)
+
+    def test_scan_error_codes_are_scan_errors(self) -> None:
+        """127 / 129 / 130 each mean the scan did NOT complete."""
+        for code in (127, 129, 130):
+            with self.subTest(code=code):
+                status, detail = sweep.classify_exit_code(code)
+                self.assertIs(status, sweep.ScanStatus.SCAN_ERROR)
+                self.assertTrue(detail, "a scan error must explain itself")
+
+    def test_each_scan_error_code_has_its_own_explanation(self) -> None:
+        """127, 129 and 130 have distinct causes, so distinct detail text."""
+        details = {code: sweep.classify_exit_code(code)[1] for code in (127, 129, 130)}
+        self.assertEqual(len(set(details.values())), 3, details)
+
+    def test_undocumented_code_is_a_scan_error_not_a_finding(self) -> None:
+        """An undocumented exit fails closed as a scan error."""
+        status, detail = sweep.classify_exit_code(42)
+        self.assertIs(status, sweep.ScanStatus.SCAN_ERROR)
+        self.assertIn("42", detail)
+
+    def test_clean_result_predicate_both_states(self) -> None:
+        """BOTH-STATES: only CLEAN / NOTHING_TO_SCAN may clear an issue."""
+        self.assertTrue(sweep.ScanStatus.CLEAN.is_clean_result)
+        self.assertTrue(sweep.ScanStatus.NOTHING_TO_SCAN.is_clean_result)
+        self.assertFalse(sweep.ScanStatus.FINDINGS.is_clean_result)
+        self.assertFalse(sweep.ScanStatus.SCAN_ERROR.is_clean_result)
+
+    def test_retryable_exits_are_the_transient_pair_only(self) -> None:
+        """127/129 are transient; 130 (invalid config) is deterministic."""
+        self.assertTrue(sweep.is_retryable_exit(127))
+        self.assertTrue(sweep.is_retryable_exit(129))
+        self.assertFalse(sweep.is_retryable_exit(130))
+        self.assertFalse(sweep.is_retryable_exit(0))
+        self.assertFalse(sweep.is_retryable_exit(1))
+
+    def test_pinned_version_matches_the_gate(self) -> None:
+        """The sweep and gate 6 must scan with the SAME pinned binary.
+
+        Different versions have different advisory-matching behaviour, so a
+        sweep on another version would predict a "would block" verdict the
+        gate does not actually reach.
+        """
+        text = REUSABLE_QUALITY.read_text(encoding="utf-8")
+        self.assertIn(f"osv-scanner/releases/download/{sweep.OSV_SCANNER_VERSION}/", text)
+
+
+# ---------------------------------------------------------------------------
+# 2. The roster comes from inventory/repos.yml — never a hardcoded list.
+# ---------------------------------------------------------------------------
+
+
+class FleetRosterTests(unittest.TestCase):
+    """The fleet is read from the inventory file, and stays in step with it."""
+
+    def test_reads_every_slug_from_the_real_inventory(self) -> None:
+        """The roster equals the inventory's own slug set, exactly."""
+        declared = {
+            entry["slug"]
+            for entry in yaml.safe_load(INVENTORY.read_text(encoding="utf-8"))["repos"]
+            if entry.get("slug")
+        }
+        self.assertEqual(set(sweep.load_fleet_slugs(INVENTORY)), declared)
+        self.assertGreater(len(declared), 1, "the inventory should hold the whole fleet")
+
+    def test_no_slug_is_hardcoded_in_the_module(self) -> None:
+        """Detector-controlled: a real slug appears in the inventory, not the code."""
+        source = (ROOT / "scripts" / "quality" / "scheduled_cve_scan.py").read_text(encoding="utf-8")
+        inventory_text = INVENTORY.read_text(encoding="utf-8")
+        needle = "Prekzursil/momentstudio"
+        self.assertIn(needle, inventory_text, "detector control: the needle must exist somewhere")
+        self.assertNotIn(needle, source, "repo slugs must come from the inventory, not the source")
+
+    def test_only_filter_narrows_the_roster(self) -> None:
+        """``--only`` accepts a full slug and keeps inventory ordering."""
+        slugs = sweep.load_fleet_slugs(INVENTORY, only=["Prekzursil/momentstudio"])
+        self.assertEqual(slugs, ["Prekzursil/momentstudio"])
+
+    def test_only_filter_accepts_a_bare_repo_name(self) -> None:
+        """Operators type the short name; both forms resolve."""
+        self.assertEqual(sweep.load_fleet_slugs(INVENTORY, only=["momentstudio"]), ["Prekzursil/momentstudio"])
+
+    def test_only_filter_rejects_an_unknown_name(self) -> None:
+        """An unknown ``--only`` value is an error, not a silent empty sweep."""
+        with self.assertRaises(sweep.FleetRosterError):
+            sweep.load_fleet_slugs(INVENTORY, only=["not-a-fleet-repo"])
+
+    def test_blank_only_entries_are_ignored(self) -> None:
+        """An empty dispatch input must not narrow the sweep to nothing."""
+        self.assertEqual(sweep.load_fleet_slugs(INVENTORY, only=["", "  "]), sweep.load_fleet_slugs(INVENTORY))
+
+    def test_missing_inventory_is_an_error(self) -> None:
+        """A missing roster file never degrades to "the fleet is empty"."""
+        with self.assertRaises(sweep.FleetRosterError):
+            sweep.load_fleet_slugs(ROOT / "inventory" / "does-not-exist.yml")
+
+    def test_malformed_inventory_is_an_error(self) -> None:
+        """A roster with no usable slugs is an error, not an empty sweep."""
+        with isolated_cwd() as tmp:
+            path = tmp / "repos.yml"
+            path.write_text("version: 1\nrepos: []\n", encoding="utf-8")
+            with self.assertRaises(sweep.FleetRosterError):
+                sweep.load_fleet_slugs(path)
+
+
+# ---------------------------------------------------------------------------
+# 3. scan_repo — clone, scan, retry, classify.
+# ---------------------------------------------------------------------------
+
+
+class ScanRepoTests(unittest.TestCase):
+    """One repo, end to end, against a scripted ``gh`` + ``osv-scanner``."""
+
+    def _scan(self, runner: FakeRunner, *, sleeper: Optional[NoopSleeper] = None, **kwargs: Any) -> sweep.RepoScan:
+        """Run ``scan_repo`` inside a throwaway workdir."""
+        with isolated_cwd() as tmp:
+            return sweep.scan_repo(
+                "Prekzursil/momentstudio",
+                workdir=tmp,
+                floor=severity.SEVERITY_FLOOR,
+                runner=runner,
+                sleeper=sleeper or NoopSleeper(),
+                **kwargs,
+            )
+
+    def test_clean_scan_is_clean(self) -> None:
+        """Exit 0 yields CLEAN with no findings."""
+        scan = self._scan(FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))]))
+        self.assertIs(scan.status, sweep.ScanStatus.CLEAN)
+        self.assertEqual(scan.blocking, ())
+        self.assertEqual(scan.demoted, ())
+
+    def test_findings_are_split_into_t0_and_t2(self) -> None:
+        """Exit 1 re-reads the report and applies the SAME classifier as the gate."""
+        scan = self._scan(FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))]))
+        self.assertIs(scan.status, sweep.ScanStatus.FINDINGS)
+        self.assertEqual([f.package for f in scan.blocking], ["@angular/common"])
+        self.assertEqual([f.package for f in scan.demoted], ["brace-expansion"])
+
+    def test_nothing_to_scan_is_not_a_finding(self) -> None:
+        """Exit 128 on a zero-dependency repo is a pass, not an error."""
+        scan = self._scan(FakeRunner(osv_results=[(128, "")]))
+        self.assertIs(scan.status, sweep.ScanStatus.NOTHING_TO_SCAN)
+
+    def test_clone_failure_is_a_scan_error(self) -> None:
+        """A repo we could not clone was NOT scanned, so it is never clean."""
+        runner = FakeRunner(clone_returncode=1)
+        scan = self._scan(runner)
+        self.assertIs(scan.status, sweep.ScanStatus.SCAN_ERROR)
+        self.assertFalse(scan.status.is_clean_result)
+        self.assertEqual(runner.argv_starting("osv-scanner"), [], "no scan should be attempted")
+
+    def test_transient_exit_is_retried_then_succeeds(self) -> None:
+        """127 retries with gate 6's ``attempt * 20`` backoff, then passes."""
+        sleeper = NoopSleeper()
+        runner = FakeRunner(osv_results=[(127, ""), (0, json.dumps(CLEAN_REPORT))])
+        scan = self._scan(runner, sleeper=sleeper)
+        self.assertIs(scan.status, sweep.ScanStatus.CLEAN)
+        self.assertEqual(scan.attempts, 2)
+        self.assertEqual(sleeper.slept, [20])
+
+    def test_transient_exit_exhausts_attempts_and_stays_an_error(self) -> None:
+        """Three failures is a scan error - never downgraded to clean."""
+        sleeper = NoopSleeper()
+        runner = FakeRunner(osv_results=[(129, ""), (129, ""), (129, "")])
+        scan = self._scan(runner, sleeper=sleeper)
+        self.assertIs(scan.status, sweep.ScanStatus.SCAN_ERROR)
+        self.assertEqual(scan.attempts, 3)
+        self.assertEqual(sleeper.slept, [20, 40])
+
+    def test_invalid_config_is_not_retried(self) -> None:
+        """130 is deterministic; retrying it only burns runner minutes."""
+        sleeper = NoopSleeper()
+        runner = FakeRunner(osv_results=[(130, "")])
+        scan = self._scan(runner, sleeper=sleeper)
+        self.assertIs(scan.status, sweep.ScanStatus.SCAN_ERROR)
+        self.assertEqual(scan.attempts, 1)
+        self.assertEqual(sleeper.slept, [])
+
+    def test_unparseable_report_on_exit_one_is_a_scan_error(self) -> None:
+        """We could not classify, so we must not claim a verdict either way."""
+        scan = self._scan(FakeRunner(osv_results=[(1, "{not json")]))
+        self.assertIs(scan.status, sweep.ScanStatus.SCAN_ERROR)
+        self.assertIn("could not be parsed", scan.detail)
+
+    def test_callers_ignore_file_is_applied_when_present(self) -> None:
+        """``--config`` mirrors gate 6 so T0 is a faithful would-block prediction."""
+        runner = FakeRunner(
+            osv_results=[(0, json.dumps(CLEAN_REPORT))],
+            config_repos=["Prekzursil/momentstudio"],
+        )
+        scan = self._scan(runner)
+        self.assertTrue(scan.config_applied)
+        argv = runner.argv_starting("osv-scanner")[0]
+        self.assertTrue(any(item.startswith("--config=") for item in argv), argv)
+
+    def test_no_ignore_file_means_no_config_flag(self) -> None:
+        """BOTH-STATES: without the file the flag is absent (osv rejects a missing config)."""
+        runner = FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))])
+        scan = self._scan(runner)
+        self.assertFalse(scan.config_applied)
+        argv = runner.argv_starting("osv-scanner")[0]
+        self.assertFalse(any(item.startswith("--config=") for item in argv), argv)
+
+    def test_scan_is_json_recursive_and_source_scoped(self) -> None:
+        """The scan shape matches gate 6: ``scan source --recursive --format json``."""
+        runner = FakeRunner()
+        self._scan(runner)
+        argv = runner.argv_starting("osv-scanner")[0]
+        self.assertEqual(argv[:3], ["osv-scanner", "scan", "source"])
+        self.assertIn("--recursive", argv)
+        self.assertIn("--format", argv)
+        self.assertIn("json", argv)
+
+    def test_clone_is_shallow_and_single_branch(self) -> None:
+        """A full fleet clone every night is wasted minutes and disk."""
+        runner = FakeRunner()
+        self._scan(runner)
+        argv = runner.argv_starting("gh", "repo", "clone")[0]
+        self.assertIn("--depth=1", argv)
+        self.assertIn("--single-branch", argv)
+
+
+# ---------------------------------------------------------------------------
+# 4. Issue body rendering — the both-states proof.
+# ---------------------------------------------------------------------------
+
+
+class RenderIssueBodyTests(unittest.TestCase):
+    """The body must distinguish act-now from for-information, and states."""
+
+    def _body(self, status: sweep.ScanStatus, **overrides: Any) -> str:
+        """Render a body for the given status."""
+        return sweep.render_issue_body(
+            _scan(status, **overrides),
+            floor=severity.SEVERITY_FLOOR,
+            generated_at=FIXED_NOW,
+        )
+
+    def test_findings_body_separates_t0_from_t2(self) -> None:
+        """T0 names the fix; T2 names the demotion reason."""
+        body = self._body(sweep.ScanStatus.FINDINGS)
+        self.assertIn("T0", body)
+        self.assertIn("T2", body)
+        self.assertIn("@angular/common", body)
+        self.assertIn("fixed in 17.3.12", body)
+        self.assertIn("brace-expansion", body)
+        self.assertIn("dev-only", body)
+
+    def test_findings_body_counts_each_tier(self) -> None:
+        """Counts let a reader triage without reading every row."""
+        body = self._body(sweep.ScanStatus.FINDINGS)
+        self.assertIn("T0 - WOULD BLOCK (1)", body)
+        self.assertIn("T2 - INVENTORY (1)", body)
+
+    def test_body_carries_the_stable_marker_and_pinned_version(self) -> None:
+        """The marker identifies our own body; the version pins the evidence."""
+        body = self._body(sweep.ScanStatus.FINDINGS)
+        self.assertIn(sweep.BODY_MARKER, body)
+        self.assertIn(sweep.OSV_SCANNER_VERSION, body)
+
+    def test_body_is_timestamped_from_the_injected_clock(self) -> None:
+        """Determinism: the timestamp comes from the caller, never ``now()``."""
+        self.assertIn("2026-08-11T05:41:00+00:00", self._body(sweep.ScanStatus.FINDINGS))
+
+    def test_body_states_whether_the_callers_ignore_file_was_applied(self) -> None:
+        """A suppressed finding must not read as an absent finding."""
+        applied = self._body(sweep.ScanStatus.FINDINGS, config_applied=True)
+        absent = self._body(sweep.ScanStatus.FINDINGS, config_applied=False)
+        self.assertIn("osv-scanner.toml", applied)
+        self.assertIn("osv-scanner.toml", absent)
+        self.assertNotEqual(applied, absent)
+
+    def test_body_says_it_is_not_a_gate(self) -> None:
+        """Nobody should mistake this issue for a blocking check."""
+        self.assertIn("not a gate", self._body(sweep.ScanStatus.FINDINGS).lower())
+
+    def test_both_states_findings_body_differs_from_clean_body(self) -> None:
+        """BOTH-STATES PROOF: the two runs cannot render the same body."""
+        findings = self._body(sweep.ScanStatus.FINDINGS)
+        clean = self._body(sweep.ScanStatus.CLEAN)
+        self.assertNotEqual(findings, clean)
+        self.assertIn("@angular/common", findings)
+        self.assertNotIn("@angular/common", clean)
+        self.assertIn("No dependency advisories", clean)
+        self.assertNotIn("No dependency advisories", findings)
+
+    def test_nothing_to_scan_body_says_so_explicitly(self) -> None:
+        """ "No packages" is a different fact from "no advisories"."""
+        body = self._body(sweep.ScanStatus.NOTHING_TO_SCAN)
+        self.assertIn("no dependency manifests", body.lower())
+
+    def test_scan_error_body_never_claims_a_clean_result(self) -> None:
+        """The single most important sentence in the module."""
+        body = self._body(sweep.ScanStatus.SCAN_ERROR, exit_code=129, detail="the OSV.dev API was unreachable")
+        self.assertIn("SCAN ERROR", body)
+        self.assertIn("NOT a vulnerability verdict", body)
+        self.assertIn("not a clean result", body)
+        self.assertIn("the OSV.dev API was unreachable", body)
+
+    def test_run_url_is_linked_when_supplied(self) -> None:
+        """The run that produced the body is the provenance for it."""
+        body = sweep.render_issue_body(
+            _scan(sweep.ScanStatus.FINDINGS),
+            floor=severity.SEVERITY_FLOOR,
+            generated_at=FIXED_NOW,
+            run_url="https://github.com/x/y/actions/runs/1",
+        )
+        self.assertIn("https://github.com/x/y/actions/runs/1", body)
+
+    def test_rows_are_capped_and_the_remainder_is_disclosed(self) -> None:
+        """A 500-finding repo must not produce an unreadable, over-limit body."""
+        packages = [
+            {
+                "package": {"name": f"pkg-{index}", "version": "1.0.0", "ecosystem": "npm"},
+                "dependency_groups": ["dev"],
+                "groups": [{"ids": [f"GHSA-{index}"], "max_severity": "1.0"}],
+                "vulnerabilities": [],
+            }
+            for index in range(sweep.MAX_ROWS_PER_TIER + 3)
+        ]
+        document = {"results": [{"source": {"path": "lock.json"}, "packages": packages}]}
+        blocking, demoted = severity.classify(severity.iter_findings(document), severity.SEVERITY_FLOOR)
+        body = sweep.render_issue_body(
+            _scan(sweep.ScanStatus.FINDINGS, blocking=tuple(blocking), demoted=tuple(demoted)),
+            floor=severity.SEVERITY_FLOOR,
+            generated_at=FIXED_NOW,
+        )
+        self.assertIn("3 more", body)
+
+    def test_body_is_truncated_below_the_github_limit(self) -> None:
+        """GitHub hard-caps an issue body; a rejected update is a silent gap."""
+        body = sweep.render_issue_body(
+            _scan(sweep.ScanStatus.FINDINGS),
+            floor=severity.SEVERITY_FLOOR,
+            generated_at=FIXED_NOW,
+            max_body_chars=200,
+        )
+        self.assertLessEqual(len(body), 200)
+        self.assertIn("truncated", body)
+
+    def test_default_body_cap_is_under_the_github_ceiling(self) -> None:
+        """The shipped cap must be below GitHub's 65536-character limit."""
+        self.assertLess(sweep.MAX_BODY_CHARS, 65536)
+
+
+# ---------------------------------------------------------------------------
+# 5. Reconciliation — one issue per repo, updated in place, closed when clear.
+# ---------------------------------------------------------------------------
+
+
+OPEN_ISSUE = [{"number": 77, "title": "[alert:cve-watch] Prekzursil/momentstudio", "state": "OPEN"}]
+
+
+class ReconcileTests(unittest.TestCase):
+    """The reconciler is the part that must be idempotent and safe to re-run."""
+
+    def _reconcile(self, scan: sweep.RepoScan, runner: FakeRunner, **kwargs: Any) -> sweep.RepoOutcome:
+        """Reconcile one scan against a scripted ``gh``."""
+        return sweep.reconcile(
+            scan,
+            platform_slug="Prekzursil/quality-zero-platform",
+            floor=severity.SEVERITY_FLOOR,
+            generated_at=FIXED_NOW,
+            runner=runner,
+            **kwargs,
+        )
+
+    def test_findings_with_no_existing_issue_creates_one(self) -> None:
+        """First sighting opens the tracking issue."""
+        runner = FakeRunner()
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CREATED)
+        self.assertEqual(outcome.issue_number, 512)
+        self.assertEqual(len(runner.argv_starting("gh", "issue", "create")), 1)
+
+    def test_findings_with_an_existing_issue_updates_in_place(self) -> None:
+        """THE core requirement: update, never open a second issue."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.UPDATED)
+        self.assertEqual(outcome.issue_number, 77)
+        self.assertEqual(runner.argv_starting("gh", "issue", "create"), [])
+        edits = runner.argv_starting("gh", "issue", "edit")
+        self.assertEqual(len(edits), 1)
+        self.assertIn("77", edits[0])
+
+    def test_clean_closes_the_open_issue(self) -> None:
+        """ "Close or clear the issue when findings clear."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.CLEAN), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CLOSED)
+        self.assertEqual(outcome.issue_number, 77)
+        closes = runner.argv_starting("gh", "issue", "close")
+        self.assertEqual(len(closes), 1)
+        self.assertIn("--comment", closes[0])
+
+    def test_clean_with_no_issue_is_a_noop(self) -> None:
+        """A permanently clean repo generates no traffic at all."""
+        runner = FakeRunner()
+        outcome = self._reconcile(_scan(sweep.ScanStatus.CLEAN), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.NOOP)
+        self.assertEqual(runner.argv_starting("gh", "issue", "close"), [])
+
+    def test_nothing_to_scan_also_clears_the_issue(self) -> None:
+        """A repo that lost its manifests has no advisories to track."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.NOTHING_TO_SCAN), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CLOSED)
+
+    def test_scan_error_touches_nothing(self) -> None:
+        """A failed scan must not close, create, or overwrite anything."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(
+            _scan(sweep.ScanStatus.SCAN_ERROR, exit_code=127, detail="resolver outage"),
+            runner,
+        )
+        self.assertIs(outcome.action, sweep.IssueAction.SKIPPED_SCAN_ERROR)
+        self.assertEqual(runner.argv_starting("gh", "issue", "create"), [])
+        self.assertEqual(runner.argv_starting("gh", "issue", "edit"), [])
+        self.assertEqual(runner.argv_starting("gh", "issue", "close"), [])
+
+    def test_label_is_ensured_before_creating(self) -> None:
+        """``gh issue create --label`` fails outright on an unknown label."""
+        runner = FakeRunner()
+        self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        labels = runner.argv_starting("gh", "label", "create")
+        self.assertEqual(len(labels), 1)
+        self.assertIn(sweep.ALERT_LABEL, labels[0])
+        self.assertIn("--force", labels[0])
+
+    def test_label_failure_does_not_abort_the_repo(self) -> None:
+        """A label race is not a reason to lose the finding."""
+        runner = FakeRunner(label_returncode=1)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CREATED)
+
+    def test_dry_run_makes_no_write_call(self) -> None:
+        """Manual dispatch defaults to dry-run; it must be inert."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner, dry_run=True)
+        self.assertIs(outcome.action, sweep.IssueAction.UPDATED)
+        self.assertTrue(outcome.dry_run)
+        self.assertEqual(runner.argv_starting("gh", "issue", "edit"), [])
+        self.assertEqual(runner.argv_starting("gh", "label", "create"), [])
+
+    def test_dry_run_clean_reports_the_close_it_would_make(self) -> None:
+        """Dry-run must still show the clearing action."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE)
+        outcome = self._reconcile(_scan(sweep.ScanStatus.CLEAN), runner, dry_run=True)
+        self.assertIs(outcome.action, sweep.IssueAction.CLOSED)
+        self.assertEqual(runner.argv_starting("gh", "issue", "close"), [])
+
+    def test_dry_run_clean_with_no_issue_is_a_noop(self) -> None:
+        """Nothing open, nothing to clear, nothing to report."""
+        outcome = self._reconcile(_scan(sweep.ScanStatus.CLEAN), FakeRunner(), dry_run=True)
+        self.assertIs(outcome.action, sweep.IssueAction.NOOP)
+
+    def test_issue_lookup_failure_never_creates_a_duplicate(self) -> None:
+        """If we cannot read the issue state we must not guess it."""
+        runner = FakeRunner(issue_list_returncode=1)
+        with self.assertRaises(sweep.GhCommandError):
+            self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertEqual(runner.argv_starting("gh", "issue", "create"), [])
+
+    def test_unparseable_issue_list_is_an_error_not_an_empty_list(self) -> None:
+        """A broken payload must not read as "no issue exists"."""
+        runner = FakeRunner()
+        runner.issue_list = None
+        original = runner.__call__
+
+        def broken(args: Sequence[str], **kwargs: Any) -> "subprocess.CompletedProcess[str]":
+            """Return junk for the issue-list call only."""
+            argv = list(args)
+            if argv[:3] == ["gh", "issue", "list"]:
+                runner.calls.append(argv)
+                return _completed(argv, stdout="{not json")
+            return original(args, **kwargs)
+
+        with self.assertRaises(sweep.GhCommandError):
+            sweep.reconcile(
+                _scan(sweep.ScanStatus.FINDINGS),
+                platform_slug="Prekzursil/quality-zero-platform",
+                floor=severity.SEVERITY_FLOOR,
+                generated_at=FIXED_NOW,
+                runner=broken,
+            )
+
+    def test_non_list_issue_payload_is_an_error(self) -> None:
+        """A JSON object where an array was promised is a broken detector."""
+        runner = FakeRunner(issue_list={"number": 1})
+        with self.assertRaises(sweep.GhCommandError):
+            self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+
+    def test_a_differently_titled_issue_is_not_reused(self) -> None:
+        """Search is fuzzy; the title match must be exact."""
+        runner = FakeRunner(issue_list=[{"number": 5, "title": "[alert:cve-watch] Prekzursil/other", "state": "OPEN"}])
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CREATED)
+
+    def test_non_mapping_issue_entries_are_skipped(self) -> None:
+        """Stray payload members must not crash the sweep."""
+        runner = FakeRunner(
+            issue_list=[
+                "nope",
+                {"number": 77, "title": sweep.issue_title(_scan(sweep.ScanStatus.FINDINGS).slug), "state": "OPEN"},
+            ]
+        )
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.UPDATED)
+
+    def test_create_output_without_a_number_still_reports_created(self) -> None:
+        """A parse miss on the URL must not look like a failure."""
+        runner = FakeRunner(create_stdout="no url here\n")
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertIs(outcome.action, sweep.IssueAction.CREATED)
+        self.assertEqual(outcome.issue_number, 0)
+
+    def test_create_output_empty_still_reports_created(self) -> None:
+        """Empty stdout is tolerated for the same reason."""
+        runner = FakeRunner(create_stdout="")
+        outcome = self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+        self.assertEqual(outcome.issue_number, 0)
+
+    def test_edit_failure_is_reported_as_an_error(self) -> None:
+        """A failed update must not be logged as a successful one."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE, edit_returncode=1)
+        with self.assertRaises(sweep.GhCommandError):
+            self._reconcile(_scan(sweep.ScanStatus.FINDINGS), runner)
+
+    def test_close_failure_is_reported_as_an_error(self) -> None:
+        """Same for a failed clear."""
+        runner = FakeRunner(issue_list=OPEN_ISSUE, close_returncode=1)
+        with self.assertRaises(sweep.GhCommandError):
+            self._reconcile(_scan(sweep.ScanStatus.CLEAN), runner)
+
+    def test_issue_title_is_stable_and_dedupable(self) -> None:
+        """The title IS the dedupe key; it must not drift."""
+        self.assertEqual(
+            sweep.issue_title("Prekzursil/env-inspector"),
+            f"[{sweep.ALERT_LABEL}] Prekzursil/env-inspector",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Sweep + CLI.
+# ---------------------------------------------------------------------------
+
+
+class RunSweepTests(unittest.TestCase):
+    """The whole-fleet loop, including idempotency across two runs."""
+
+    def _sweep(self, slugs: Sequence[str], runner: FakeRunner, **kwargs: Any) -> List[sweep.RepoOutcome]:
+        """Run one sweep in a throwaway workdir."""
+        with isolated_cwd() as tmp:
+            return sweep.run_sweep(
+                slugs,
+                workdir=tmp,
+                platform_slug="Prekzursil/quality-zero-platform",
+                floor=severity.SEVERITY_FLOOR,
+                generated_at=FIXED_NOW,
+                runner=runner,
+                sleeper=NoopSleeper(),
+                **kwargs,
+            )
+
+    def test_every_repo_produces_exactly_one_outcome(self) -> None:
+        """No repo is silently dropped from the sweep."""
+        runner = FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))])
+        outcomes = self._sweep(["Prekzursil/a", "Prekzursil/b", "Prekzursil/c"], runner)
+        self.assertEqual([o.slug for o in outcomes], ["Prekzursil/a", "Prekzursil/b", "Prekzursil/c"])
+
+    def test_a_gh_failure_on_one_repo_does_not_abort_the_others(self) -> None:
+        """A fleet sweep must be resilient per repo."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))], issue_list_returncode=1)
+        outcomes = self._sweep(["Prekzursil/a", "Prekzursil/b"], runner)
+        self.assertEqual([o.action for o in outcomes], [sweep.IssueAction.FAILED, sweep.IssueAction.FAILED])
+        self.assertTrue(all(o.detail for o in outcomes))
+
+    def test_idempotent_across_two_runs(self) -> None:
+        """Re-running with the issue now open UPDATES it; it never duplicates."""
+        first = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        self.assertIs(self._sweep(["Prekzursil/a"], first)[0].action, sweep.IssueAction.CREATED)
+
+        second = FakeRunner(
+            osv_results=[(1, json.dumps(VULNERABLE_REPORT))],
+            issue_list=[{"number": 512, "title": sweep.issue_title("Prekzursil/a"), "state": "OPEN"}],
+        )
+        outcome = self._sweep(["Prekzursil/a"], second)[0]
+        self.assertIs(outcome.action, sweep.IssueAction.UPDATED)
+        self.assertEqual(second.argv_starting("gh", "issue", "create"), [])
+
+    def test_each_repo_is_cloned_into_its_own_directory(self) -> None:
+        """Two repos must not share a working tree."""
+        runner = FakeRunner()
+        self._sweep(["Prekzursil/a", "Prekzursil/b"], runner)
+        destinations = [argv[4] for argv in runner.argv_starting("gh", "repo", "clone")]
+        self.assertEqual(len(set(destinations)), 2, destinations)
+
+    def test_summary_reports_every_status_and_action(self) -> None:
+        """The step summary is the operator's only view of a scheduled run."""
+        outcomes = [
+            sweep.RepoOutcome("Prekzursil/a", sweep.ScanStatus.FINDINGS, sweep.IssueAction.CREATED, 1, "", False),
+            sweep.RepoOutcome("Prekzursil/b", sweep.ScanStatus.CLEAN, sweep.IssueAction.CLOSED, 2, "", False),
+            sweep.RepoOutcome(
+                "Prekzursil/c",
+                sweep.ScanStatus.SCAN_ERROR,
+                sweep.IssueAction.SKIPPED_SCAN_ERROR,
+                0,
+                "resolver outage",
+                False,
+            ),
+        ]
+        text = sweep.render_summary(outcomes)
+        for needle in ("Prekzursil/a", "Prekzursil/b", "Prekzursil/c", "created", "closed", "resolver outage"):
+            self.assertIn(needle, text)
+
+    def test_summary_of_an_empty_sweep_says_so(self) -> None:
+        """An empty table is worse than an explicit zero."""
+        self.assertIn("no repositories", sweep.render_summary([]).lower())
+
+
+class MainTests(unittest.TestCase):
+    """CLI behaviour: exit codes, JSON output, summary file, dry-run."""
+
+    def _run(self, argv: List[str], runner: FakeRunner) -> Tuple[int, str]:
+        """Invoke ``main`` with an injected runner and captured output."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = sweep.main(argv, runner=runner, sleeper=NoopSleeper(), now=FIXED_NOW)
+        return code, out.getvalue() + err.getvalue()
+
+    def test_clean_fleet_exits_zero(self) -> None:
+        """Nothing to report is a successful run."""
+        runner = FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))])
+        with isolated_cwd() as tmp:
+            code, _text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp)],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_OK)
+
+    def test_findings_exit_zero_because_this_is_not_a_gate(self) -> None:
+        """Findings are tracked in an issue, not turned into a red check."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        with isolated_cwd() as tmp:
+            code, text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp)],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_OK)
+        self.assertIn("findings", text)
+
+    def test_scan_error_exits_non_zero(self) -> None:
+        """An incomplete sweep must be visible in the Actions tab."""
+        runner = FakeRunner(osv_results=[(130, "")])
+        with isolated_cwd() as tmp:
+            code, text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp)],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_INCOMPLETE)
+        self.assertIn("scan-error", text)
+
+    def test_gh_failure_exits_non_zero(self) -> None:
+        """A reconcile failure is also an incomplete sweep."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))], issue_list_returncode=1)
+        with isolated_cwd() as tmp:
+            code, _text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp)],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_INCOMPLETE)
+
+    def test_json_output_is_machine_readable(self) -> None:
+        """``--json`` gives the dashboard a stable shape."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        with isolated_cwd() as tmp:
+            _code, text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp), "--json"],
+                runner,
+            )
+        payload = json.loads(text)
+        self.assertEqual(payload["repos"][0]["slug"], "Prekzursil/momentstudio")
+        self.assertEqual(payload["repos"][0]["status"], "findings")
+        self.assertEqual(payload["repos"][0]["t0"], 1)
+        self.assertEqual(payload["repos"][0]["t2"], 1)
+
+    def test_summary_file_is_appended(self) -> None:
+        """The workflow points ``--summary-file`` at ``GITHUB_STEP_SUMMARY``."""
+        runner = FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))])
+        with isolated_cwd() as tmp:
+            summary = tmp / "summary.md"
+            summary.write_text("pre-existing\n", encoding="utf-8")
+            self._run(
+                [
+                    "--inventory",
+                    str(INVENTORY),
+                    "--only",
+                    "momentstudio",
+                    "--workdir",
+                    str(tmp),
+                    "--summary-file",
+                    str(summary),
+                ],
+                runner,
+            )
+            text = summary.read_text(encoding="utf-8")
+        self.assertIn("pre-existing", text)
+        self.assertIn("Prekzursil/momentstudio", text)
+
+    def test_dry_run_makes_no_write_call(self) -> None:
+        """The dispatch default must be inert."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        with isolated_cwd() as tmp:
+            code, _text = self._run(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp), "--dry-run"],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_OK)
+        self.assertEqual(runner.argv_starting("gh", "issue", "create"), [])
+
+    def test_bad_only_value_exits_with_the_config_code(self) -> None:
+        """A typo in the dispatch input fails loudly, not silently empty."""
+        runner = FakeRunner()
+        code, text = self._run(["--inventory", str(INVENTORY), "--only", "nope"], runner)
+        self.assertEqual(code, sweep.EXIT_CONFIG_ERROR)
+        self.assertIn("nope", text)
+
+    def test_workdir_defaults_to_a_temporary_directory(self) -> None:
+        """Omitting ``--workdir`` must not write clones into the repo."""
+        runner = FakeRunner(osv_results=[(0, json.dumps(CLEAN_REPORT))])
+        with isolated_cwd() as tmp:
+            code, _text = self._run(["--inventory", str(INVENTORY), "--only", "momentstudio"], runner)
+            self.assertEqual(sorted(p.name for p in tmp.iterdir()), [])
+        self.assertEqual(code, sweep.EXIT_OK)
+
+    def test_min_severity_override_moves_the_t0_boundary(self) -> None:
+        """The floor is configurable, and the body reflects the value used."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        with isolated_cwd() as tmp:
+            _code, text = self._run(
+                [
+                    "--inventory",
+                    str(INVENTORY),
+                    "--only",
+                    "momentstudio",
+                    "--workdir",
+                    str(tmp),
+                    "--min-severity",
+                    "2.0",
+                    "--json",
+                ],
+                runner,
+            )
+        payload = json.loads(text)
+        self.assertEqual(payload["repos"][0]["t0"], 1)
+        self.assertEqual(payload["repos"][0]["t2"], 1)
+
+    def test_run_url_flows_into_the_issue_body(self) -> None:
+        """Provenance survives the CLI boundary."""
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        with isolated_cwd() as tmp:
+            self._run(
+                [
+                    "--inventory",
+                    str(INVENTORY),
+                    "--only",
+                    "momentstudio",
+                    "--workdir",
+                    str(tmp),
+                    "--run-url",
+                    "https://example.invalid/run/9",
+                ],
+                runner,
+            )
+        create = runner.argv_starting("gh", "issue", "create")[0]
+        self.assertTrue(any("https://example.invalid/run/9" in item for item in create), create)
+
+    def test_max_attempts_is_configurable(self) -> None:
+        """A long upstream outage should not burn nine scans per repo."""
+        runner = FakeRunner(osv_results=[(127, "")])
+        with isolated_cwd() as tmp:
+            code, _text = self._run(
+                [
+                    "--inventory",
+                    str(INVENTORY),
+                    "--only",
+                    "momentstudio",
+                    "--workdir",
+                    str(tmp),
+                    "--max-attempts",
+                    "1",
+                ],
+                runner,
+            )
+        self.assertEqual(code, sweep.EXIT_INCOMPLETE)
+        self.assertEqual(len(runner.argv_starting("osv-scanner")), 1)
+
+    def test_default_clock_is_used_when_no_timestamp_is_injected(self) -> None:
+        """Coverage cannot see inside a ternary, so exercise it explicitly.
+
+        Every other test injects ``now`` for determinism, which would leave the
+        production default (``datetime.now(UTC)``) unexecuted behind a green
+        100% report - a coverage blind spot, not a covered path.
+        """
+        runner = FakeRunner(osv_results=[(1, json.dumps(VULNERABLE_REPORT))])
+        before = dt.datetime.now(dt.UTC)
+        out = io.StringIO()
+        with isolated_cwd() as tmp, redirect_stdout(out), redirect_stderr(io.StringIO()):
+            code = sweep.main(
+                ["--inventory", str(INVENTORY), "--only", "momentstudio", "--workdir", str(tmp), "--json"],
+                runner=runner,
+                sleeper=NoopSleeper(),
+            )
+        after = dt.datetime.now(dt.UTC)
+        self.assertEqual(code, sweep.EXIT_OK)
+        stamped = dt.datetime.fromisoformat(json.loads(out.getvalue())["generated_at"])
+        self.assertLessEqual(before, stamped)
+        self.assertLessEqual(stamped, after)
+
+
+class IssueNumberParsingTests(unittest.TestCase):
+    """The two number parsers, including the shapes coverage cannot branch on."""
+
+    def test_integer_number_is_read(self) -> None:
+        """The normal ``gh issue list`` shape."""
+        self.assertEqual(sweep._issue_number({"number": 77}), 77)
+
+    def test_non_integer_number_falls_back_to_zero(self) -> None:
+        """A malformed record must not crash a whole-fleet sweep."""
+        self.assertEqual(sweep._issue_number({"number": "77"}), 0)
+        self.assertEqual(sweep._issue_number({}), 0)
+
+    def test_create_url_number_is_parsed(self) -> None:
+        """``gh issue create`` prints the URL; the tail is the number."""
+        self.assertEqual(sweep._issue_number_from_url("https://github.com/o/r/issues/91\n"), 91)
+
+    def test_unparseable_create_output_is_zero(self) -> None:
+        """A parse miss is reported as 0, never as a failure."""
+        self.assertEqual(sweep._issue_number_from_url("no url"), 0)
+        self.assertEqual(sweep._issue_number_from_url(""), 0)
+
+
+# ---------------------------------------------------------------------------
+# 7. Workflow contract — scheduled, safe, and NOT a gate.
+# ---------------------------------------------------------------------------
+
+
+class ScheduledCveScanWorkflowTests(unittest.TestCase):
+    """Invariants on ``.github/workflows/scheduled-cve-scan.yml``."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Parse the workflow once per class."""
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.text)
+
+    def test_runs_on_a_cron_and_on_manual_dispatch(self) -> None:
+        """The whole point is that it fires with no developer action."""
+        on_block = self.doc[True]
+        self.assertIn("schedule", on_block)
+        self.assertIn("workflow_dispatch", on_block)
+        self.assertTrue(str(on_block["schedule"][0]["cron"]).strip())
+
+    def test_it_is_not_triggered_by_pull_request_or_push(self) -> None:
+        """A standing surface must not become a per-PR gate by accident."""
+        on_block = self.doc[True]
+        for event in ("pull_request", "pull_request_target", "push", "merge_group"):
+            self.assertNotIn(event, on_block)
+
+    def test_dry_run_defaults_to_true_on_dispatch(self) -> None:
+        """House convention: a manual run never fires ``gh`` by accident."""
+        inputs = self.doc[True]["workflow_dispatch"]["inputs"]
+        self.assertTrue(inputs["dry_run"]["default"])
+
+    def test_concurrency_group_is_a_fixed_string(self) -> None:
+        """Overlapping crons must merge, not race on the same issues."""
+        self.assertEqual(self.doc["concurrency"]["group"], "scheduled-cve-scan")
+        self.assertFalse(self.doc["concurrency"]["cancel-in-progress"])
+
+    def test_permissions_are_narrow(self) -> None:
+        """Top-level empty; the job gets contents:read + issues:write only."""
+        self.assertEqual(self.doc.get("permissions"), {})
+        perms = self.doc["jobs"]["sweep"]["permissions"]
+        self.assertEqual(perms, {"contents": "read", "issues": "write"})
+
+    def test_checkout_does_not_persist_credentials(self) -> None:
+        """CodeQL safety, and the sweep clones other repos explicitly."""
+        steps = self.doc["jobs"]["sweep"]["steps"]
+        checkouts = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout")]
+        self.assertEqual(len(checkouts), 1)
+        self.assertIs(checkouts[0]["with"]["persist-credentials"], False)
+
+    def test_osv_scanner_is_pinned_to_the_gate_version(self) -> None:
+        """Same binary as gate 6 - a T0 prediction from another version is noise."""
+        self.assertIn(f"osv-scanner/releases/download/{sweep.OSV_SCANNER_VERSION}/", self.text)
+
+    def test_no_github_expression_is_spliced_into_a_run_block(self) -> None:
+        """Every dispatch input arrives through ``env:`` (CWE-78)."""
+        for step in self.doc["jobs"]["sweep"]["steps"]:
+            run = step.get("run")
+            if not run:
+                continue
+            with self.subTest(step=step.get("name")):
+                self.assertNotIn("${{ inputs.", run)
+                self.assertNotIn("${{ github.", run)
+                self.assertNotIn("${{ secrets.", run)
+
+    def test_it_invokes_the_swept_module_and_not_an_inline_reimplementation(self) -> None:
+        """The tested code is the code that runs."""
+        self.assertIn("scripts.quality.scheduled_cve_scan", self.text)
+        self.assertNotIn("python - <<'PY'", self.text)
+
+    def test_it_passes_the_inventory_rather_than_a_repo_list(self) -> None:
+        """ "Read the fleet from inventory/repos.yml" - mechanically checked."""
+        self.assertIn("inventory/repos.yml", self.text)
+
+    def test_it_is_not_a_required_status_check_anywhere_in_the_fleet(self) -> None:
+        """Observability, not a gate. Detector-controlled against a real context."""
+        contexts = set()
+        for path in sorted(GENERATED_RULESETS.glob("*.json")):
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            for rule in payload.get("rules", []):
+                if rule.get("type") != "required_status_checks":
+                    continue
+                for check in rule.get("parameters", {}).get("required_status_checks", []):
+                    contexts.add(str(check.get("context", "")))
+        self.assertIn("codeql / CodeQL", contexts, "detector control: a known required context must be found")
+        job_name = str(self.doc["jobs"]["sweep"].get("name") or "sweep")
+        for context in contexts:
+            self.assertNotIn(job_name, context)
+            self.assertNotIn(str(self.doc["name"]), context)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## The structural gap

A dependency advisory is **not a function of the code** — it is time-varying. Every other lean-gate lane is safely a PR-diff gate because no diff means no new finding. Gate 6 is not, because the advisory feed refreshes while the tree stands still.

Measured 2026-08-11 on DevExtreme's **unchanged** `go 1.25.11` directive: the CI run of 2026-07-25 reported **one** Go stdlib advisory; the identical scan with the identical pinned binary reported **two**. The finding set grew 100% with zero code change. Pinning the *tool* does not pin the *data*.

Two consequences follow. #286 handled the first — a per-PR gate must apply a severity floor or it is non-convergent by construction. This PR is the second, and it closes two holes at once:

1. **A PR-diff gate cannot fire without a diff**, so a new advisory published against unchanged code stays invisible until somebody happens to touch that repo.
2. **#286 demoted dev-only / unscored / unfixable findings to T2 — and nothing surfaced T2**, so those findings went nowhere at all.

## What this adds

| | |
|---|---|
| `scripts/quality/scheduled_cve_scan.py` | Reads the roster from `inventory/repos.yml`, shallow-clones each repo, scans with the **same pinned `osv-scanner v2.3.8` gate 6 downloads**, splits the report with the **same `osv_severity_gate` classifier**. |
| `.github/workflows/scheduled-cve-scan.yml` | Daily at 05:41 UTC, plus `workflow_dispatch` with `dry_run` defaulting to `true` and an `only` filter. |

Because it reuses the gate's binary *and* the gate's classifier, **T0 is a faithful "this would block a PR today" prediction** rather than a second opinion, and **T2 is the inventory nothing else was showing**.

Findings land in **one `alert:cve-watch` issue per repo, updated in place**, closed when the findings clear. An issue-per-run is a notification spammer that gets muted inside a week, which would defeat the entire purpose.

## The honesty contract

Exit codes are gate 6's, verbatim — `0` clean, `1` findings, `128` nothing to scan, `127`/`129`/`130` a **scan error that is not a vulnerability verdict**.

On a scan error the sweep **touches nothing**: no create, no update, and above all **no close**. An incomplete scan is not evidence of a clean tree, so it must never clear a real finding. The run exits non-zero so an incomplete sweep is visible in the Actions tab. **Findings alone exit 0** — turning a fresh upstream advisory into a red check is the exact treadmill the tiering exists to end.

## Deliberately NOT a required status check

Its value is that it can report freely without reddening anybody's branch, which is precisely what lets it show the T2 tier honestly. `test_it_is_not_a_required_status_check_anywhere_in_the_fleet` asserts its name appears in no `generated/rulesets/*.json` `required_status_checks`, with a detector control confirming the probe *does* find a real required context (`codeql / CodeQL`) — so a zero there is a measurement, not a broken matcher.

## Verification

**`bash scripts/verify` → exit 0**, `Ran 1719 tests`, `OK (skipped=1)`, `TOTAL … 100.00%` (2634 stmts / 704 branches), working tree clean. Baseline on `3009dca` was 1622 tests; the delta is exactly the 97 added here, and the new module is at 100% line+branch on its own.

**BOTH-STATES against the real binary.** Local `osv-scanner` is *exactly* the pinned 2.3.8, so the exit-code contract was checked against the binary rather than only against the test double:

| tree | real exit | mapped status | counts as clean? |
|---|---|---|---|
| vulnerable (`urllib3==1.26.4`, `jinja2==2.11.2`) | `1` | `findings` — 7 T0 / 7 T2 from the real report | no |
| no manifests | `128` | `nothing-to-scan` | yes |
| broken `osv-scanner.toml` | `127` | `scan-error` | **no** |
| current pin | `0` | `clean` | yes |

Note the third row: a **malformed** config surfaced as `127`, **not** `130`. That is recorded inline in the module and is exactly why the whole `{127,129,130}` set maps to `SCAN_ERROR` instead of the code branching on `130`. Whether `130` is reserved for a config that parses but is semantically invalid is tagged **UNVERIFIED** with the settling experiment named.

**BOTH-STATES on the issue body** — `render_issue_body` for a findings run and a no-findings run must differ, and each must carry text the other cannot.

**Mutation check: 10/10 killed.** Retrying the deterministic `130`; letting a scan error count as clean; dropping the scan-error early return; unpinning the scanner version; mapping `127` to clean; swallowing a `gh` lookup failure; creating instead of updating; rendering identical bodies for both states; ignoring the inventory; closing on findings. No survivors — the suite protects the behaviour rather than merely executing it.

**Other gates.** `ruff check .` + `ruff format --check .` clean at the CI-pinned `0.15.17`, verified against the **stored blob** via `git cat-file -p` (not the CRLF working tree, and not `git archive`, which re-applies EOL conversion on Windows); `.quality/charter_check.sh` PASS; curated SAST 0 findings on the new files, with a detector control proving that ruleset fires (2 findings, exit 1) on a known-bad input.

## Known limitation, stated rather than hidden

The default `GITHUB_TOKEN` is scoped to this repo, so it cannot clone the three private fleet members (`pbinfo-get-unsolved`, `PrimariRo`, `agent-skills-toolchain`). Those are reported as `scan-error` — **never as clean**, which is the correct failure direction. Setting the optional, already-conventional `CODEX_FLEET_READ_PAT` (Contents: Read across the fleet) closes the gap. **No credential is created, rotated or modified by this PR.**

## Scope

No git tag was moved, created or deleted — **`v1` is untouched**, so nothing here changes what the fleet executes today. Nothing is merged; this is a proposal.
