### PR TITLE
feat(gates): complexity + duplication decision modules (T1 new-code-only) — NOT YET WIRED

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ source = [
   # 100%-covered here — the workflow copy is byte-identical by contract test.
   "scripts.quality.osv_severity_gate",
   "scripts.quality.jsts_coverage_assert",
+  "scripts.quality.complexity_gate",
 ]
 branch = true
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ source = [
   "scripts.quality.osv_severity_gate",
   "scripts.quality.jsts_coverage_assert",
   "scripts.quality.complexity_gate",
+  "scripts.quality.duplication_gate",
 ]
 branch = true
 omit = [

--- a/scripts/quality/complexity_gate.py
+++ b/scripts/quality/complexity_gate.py
@@ -367,6 +367,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"ERROR gate-complexity: {exc}", file=sys.stderr)
         return EXIT_CONFIG_ERROR
     report = parse_lizard_csv(csv_text, args.root)
+    # Whether this run is scoped to new code at all. A missing --diff is a legitimate
+    # unscoped run (a push to the default branch, a merge group): there is no base to
+    # diff against, so the gate emits the T2 inventory and blocks nothing. It is NOT the
+    # same as a supplied-but-empty diff, which is scoped and simply added no lines --
+    # load_added_ranges already raises rather than degrading a broken --diff to "no
+    # scope", because that would turn a misinvocation into a permanent pass.
+    scoped = args.diff is not None
     verdict = classify(report.functions, added_ranges, max_ccn, scoped)
     print(render_report(report, verdict, max_ccn))
     if verdict.blocking:

--- a/scripts/quality/complexity_gate.py
+++ b/scripts/quality/complexity_gate.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Gate 7 - cyclomatic complexity, scoped to NEW CODE ONLY (T1).
+
+``lizard`` measures every function in the tree. A gate that blocked on all of
+them would be unreachable on any repo with history: it would demand the owner
+refactor code the change never touched, which is the treadmill the lean charter
+exists to escape. So this module splits lizard's report into two tiers:
+
+* **BLOCK (T1)** - the change added or modified lines *inside* the function's own
+  span AND its CCN is over the bar. New complexity cannot be merged.
+* **T2 inventory** - every other over-threshold function. PRINTED in full,
+  never blocking. Legacy debt is made visible, not enforced.
+
+The scope is LINE-level, not file-level, and that distinction is the whole
+design. Touching one line of a 900-line legacy module must not summon every
+knot in it. ``tests/fixtures/newcode/`` pins the case that proves it:
+``src/legacy_knot.py`` IS a changed file, but the only hunk adds lines 48-52
+while the CCN=21 ``classify`` occupies lines 4-42 - so ``classify`` is T2 and
+the newly-added ``Knot`` (CCN=18) blocks.
+
+**"New" is defined by the diff, never by a time window.** SonarQube Cloud's
+"number of days" new-code period lets an unfixed finding age into legacy on day
+31, so the gate goes green with the defect still in the code - a decay function
+wearing a gate's clothes. The only accepted scope input here is a unified diff.
+
+Threshold. The default is **CCN 15**: it is lizard's own ``-C`` default, so a
+developer running ``lizard`` locally sees the same verdict CI does, and it is
+already the value in the estate's tool-routing table (``lizard -C 15``).
+McCabe's 1976 paper proposed 10; NIST 500-235 endorses 10 while explicitly
+allowing a limit up to 15 for well-tested code. 15 is therefore the lenient end
+of the defensible range - deliberately so, because this gate BLOCKS, and a
+blocking bar should be one nobody can argue is arbitrary. Tighten per-repo via
+``--max-ccn`` if desired; it is rejected outside 1..100 so neither a
+block-everything 0 nor a switched-off 10000 is expressible.
+
+When no diff is supplied (a push to ``main``, a merge group - there is no base to
+diff against) the gate emits the T2 inventory and **passes**. It never blocks
+without a scope.
+
+Exit codes: ``0`` nothing new is over the bar, ``1`` new code is over the bar,
+``2`` the input or the threshold itself is unusable (never a silent pass).
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import csv
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+DEFAULT_MAX_CCN = 15
+MIN_ACCEPTED_CCN = 1
+MAX_ACCEPTED_CCN = 100
+
+EXIT_OK = 0
+EXIT_BLOCKED = 1
+EXIT_CONFIG_ERROR = 2
+
+#: ``lizard --csv`` emits no header. Column order, verified against recorded output:
+#: NLOC, CCN, token_count, param_count, length, name@start-end@file, file,
+#: function, signature, start, end
+LIZARD_COLUMNS = 11
+_CCN_INDEX = 1
+_FILE_INDEX = 6
+_NAME_INDEX = 7
+_START_INDEX = 9
+_END_INDEX = 10
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+#: file -> the line ranges this change added or modified, 1-based and inclusive.
+AddedRanges = Dict[str, List[Tuple[int, int]]]
+
+
+class ThresholdError(ValueError):
+    """The ``--max-ccn`` argument cannot be read as a usable bar."""
+
+
+@dataclass(frozen=True)
+class FunctionMetric:
+    """One function, as lizard measured it."""
+
+    path: str
+    name: str
+    ccn: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class LizardReport:
+    """A parsed lizard report, plus how much of it could not be read."""
+
+    functions: List[FunctionMetric]
+    skipped_rows: int
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The tiering decision for one report."""
+
+    blocking: List[FunctionMetric]
+    inventory: List[FunctionMetric]
+    scoped: bool
+
+
+def normalize_path(raw: str, root: Optional[str] = None) -> str:
+    """Collapse any recorded path convention to one repo-relative POSIX form.
+
+    lizard records ``.\\src\\x.py`` on Windows and ``./src/x.py`` on Linux, and
+    can emit absolute paths depending on how it is invoked. The diff always
+    speaks repo-relative POSIX, so every path must be reduced to that or the
+    per-file lookup silently misses and the gate fails OPEN.
+    """
+    text = raw.strip().strip('"').replace("\\", "/")
+    if root:
+        prefix = root.replace("\\", "/").rstrip("/") + "/"
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    while text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def parse_lizard_csv(text: str, root: Optional[str] = None) -> LizardReport:
+    """Parse ``lizard --csv`` output.
+
+    Unreadable rows are COUNTED rather than dropped: a partially-parsed report
+    that reads as clean is the exact shape of a silent pass, so the count is
+    surfaced in the rendered output.
+    """
+    functions: List[FunctionMetric] = []
+    skipped = 0
+    for row in csv.reader(text.splitlines()):
+        if not row:
+            continue
+        if len(row) < LIZARD_COLUMNS:
+            skipped += 1
+            continue
+        try:
+            ccn = int(row[_CCN_INDEX])
+            start = int(row[_START_INDEX])
+            end = int(row[_END_INDEX])
+        except ValueError:
+            skipped += 1
+            continue
+        functions.append(
+            FunctionMetric(
+                path=normalize_path(row[_FILE_INDEX], root),
+                name=row[_NAME_INDEX],
+                ccn=ccn,
+                start=start,
+                end=end,
+            )
+        )
+    return LizardReport(functions=functions, skipped_rows=skipped)
+
+
+def _header_target(line: str) -> Optional[str]:
+    """Return the new-side path of a ``+++`` header, or ``None`` for a deletion."""
+    target = line[4:].split("\t")[0].strip()
+    if target == "/dev/null":
+        return None
+    if target.startswith("b/"):
+        target = target[2:]
+    return normalize_path(target)
+
+
+def parse_added_ranges(diff_text: str) -> AddedRanges:
+    """Extract the added/modified line ranges of a unified diff, per file.
+
+    Only the NEW side matters: a range is what the change put in the tree. A
+    pure-deletion hunk (``+40,0``) contributes nothing, and a deleted file
+    (``+++ /dev/null``) has no new side at all.
+
+    A ``+++`` line only counts as a file header when it directly follows a
+    ``---`` one. Adding a source line whose own text begins ``++ `` renders as
+    ``+++ ...`` inside a hunk body, and treating that as a header would
+    silently retarget every range that followed it.
+    """
+    ranges: AddedRanges = {}
+    current: Optional[str] = None
+    previous_was_old_header = False
+    for line in diff_text.splitlines():
+        if line.startswith("--- "):
+            previous_was_old_header = True
+            continue
+        if previous_was_old_header and line.startswith("+++ "):
+            previous_was_old_header = False
+            current = _header_target(line)
+            continue
+        previous_was_old_header = False
+        if not line.startswith("@@"):
+            continue
+        match = _HUNK.match(line)
+        if match is None or current is None:
+            continue
+        start = int(match.group(1))
+        count = 1 if match.group(2) is None else int(match.group(2))
+        if count <= 0:
+            continue
+        ranges.setdefault(current, []).append((start, start + count - 1))
+    return ranges
+
+
+def touches(function: FunctionMetric, added_ranges: AddedRanges) -> bool:
+    """Return whether the change added or modified a line inside this function."""
+    return any(function.start <= high and low <= function.end for low, high in added_ranges.get(function.path, ()))
+
+
+def classify(
+    functions: Sequence[FunctionMetric],
+    added_ranges: AddedRanges,
+    max_ccn: int,
+    scoped: bool,
+) -> Verdict:
+    """Split the over-threshold functions into the blocking set and the T2 set."""
+    blocking: List[FunctionMetric] = []
+    inventory: List[FunctionMetric] = []
+    for function in functions:
+        if function.ccn <= max_ccn:
+            continue
+        if scoped and touches(function, added_ranges):
+            blocking.append(function)
+        else:
+            inventory.append(function)
+    return Verdict(blocking=blocking, inventory=inventory, scoped=scoped)
+
+
+def _row(function: FunctionMetric) -> str:
+    """Render one function as an actionable line: where, what, how bad."""
+    return f"  {function.path}:{function.start}-{function.end}  {function.name}  CCN={function.ccn}"
+
+
+def render_report(report: LizardReport, verdict: Verdict, max_ccn: int) -> str:
+    """Render the full verdict, T2 included.
+
+    The demoted set is printed unconditionally. A gate that hides what it chose
+    not to enforce is indistinguishable from one that found nothing.
+    """
+    over = len(verdict.blocking) + len(verdict.inventory)
+    lines = [
+        f"complexity: {len(report.functions)} function(s) measured, {over} over the bar (lizard CCN <= {max_ccn})."
+    ]
+    if report.skipped_rows:
+        lines.append(
+            f"WARNING gate-complexity: {report.skipped_rows} unreadable row(s) in the lizard report were "
+            "not measured. The report is incomplete, so treat this run as partial."
+        )
+    if verdict.scoped:
+        lines.append("scope: lines this change added or modified (T1 new-code-only).")
+    else:
+        lines.append("scope: whole repo, no diff base - inventory only, nothing can block.")
+    if verdict.blocking:
+        lines.append(f"BLOCKING ({len(verdict.blocking)}) - new or changed lines inside an over-the-bar function:")
+        lines.extend(_row(function) for function in verdict.blocking)
+    if verdict.inventory:
+        lines.append(
+            f"T2 INVENTORY ({len(verdict.inventory)}) - pre-existing complexity on lines this change did not "
+            "touch; visible and tracked, deliberately NOT blocking:"
+        )
+        lines.extend(_row(function) for function in verdict.inventory)
+    return "\n".join(lines)
+
+
+def parse_max_ccn(raw: str) -> int:
+    """Validate the CCN bar, rejecting anything that would neuter the gate."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ThresholdError(f"--max-ccn must be a whole number, got {raw!r}") from None
+    if value < MIN_ACCEPTED_CCN or value > MAX_ACCEPTED_CCN:
+        raise ThresholdError(
+            f"--max-ccn must be between {MIN_ACCEPTED_CCN} and {MAX_ACCEPTED_CCN}, got {value}. "
+            "A bar below 1 blocks every function; one above the ceiling switches the gate off."
+        )
+    return value
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI."""
+    parser = argparse.ArgumentParser(description="Gate 7: block NEW code whose cyclomatic complexity is over the bar.")
+    parser.add_argument("--csv", required=True, help="path to a `lizard --csv` report")
+    parser.add_argument(
+        "--diff",
+        default=None,
+        help="path to the unified diff defining new code; omit to emit T2 inventory and pass",
+    )
+    parser.add_argument("--max-ccn", default=str(DEFAULT_MAX_CCN), help=f"CCN bar (default {DEFAULT_MAX_CCN})")
+    parser.add_argument("--root", default=None, help="repo root, to relativize absolute paths in the report")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the gate; see the module docstring for the exit-code contract."""
+    args = _build_parser().parse_args(argv)
+    try:
+        max_ccn = parse_max_ccn(args.max_ccn)
+    except ThresholdError as exc:
+        print(f"ERROR gate-complexity: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+    try:
+        csv_text = Path(args.csv).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"ERROR gate-complexity: cannot read the lizard report {args.csv!r} ({exc}). "
+            "An unmeasured tree is not a clean tree, so this is an error rather than a pass.",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG_ERROR
+    added_ranges: AddedRanges = {}
+    scoped = args.diff is not None
+    if scoped:
+        try:
+            diff_text = Path(args.diff).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"ERROR gate-complexity: cannot read the diff {args.diff!r} ({exc}). "
+                "The caller promised a new-code scope, so an unreadable diff is an error, not 'no scope'.",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        added_ranges = parse_added_ranges(diff_text)
+    report = parse_lizard_csv(csv_text, args.root)
+    verdict = classify(report.functions, added_ranges, max_ccn, scoped)
+    print(render_report(report, verdict, max_ccn))
+    if verdict.blocking:
+        print(
+            f"FAIL gate-complexity: {len(verdict.blocking)} function(s) this change wrote or edited exceed "
+            f"CCN {max_ccn}. Split them, or raise the bar deliberately in the workflow.",
+            file=sys.stderr,
+        )
+        return EXIT_BLOCKED
+    print(
+        f"PASS gate-complexity: 0 new function(s) over CCN {max_ccn}; "
+        f"{len(verdict.inventory)} demoted to T2 inventory (listed above)."
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality/complexity_gate.py
+++ b/scripts/quality/complexity_gate.py
@@ -69,11 +69,6 @@ _NAME_INDEX = 7
 _START_INDEX = 9
 _END_INDEX = 10
 
-_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
-
-#: file -> the line ranges this change added or modified, 1-based and inclusive.
-AddedRanges = Dict[str, List[Tuple[int, int]]]
-
 
 class ThresholdError(ValueError):
     """The ``--max-ccn`` argument cannot be read as a usable bar."""
@@ -107,11 +102,36 @@ class Verdict:
     scoped: bool
 
 
+# jscpd:ignore-start
+# ─── SHARED NEW-CODE SCOPING ────────────────────────────────────────────────
+# This block is BYTE-IDENTICAL in complexity_gate.py and duplication_gate.py,
+# and tests/test_newcode_scope_parity.py fails if the two ever diverge.
+#
+# Why it is duplicated rather than imported: both modules are embedded verbatim
+# into .github/workflows/reusable-quality.yml and run as standalone scripts in a
+# CALLER's checkout, which has no `scripts/` tree. Neither can import the other,
+# and neither can import a third shared module. Duplication is only safe when
+# drift is impossible - the same argument test_lean_gate_embedded_helpers.py
+# already makes for the embedded workflow copies.
+#
+# The jscpd markers suppress gate 8 on this one block. They are INLINE and
+# therefore visible in review, deliberately not a .jscpd.json exclusion: a
+# config-file suppression is invisible in a diff, and a suppressed finding has
+# to stay countable (see the qlty `[[triage]]` trap - suppress-at-generation
+# makes a dirty dashboard pixel-identical to a clean one).
+
+#: file -> the line ranges this change added or modified, 1-based and inclusive.
+AddedRanges = Dict[str, List[Tuple[int, int]]]
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
 def normalize_path(raw: str, root: Optional[str] = None) -> str:
     """Collapse any recorded path convention to one repo-relative POSIX form.
 
-    lizard records ``.\\src\\x.py`` on Windows and ``./src/x.py`` on Linux, and
-    can emit absolute paths depending on how it is invoked. The diff always
+    The reporting tools disagree with each other and with git. lizard records
+    ``.\\src\\x.py`` on Windows and ``./src/x.py`` on Linux; jscpd records
+    ``src\\x.py``, or an absolute path under ``--absolute``. The diff always
     speaks repo-relative POSIX, so every path must be reduced to that or the
     per-file lookup silently misses and the gate fails OPEN.
     """
@@ -123,40 +143,6 @@ def normalize_path(raw: str, root: Optional[str] = None) -> str:
     while text.startswith("./"):
         text = text[2:]
     return text
-
-
-def parse_lizard_csv(text: str, root: Optional[str] = None) -> LizardReport:
-    """Parse ``lizard --csv`` output.
-
-    Unreadable rows are COUNTED rather than dropped: a partially-parsed report
-    that reads as clean is the exact shape of a silent pass, so the count is
-    surfaced in the rendered output.
-    """
-    functions: List[FunctionMetric] = []
-    skipped = 0
-    for row in csv.reader(text.splitlines()):
-        if not row:
-            continue
-        if len(row) < LIZARD_COLUMNS:
-            skipped += 1
-            continue
-        try:
-            ccn = int(row[_CCN_INDEX])
-            start = int(row[_START_INDEX])
-            end = int(row[_END_INDEX])
-        except ValueError:
-            skipped += 1
-            continue
-        functions.append(
-            FunctionMetric(
-                path=normalize_path(row[_FILE_INDEX], root),
-                name=row[_NAME_INDEX],
-                ccn=ccn,
-                start=start,
-                end=end,
-            )
-        )
-    return LizardReport(functions=functions, skipped_rows=skipped)
 
 
 def _header_target(line: str) -> Optional[str]:
@@ -206,9 +192,73 @@ def parse_added_ranges(diff_text: str) -> AddedRanges:
     return ranges
 
 
-def touches(function: FunctionMetric, added_ranges: AddedRanges) -> bool:
-    """Return whether the change added or modified a line inside this function."""
-    return any(function.start <= high and low <= function.end for low, high in added_ranges.get(function.path, ()))
+def spans_overlap(path: str, start: int, end: int, added_ranges: AddedRanges) -> bool:
+    """Return whether the change added or modified a line inside ``[start, end]``.
+
+    This is what makes the scope LINE-level rather than file-level. Touching one
+    line of a legacy module must not summon every pre-existing finding in it.
+    """
+    return any(start <= high and low <= end for low, high in added_ranges.get(path, ()))
+
+
+class ScopeInputError(ValueError):
+    """The unified diff that defines new code cannot be read."""
+
+
+def load_added_ranges(diff_path: Optional[str]) -> AddedRanges:
+    """Read the added ranges of ``diff_path``, or an empty scope when none was given.
+
+    No diff means no base to diff against (a push to the default branch, a merge
+    group), which is a legitimate unscoped run. But a caller that PROMISED a diff
+    and cannot supply a readable one is an ERROR, never "no scope": silently
+    degrading to unscoped would turn a broken invocation into a permanent pass.
+    """
+    if diff_path is None:
+        return {}
+    try:
+        return parse_added_ranges(Path(diff_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ScopeInputError(
+            f"cannot read the diff {diff_path!r} ({exc}). The caller promised a new-code scope, "
+            "so an unreadable diff is an error, not 'no scope'."
+        ) from None
+
+
+# jscpd:ignore-end
+
+
+def parse_lizard_csv(text: str, root: Optional[str] = None) -> LizardReport:
+    """Parse ``lizard --csv`` output.
+
+    Unreadable rows are COUNTED rather than dropped: a partially-parsed report
+    that reads as clean is the exact shape of a silent pass, so the count is
+    surfaced in the rendered output.
+    """
+    functions: List[FunctionMetric] = []
+    skipped = 0
+    for row in csv.reader(text.splitlines()):
+        if not row:
+            continue
+        if len(row) < LIZARD_COLUMNS:
+            skipped += 1
+            continue
+        try:
+            ccn = int(row[_CCN_INDEX])
+            start = int(row[_START_INDEX])
+            end = int(row[_END_INDEX])
+        except ValueError:
+            skipped += 1
+            continue
+        functions.append(
+            FunctionMetric(
+                path=normalize_path(row[_FILE_INDEX], root),
+                name=row[_NAME_INDEX],
+                ccn=ccn,
+                start=start,
+                end=end,
+            )
+        )
+    return LizardReport(functions=functions, skipped_rows=skipped)
 
 
 def classify(
@@ -223,7 +273,7 @@ def classify(
     for function in functions:
         if function.ccn <= max_ccn:
             continue
-        if scoped and touches(function, added_ranges):
+        if scoped and spans_overlap(function.path, function.start, function.end, added_ranges):
             blocking.append(function)
         else:
             inventory.append(function)
@@ -311,19 +361,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             file=sys.stderr,
         )
         return EXIT_CONFIG_ERROR
-    added_ranges: AddedRanges = {}
-    scoped = args.diff is not None
-    if scoped:
-        try:
-            diff_text = Path(args.diff).read_text(encoding="utf-8")
-        except OSError as exc:
-            print(
-                f"ERROR gate-complexity: cannot read the diff {args.diff!r} ({exc}). "
-                "The caller promised a new-code scope, so an unreadable diff is an error, not 'no scope'.",
-                file=sys.stderr,
-            )
-            return EXIT_CONFIG_ERROR
-        added_ranges = parse_added_ranges(diff_text)
+    try:
+        added_ranges = load_added_ranges(args.diff)
+    except ScopeInputError as exc:
+        print(f"ERROR gate-complexity: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
     report = parse_lizard_csv(csv_text, args.root)
     verdict = classify(report.functions, added_ranges, max_ccn, scoped)
     print(render_report(report, verdict, max_ccn))

--- a/scripts/quality/duplication_gate.py
+++ b/scripts/quality/duplication_gate.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Gate 8 - copy/paste duplication, scoped to NEW CODE ONLY (T1).
+
+``jscpd`` reports every clone pair in the tree. Blocking on all of them would be
+unreachable on any repo with history - it would demand the owner de-duplicate
+code the change never touched, which is the treadmill the lean charter exists to
+escape. So this module splits jscpd's report into two tiers:
+
+* **BLOCK (T1)** - at least one side of the pair sits on lines this change added
+  or modified. The change introduced a copy, and that cannot be merged.
+* **T2 inventory** - clone pairs entirely on untouched lines. PRINTED in full,
+  never blocking. Legacy duplication is made visible, not enforced.
+
+**"At least one side" is the rule, not "both sides".** The recorded fixture is
+exactly why: the pair is ``src/legacy_settings.py`` (untouched) against
+``src/new_settings.py`` (a new file that copy-pasted it). Requiring both sides to
+be new would wave through every copy-paste-from-legacy - the single most common
+way duplication actually enters a codebase - while only catching the rarer case
+of someone pasting a block twice in one change.
+
+**"New" is defined by the diff, never by a time window.** A day-count new-code
+period lets an unfixed finding age into legacy and the gate goes green with the
+duplication still in the tree - a decay function wearing a gate's clothes. The
+only accepted scope input here is a unified diff.
+
+Detection thresholds are jscpd's own (``--min-lines`` / ``--min-tokens``, pinned
+in the workflow), deliberately NOT re-implemented here. A second filter in this
+module would silently disagree with what a developer sees running jscpd locally,
+and two bars for one gate is one bar too many.
+
+When no diff is supplied (a push to ``main``, a merge group - there is no base to
+diff against) the gate emits the T2 inventory and **passes**. It never blocks
+without a scope.
+
+Exit codes: ``0`` no new duplication, ``1`` new duplication, ``2`` the report is
+unusable (never a silent pass).
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+EXIT_OK = 0
+EXIT_BLOCKED = 1
+EXIT_CONFIG_ERROR = 2
+
+DEFAULT_LANGUAGE = "unknown"
+
+
+class ReportError(ValueError):
+    """The jscpd report cannot be read as a report."""
+
+
+@dataclass(frozen=True)
+class ClonePart:
+    """One side of a clone pair: where the duplicated block sits."""
+
+    path: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class Clone:
+    """A clone pair, with the size figures jscpd measured for it."""
+
+    first: ClonePart
+    second: ClonePart
+    lines: int
+    tokens: int
+    language: str
+
+
+@dataclass(frozen=True)
+class JscpdReport:
+    """A parsed jscpd report, plus how much of it could not be read."""
+
+    clones: List[Clone]
+    skipped_entries: int
+    reported_clones: Optional[int]
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The tiering decision for one report."""
+
+    blocking: List[Clone]
+    inventory: List[Clone]
+    scoped: bool
+
+
+# jscpd:ignore-start
+# ─── SHARED NEW-CODE SCOPING ────────────────────────────────────────────────
+# This block is BYTE-IDENTICAL in complexity_gate.py and duplication_gate.py,
+# and tests/test_newcode_scope_parity.py fails if the two ever diverge.
+#
+# Why it is duplicated rather than imported: both modules are embedded verbatim
+# into .github/workflows/reusable-quality.yml and run as standalone scripts in a
+# CALLER's checkout, which has no `scripts/` tree. Neither can import the other,
+# and neither can import a third shared module. Duplication is only safe when
+# drift is impossible - the same argument test_lean_gate_embedded_helpers.py
+# already makes for the embedded workflow copies.
+#
+# The jscpd markers suppress gate 8 on this one block. They are INLINE and
+# therefore visible in review, deliberately not a .jscpd.json exclusion: a
+# config-file suppression is invisible in a diff, and a suppressed finding has
+# to stay countable (see the qlty `[[triage]]` trap - suppress-at-generation
+# makes a dirty dashboard pixel-identical to a clean one).
+
+#: file -> the line ranges this change added or modified, 1-based and inclusive.
+AddedRanges = Dict[str, List[Tuple[int, int]]]
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def normalize_path(raw: str, root: Optional[str] = None) -> str:
+    """Collapse any recorded path convention to one repo-relative POSIX form.
+
+    The reporting tools disagree with each other and with git. lizard records
+    ``.\\src\\x.py`` on Windows and ``./src/x.py`` on Linux; jscpd records
+    ``src\\x.py``, or an absolute path under ``--absolute``. The diff always
+    speaks repo-relative POSIX, so every path must be reduced to that or the
+    per-file lookup silently misses and the gate fails OPEN.
+    """
+    text = raw.strip().strip('"').replace("\\", "/")
+    if root:
+        prefix = root.replace("\\", "/").rstrip("/") + "/"
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    while text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def _header_target(line: str) -> Optional[str]:
+    """Return the new-side path of a ``+++`` header, or ``None`` for a deletion."""
+    target = line[4:].split("\t")[0].strip()
+    if target == "/dev/null":
+        return None
+    if target.startswith("b/"):
+        target = target[2:]
+    return normalize_path(target)
+
+
+def parse_added_ranges(diff_text: str) -> AddedRanges:
+    """Extract the added/modified line ranges of a unified diff, per file.
+
+    Only the NEW side matters: a range is what the change put in the tree. A
+    pure-deletion hunk (``+40,0``) contributes nothing, and a deleted file
+    (``+++ /dev/null``) has no new side at all.
+
+    A ``+++`` line only counts as a file header when it directly follows a
+    ``---`` one. Adding a source line whose own text begins ``++ `` renders as
+    ``+++ ...`` inside a hunk body, and treating that as a header would
+    silently retarget every range that followed it.
+    """
+    ranges: AddedRanges = {}
+    current: Optional[str] = None
+    previous_was_old_header = False
+    for line in diff_text.splitlines():
+        if line.startswith("--- "):
+            previous_was_old_header = True
+            continue
+        if previous_was_old_header and line.startswith("+++ "):
+            previous_was_old_header = False
+            current = _header_target(line)
+            continue
+        previous_was_old_header = False
+        if not line.startswith("@@"):
+            continue
+        match = _HUNK.match(line)
+        if match is None or current is None:
+            continue
+        start = int(match.group(1))
+        count = 1 if match.group(2) is None else int(match.group(2))
+        if count <= 0:
+            continue
+        ranges.setdefault(current, []).append((start, start + count - 1))
+    return ranges
+
+
+def spans_overlap(path: str, start: int, end: int, added_ranges: AddedRanges) -> bool:
+    """Return whether the change added or modified a line inside ``[start, end]``.
+
+    This is what makes the scope LINE-level rather than file-level. Touching one
+    line of a legacy module must not summon every pre-existing finding in it.
+    """
+    return any(start <= high and low <= end for low, high in added_ranges.get(path, ()))
+
+
+# jscpd:ignore-end
+
+
+def _optional_int(value: Any, default: int = 0) -> int:
+    """Read a report-only integer, falling back when it is absent or junk.
+
+    ``lines``/``tokens`` only feed the printed row, so a junk value must not
+    discard an otherwise locatable clone.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clone_part(raw: Any, root: Optional[str]) -> Optional[ClonePart]:
+    """Read one side of a pair, or ``None`` when it cannot be located.
+
+    The path and the span are load-bearing for scoping - they are what decides
+    block-vs-demote - so unlike the size figures they are never defaulted.
+    """
+    if not isinstance(raw, dict):
+        return None
+    name = raw.get("name")
+    if not isinstance(name, str):
+        return None
+    try:
+        start = int(raw["start"])
+        end = int(raw["end"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return ClonePart(path=normalize_path(name, root), start=start, end=end)
+
+
+def _reported_clones(document: Dict[str, Any]) -> Optional[int]:
+    """Read jscpd's own clone count, for an independent cross-check.
+
+    ``None`` means "no cross-check available", which is not the same as a failed
+    one and must not be reported as a mismatch.
+    """
+    statistics = document.get("statistics")
+    if not isinstance(statistics, dict):
+        return None
+    total = statistics.get("total")
+    if not isinstance(total, dict):
+        return None
+    value = total.get("clones")
+    if not isinstance(value, int):
+        return None
+    return value
+
+
+def parse_jscpd_json(text: str, root: Optional[str] = None) -> JscpdReport:
+    """Parse ``jscpd --reporters json`` output.
+
+    Unreadable entries are COUNTED rather than dropped: a partially-parsed report
+    that reads as clean is the exact shape of a silent pass, so the count is
+    surfaced in the rendered output and cross-checked against jscpd's own total.
+    """
+    try:
+        document = json.loads(text)
+    except ValueError as exc:
+        raise ReportError(f"the report is not valid JSON ({exc})") from None
+    if not isinstance(document, dict):
+        raise ReportError("the report is not a JSON object")
+    duplicates = document.get("duplicates")
+    if not isinstance(duplicates, list):
+        raise ReportError(
+            "the report has no `duplicates` list. A report that measured nothing is not a report of nothing."
+        )
+    clones: List[Clone] = []
+    skipped = 0
+    for entry in duplicates:
+        if not isinstance(entry, dict):
+            skipped += 1
+            continue
+        first = _clone_part(entry.get("firstFile"), root)
+        second = _clone_part(entry.get("secondFile"), root)
+        if first is None or second is None:
+            skipped += 1
+            continue
+        language = entry.get("format")
+        clones.append(
+            Clone(
+                first=first,
+                second=second,
+                lines=_optional_int(entry.get("lines")),
+                tokens=_optional_int(entry.get("tokens")),
+                language=language if isinstance(language, str) else DEFAULT_LANGUAGE,
+            )
+        )
+    return JscpdReport(clones=clones, skipped_entries=skipped, reported_clones=_reported_clones(document))
+
+
+def classify(clones: Sequence[Clone], added_ranges: AddedRanges, scoped: bool) -> Verdict:
+    """Split the clone pairs into the blocking set and the T2 set."""
+    blocking: List[Clone] = []
+    inventory: List[Clone] = []
+    for clone in clones:
+        introduced = scoped and (
+            spans_overlap(clone.first.path, clone.first.start, clone.first.end, added_ranges)
+            or spans_overlap(clone.second.path, clone.second.start, clone.second.end, added_ranges)
+        )
+        if introduced:
+            blocking.append(clone)
+        else:
+            inventory.append(clone)
+    return Verdict(blocking=blocking, inventory=inventory, scoped=scoped)
+
+
+def _row(clone: Clone) -> str:
+    """Render one clone pair as an actionable line: both copies, and how big."""
+    return (
+        f"  {clone.first.path}:{clone.first.start}-{clone.first.end}"
+        f"  <->  {clone.second.path}:{clone.second.start}-{clone.second.end}"
+        f"  ({clone.lines} line(s), {clone.tokens} token(s), {clone.language})"
+    )
+
+
+def render_report(report: JscpdReport, verdict: Verdict) -> str:
+    """Render the full verdict, T2 included.
+
+    The demoted set is printed unconditionally. A gate that hides what it chose
+    not to enforce is indistinguishable from one that found nothing.
+    """
+    lines = [f"duplication: {len(report.clones)} clone pair(s) measured."]
+    if report.skipped_entries:
+        lines.append(
+            f"WARNING gate-duplication: {report.skipped_entries} unreadable entry(ies) in the jscpd report could "
+            "not be located. The report is incomplete, so treat this run as partial."
+        )
+    if report.reported_clones is not None and report.reported_clones != len(report.clones) + report.skipped_entries:
+        lines.append(
+            f"WARNING gate-duplication: jscpd reported {report.reported_clones} clone pair(s) in its own statistics "
+            f"but the report holds {len(report.clones) + report.skipped_entries}. Two signals disagree, so this "
+            "report is not trustworthy evidence of a clean tree."
+        )
+    if verdict.scoped:
+        lines.append("scope: lines this change added or modified (T1 new-code-only).")
+    else:
+        lines.append("scope: whole repo, no diff base - inventory only, nothing can block.")
+    if verdict.blocking:
+        lines.append(f"BLOCKING ({len(verdict.blocking)}) - this change put one side of these pairs in the tree:")
+        lines.extend(_row(clone) for clone in verdict.blocking)
+    if verdict.inventory:
+        lines.append(
+            f"T2 INVENTORY ({len(verdict.inventory)}) - pre-existing duplication on lines this change did not "
+            "touch; visible and tracked, deliberately NOT blocking:"
+        )
+        lines.extend(_row(clone) for clone in verdict.inventory)
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI."""
+    parser = argparse.ArgumentParser(description="Gate 8: block duplication this change introduced.")
+    parser.add_argument("--json", required=True, help="path to a `jscpd --reporters json` report")
+    parser.add_argument(
+        "--diff",
+        default=None,
+        help="path to the unified diff defining new code; omit to emit T2 inventory and pass",
+    )
+    parser.add_argument("--root", default=None, help="repo root, to relativize absolute paths in the report")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the gate; see the module docstring for the exit-code contract."""
+    args = _build_parser().parse_args(argv)
+    try:
+        report_text = Path(args.json).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"ERROR gate-duplication: cannot read the jscpd report {args.json!r} ({exc}). "
+            "An unmeasured tree is not a clean tree, so this is an error rather than a pass.",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG_ERROR
+    added_ranges: AddedRanges = {}
+    scoped = args.diff is not None
+    if scoped:
+        try:
+            diff_text = Path(args.diff).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"ERROR gate-duplication: cannot read the diff {args.diff!r} ({exc}). "
+                "The caller promised a new-code scope, so an unreadable diff is an error, not 'no scope'.",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        added_ranges = parse_added_ranges(diff_text)
+    try:
+        report = parse_jscpd_json(report_text, args.root)
+    except ReportError as exc:
+        print(f"ERROR gate-duplication: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+    verdict = classify(report.clones, added_ranges, scoped)
+    print(render_report(report, verdict))
+    if verdict.blocking:
+        print(
+            f"FAIL gate-duplication: {len(verdict.blocking)} clone pair(s) have a side this change wrote. "
+            "Extract the shared block, or mark it with an inline jscpd:ignore-start/end and say why.",
+            file=sys.stderr,
+        )
+        return EXIT_BLOCKED
+    print(
+        f"PASS gate-duplication: 0 new clone pair(s); {len(verdict.inventory)} demoted to T2 inventory (listed above)."
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality/duplication_gate.py
+++ b/scripts/quality/duplication_gate.py
@@ -194,6 +194,29 @@ def spans_overlap(path: str, start: int, end: int, added_ranges: AddedRanges) ->
     return any(start <= high and low <= end for low, high in added_ranges.get(path, ()))
 
 
+class ScopeInputError(ValueError):
+    """The unified diff that defines new code cannot be read."""
+
+
+def load_added_ranges(diff_path: Optional[str]) -> AddedRanges:
+    """Read the added ranges of ``diff_path``, or an empty scope when none was given.
+
+    No diff means no base to diff against (a push to the default branch, a merge
+    group), which is a legitimate unscoped run. But a caller that PROMISED a diff
+    and cannot supply a readable one is an ERROR, never "no scope": silently
+    degrading to unscoped would turn a broken invocation into a permanent pass.
+    """
+    if diff_path is None:
+        return {}
+    try:
+        return parse_added_ranges(Path(diff_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ScopeInputError(
+            f"cannot read the diff {diff_path!r} ({exc}). The caller promised a new-code scope, "
+            "so an unreadable diff is an error, not 'no scope'."
+        ) from None
+
+
 # jscpd:ignore-end
 
 
@@ -372,19 +395,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             file=sys.stderr,
         )
         return EXIT_CONFIG_ERROR
-    added_ranges: AddedRanges = {}
+    # Use the SHARED load_added_ranges rather than reading the diff here. This block
+    # previously hand-rolled the same logic -- same semantics, same error text -- which
+    # is precisely the drift test_newcode_scope_parity.py exists to prevent, except it
+    # sat just below the jscpd:ignore marker and so was invisible to that guard. Two
+    # gates that reimplement "what counts as new code" can diverge silently; one shared
+    # function cannot.
     scoped = args.diff is not None
-    if scoped:
-        try:
-            diff_text = Path(args.diff).read_text(encoding="utf-8")
-        except OSError as exc:
-            print(
-                f"ERROR gate-duplication: cannot read the diff {args.diff!r} ({exc}). "
-                "The caller promised a new-code scope, so an unreadable diff is an error, not 'no scope'.",
-                file=sys.stderr,
-            )
-            return EXIT_CONFIG_ERROR
-        added_ranges = parse_added_ranges(diff_text)
+    try:
+        added_ranges: AddedRanges = load_added_ranges(args.diff)
+    except ScopeInputError as exc:
+        print(f"ERROR gate-duplication: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
     try:
         report = parse_jscpd_json(report_text, args.root)
     except ReportError as exc:

--- a/tests/fixtures/newcode/jscpd_clean.json
+++ b/tests/fixtures/newcode/jscpd_clean.json
@@ -1,0 +1,19 @@
+{
+  "duplicates": [],
+  "statistics": {
+    "detectionDate": "2026-08-11T19:57:16.380Z",
+    "formats": {},
+    "total": {
+      "clones": 0,
+      "duplicatedLines": 0,
+      "duplicatedTokens": 0,
+      "lines": 0,
+      "newClones": 0,
+      "newDuplicatedLines": 0,
+      "percentage": 0.0,
+      "percentageTokens": 0.0,
+      "sources": 0,
+      "tokens": 0
+    }
+  }
+}

--- a/tests/fixtures/newcode/jscpd_mixed.json
+++ b/tests/fixtures/newcode/jscpd_mixed.json
@@ -1,0 +1,81 @@
+{
+  "duplicates": [
+    {
+      "firstFile": {
+        "end": 27,
+        "endLoc": {
+          "column": 21,
+          "line": 27,
+          "position": 762
+        },
+        "name": "src\\legacy_settings.py",
+        "start": 6,
+        "startLoc": {
+          "column": 17,
+          "line": 6,
+          "position": 103
+        }
+      },
+      "format": "python",
+      "fragment": "def load_settings(path, defaults):\n    \"\"\"Read a JSON settings file and merge it over the supplied defaults.\"\"\"\n    merged = dict(defaults)\n    try:\n        with open(path, \"r\", encoding=\"utf-8\") as handle:\n            payload = json.load(handle)\n    except OSError:\n        return merged\n    except ValueError:\n        return merged\n    if not isinstance(payload, dict):\n        return merged\n    for key, value in payload.items():\n        if key not in defaults:\n            continue\n        if value is None:\n            continue\n        merged[key] = value\n    normalised = {}\n    for key in sorted(merged):\n        normalised[str(key)] = merged[key]\n    return normalised",
+      "lines": 22,
+      "secondFile": {
+        "end": 27,
+        "endLoc": {
+          "column": 21,
+          "line": 27,
+          "position": 768
+        },
+        "name": "src\\new_settings.py",
+        "start": 6,
+        "startLoc": {
+          "column": 15,
+          "line": 6,
+          "position": 109
+        }
+      },
+      "tokens": 116
+    }
+  ],
+  "statistics": {
+    "detectionDate": "2026-08-11T19:57:07.759Z",
+    "formats": {
+      "go": {
+        "clones": 0,
+        "duplicatedLines": 0,
+        "duplicatedTokens": 0,
+        "lines": 59,
+        "newClones": 0,
+        "newDuplicatedLines": 0,
+        "percentage": 0.0,
+        "percentageTokens": 0.0,
+        "sources": 1,
+        "tokens": 207
+      },
+      "python": {
+        "clones": 1,
+        "duplicatedLines": 21,
+        "duplicatedTokens": 116,
+        "lines": 111,
+        "newClones": 0,
+        "newDuplicatedLines": 0,
+        "percentage": 18.91891891891892,
+        "percentageTokens": 24.267782426778243,
+        "sources": 3,
+        "tokens": 478
+      }
+    },
+    "total": {
+      "clones": 1,
+      "duplicatedLines": 21,
+      "duplicatedTokens": 116,
+      "lines": 170,
+      "newClones": 0,
+      "newDuplicatedLines": 0,
+      "percentage": 12.352941176470589,
+      "percentageTokens": 16.934306569343065,
+      "sources": 4,
+      "tokens": 685
+    }
+  }
+}

--- a/tests/fixtures/newcode/lizard_clean.csv
+++ b/tests/fixtures/newcode/lizard_clean.csv
@@ -1,0 +1,1 @@
+2,1,10,1,3,"ok@1-3@src/clean.py","src/clean.py","ok","ok( value )",1,3

--- a/tests/fixtures/newcode/lizard_mixed.csv
+++ b/tests/fixtures/newcode/lizard_mixed.csv
@@ -1,0 +1,9 @@
+2,1,10,1,3,"ok@1-3@.\src\clean.py",".\src\clean.py","ok","ok( value )",1,3
+38,21,160,5,39,"classify@4-42@.\src\legacy_knot.py",".\src\legacy_knot.py","classify","classify( value , mode , flag_a , flag_b , flag_c )",4,42
+2,1,10,1,3,"tiny@45-47@.\src\legacy_knot.py",".\src\legacy_knot.py","tiny","tiny( value )",45,47
+2,1,10,1,3,"also_ok@50-52@.\src\legacy_knot.py",".\src\legacy_knot.py","also_ok","also_ok( value )",50,52
+21,8,115,2,22,"load_settings@6-27@.\src\legacy_settings.py",".\src\legacy_settings.py","load_settings","load_settings( path , defaults )",6,27
+6,2,20,1,6,"Simple@4-9@.\src\new_knot.go",".\src\new_knot.go","Simple","Simple value int",4,9
+47,18,160,5,47,"Knot@13-59@.\src\new_knot.go",".\src\new_knot.go","Knot","Knot value int , mode string , a bool , b bool , c bool",13,59
+21,8,115,2,22,"read_config@6-27@.\src\new_settings.py",".\src\new_settings.py","read_config","read_config( path , defaults )",6,27
+2,1,14,1,3,"unique_helper@30-32@.\src\new_settings.py",".\src\new_settings.py","unique_helper","unique_helper( items )",30,32

--- a/tests/fixtures/newcode/newcode.diff
+++ b/tests/fixtures/newcode/newcode.diff
@@ -1,0 +1,113 @@
+diff --git a/src/legacy_knot.py b/src/legacy_knot.py
+index 56fafd9..22b6c41 100644
+--- a/src/legacy_knot.py
++++ b/src/legacy_knot.py
+@@ -47,0 +48,5 @@ def tiny(value):
++
++
++def also_ok(value):
++    """Clean addition to a legacy file."""
++    return value - 1
+diff --git a/src/new_knot.go b/src/new_knot.go
+new file mode 100644
+index 0000000..3d14211
+--- /dev/null
++++ b/src/new_knot.go
+@@ -0,0 +1,59 @@
++package src
++
++// Simple is comfortably under any sane CCN threshold.
++func Simple(value int) int {
++	if value > 0 {
++		return value
++	}
++	return -value
++}
++
++// Knot is deliberately over the threshold, in Go, to prove the lane is
++// language-agnostic and not Python-only.
++func Knot(value int, mode string, a bool, b bool, c bool) int {
++	total := 0
++	if value > 1 {
++		total++
++	}
++	if value > 2 {
++		total += 2
++	}
++	if value > 3 {
++		total += 3
++	}
++	if value > 4 {
++		total += 4
++	}
++	if value > 5 {
++		total += 5
++	}
++	switch mode {
++	case "a":
++		total += 6
++	case "b":
++		total += 7
++	case "c":
++		total += 8
++	case "d":
++		total += 9
++	default:
++		total += 10
++	}
++	if a && b {
++		total += 11
++	}
++	if b || c {
++		total += 12
++	}
++	if a && c {
++		total += 13
++	}
++	for i := 0; i < value; i++ {
++		if i%2 == 0 {
++			total += i
++		} else {
++			total -= i
++		}
++	}
++	return total
++}
+diff --git a/src/new_settings.py b/src/new_settings.py
+new file mode 100644
+index 0000000..9c796c7
+--- /dev/null
++++ b/src/new_settings.py
+@@ -0,0 +1,32 @@
++"""A verbatim copy-paste of load_settings, renamed. Deliberate duplication."""
++
++import json
++
++
++def read_config(path, defaults):
++    """Read a JSON settings file and merge it over the supplied defaults."""
++    merged = dict(defaults)
++    try:
++        with open(path, "r", encoding="utf-8") as handle:
++            payload = json.load(handle)
++    except OSError:
++        return merged
++    except ValueError:
++        return merged
++    if not isinstance(payload, dict):
++        return merged
++    for key, value in payload.items():
++        if key not in defaults:
++            continue
++        if value is None:
++            continue
++        merged[key] = value
++    normalised = {}
++    for key in sorted(merged):
++        normalised[str(key)] = merged[key]
++    return normalised
++
++
++def unique_helper(items):
++    """Not duplicated anywhere - the clean control."""
++    return sorted(set(items))

--- a/tests/newcode_scope_support.py
+++ b/tests/newcode_scope_support.py
@@ -1,0 +1,185 @@
+"""One behavioural contract for the new-code scoping block, run against BOTH gates.
+
+``complexity_gate.py`` and ``duplication_gate.py`` each carry their own copy of
+the scoping block (they are embedded as standalone scripts in a caller checkout
+and cannot import each other - see ``test_newcode_scope_parity.py``). Copies mean
+each one needs its own coverage, and copied *tests* would rot at different rates
+than the code.
+
+So the cases live here once and every sharing module subclasses
+``NewCodeScopeContract``. That makes the parity guarantee BEHAVIOURAL as well as
+byte-wise: ``test_newcode_scope_parity`` proves the two copies are identical
+text, and this suite proves each copy actually behaves correctly.
+
+``NewCodeScopeContract`` is a plain mixin, deliberately NOT a ``TestCase``
+subclass: unittest discovery would otherwise collect the base itself and run
+every case against ``gate = None``.
+"""
+
+from __future__ import absolute_import
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "newcode"
+NEWCODE_DIFF = FIXTURES / "newcode.diff"
+
+
+class NewCodeScopeContract:
+    """Shared cases for one module's copy of the scoping block.
+
+    Concrete subclasses set ``module`` to the gate module under test and inherit
+    from ``unittest.TestCase`` alongside this mixin.
+    """
+
+    #: The gate module under test. Set by each concrete subclass.
+    module = None
+
+    # ── normalize_path ──────────────────────────────────────────────────────
+    def test_windows_backslash_form_becomes_posix(self) -> None:
+        """lizard on Windows records ``.\\src\\x.py``; CI compares against ``src/x.py``."""
+        self.assertEqual(self.module.normalize_path(".\\src\\legacy_knot.py"), "src/legacy_knot.py")
+
+    def test_jscpd_backslash_form_becomes_posix(self) -> None:
+        """jscpd records ``src\\x.py`` with no leading ``./``."""
+        self.assertEqual(self.module.normalize_path("src\\new_settings.py"), "src/new_settings.py")
+
+    def test_posix_dot_slash_prefix_is_stripped(self) -> None:
+        """lizard on Linux records ``./src/x.py``."""
+        self.assertEqual(self.module.normalize_path("./src/clean.py"), "src/clean.py")
+
+    def test_repeated_dot_slash_prefixes_are_all_stripped(self) -> None:
+        """A doubled prefix must not survive as a mismatching key."""
+        self.assertEqual(self.module.normalize_path("././src/clean.py"), "src/clean.py")
+
+    def test_already_relative_path_is_unchanged(self) -> None:
+        """The strip loop must also terminate immediately when there is no prefix."""
+        self.assertEqual(self.module.normalize_path("src/clean.py"), "src/clean.py")
+
+    def test_surrounding_quotes_and_whitespace_are_stripped(self) -> None:
+        """Defensive: a hand-edited report can leave the quoting in the field."""
+        self.assertEqual(self.module.normalize_path('  "src/clean.py"  '), "src/clean.py")
+
+    def test_absolute_path_is_made_relative_to_the_root(self) -> None:
+        """``jscpd --absolute`` and some lizard invocations emit absolute paths."""
+        self.assertEqual(
+            self.module.normalize_path("/home/runner/work/repo/repo/src/clean.py", root="/home/runner/work/repo/repo"),
+            "src/clean.py",
+        )
+
+    def test_absolute_path_outside_the_root_is_left_alone(self) -> None:
+        """A path the root does not prefix must not be silently truncated."""
+        self.assertEqual(
+            self.module.normalize_path("/elsewhere/src/clean.py", root="/home/runner"), "/elsewhere/src/clean.py"
+        )
+
+    def test_windows_root_is_normalized_before_comparison(self) -> None:
+        """A backslash root must still match a backslash path."""
+        self.assertEqual(
+            self.module.normalize_path("D:\\work\\repo\\src\\clean.py", root="D:\\work\\repo\\"), "src/clean.py"
+        )
+
+    def test_a_relative_path_under_a_root_is_left_alone(self) -> None:
+        """The root only relativizes what it actually prefixes."""
+        self.assertEqual(self.module.normalize_path("src/clean.py", root="/home/runner"), "src/clean.py")
+
+    # ── parse_added_ranges ──────────────────────────────────────────────────
+    def test_real_diff_yields_one_range_per_hunk(self) -> None:
+        """The recorded diff has three files and one hunk each."""
+        ranges = self.module.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+        self.assertEqual(
+            ranges,
+            {
+                "src/legacy_knot.py": [(48, 52)],
+                "src/new_knot.go": [(1, 59)],
+                "src/new_settings.py": [(1, 32)],
+            },
+        )
+
+    def test_a_hunk_with_no_count_covers_a_single_line(self) -> None:
+        """``@@ -12 +12 @@`` is the one-line form."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -12 +12 @@\n+value = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {"x.py": [(12, 12)]})
+
+    def test_a_pure_deletion_hunk_adds_no_range(self) -> None:
+        """``+40,0`` added nothing, so it cannot make anything new code."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -40,3 +40,0 @@\n-gone = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {})
+
+    def test_a_deleted_file_contributes_no_ranges(self) -> None:
+        """``+++ /dev/null`` has no new side to scope against."""
+        diff = "diff --git a/x.py b/x.py\ndeleted file mode 100644\n--- a/x.py\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-gone = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {})
+
+    def test_multiple_hunks_in_one_file_are_all_recorded(self) -> None:
+        """A realistic change touches a file in several places."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+a = 1\n+b = 2\n@@ -20,0 +30,1 @@\n+c = 3\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {"x.py": [(1, 2), (30, 30)]})
+
+    def test_a_hunk_before_any_file_header_is_ignored(self) -> None:
+        """A truncated diff must not attribute lines to the wrong file."""
+        self.assertEqual(self.module.parse_added_ranges("@@ -1,0 +1,2 @@\n+a = 1\n"), {})
+
+    def test_a_malformed_hunk_header_is_ignored(self) -> None:
+        """An unparseable ``@@`` line must not crash or invent a range."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ this is not a hunk @@\n+a = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {})
+
+    def test_an_added_line_that_looks_like_a_file_header_is_not_one(self) -> None:
+        """Adding a line whose text starts with ``++ `` renders as ``+++ ``.
+
+        Only a ``+++`` immediately following a ``---`` is a real file header, so
+        the content line must not silently retarget every following hunk.
+        """
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+++ not/a/header.py\n+a = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {"x.py": [(1, 2)]})
+
+    def test_paths_are_normalized_and_the_b_prefix_removed(self) -> None:
+        """``+++ b/src/x.py`` and a bare ``+++ src/x.py`` must key identically."""
+        with_prefix = self.module.parse_added_ranges("--- a/src/x.py\n+++ b/src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
+        without_prefix = self.module.parse_added_ranges("--- src/x.py\n+++ src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
+        self.assertEqual(with_prefix, {"src/x.py": [(1, 1)]})
+        self.assertEqual(without_prefix, {"src/x.py": [(1, 1)]})
+
+    def test_a_tab_separated_header_timestamp_is_dropped(self) -> None:
+        """``git diff`` omits it, but ``diff -u`` appends a tab and a timestamp."""
+        diff = "--- a/x.py\t2026-08-11\n+++ b/x.py\t2026-08-11\n@@ -0,0 +1,1 @@\n+a = 1\n"
+        self.assertEqual(self.module.parse_added_ranges(diff), {"x.py": [(1, 1)]})
+
+    def test_crlf_diff_parses_identically(self) -> None:
+        """A diff captured on Windows carries CRLF; a \\n-only parser reads zero hunks."""
+        text = NEWCODE_DIFF.read_text(encoding="utf-8").replace("\n", "\r\n")
+        self.assertEqual(self.module.parse_added_ranges(text)["src/new_knot.go"], [(1, 59)])
+
+    # ── spans_overlap ───────────────────────────────────────────────────────
+    def test_a_span_with_no_ranges_in_its_file_is_untouched(self) -> None:
+        """The scan must terminate to ``False`` rather than raising on a missing key."""
+        self.assertFalse(self.module.spans_overlap("src/a.py", 1, 10, {}))
+
+    def test_a_hunk_inside_the_span_overlaps(self) -> None:
+        """The ordinary case: the change edited the body of this span."""
+        self.assertTrue(self.module.spans_overlap("src/a.py", 1, 10, {"src/a.py": [(5, 6)]}))
+
+    def test_a_hunk_after_the_span_does_not_overlap(self) -> None:
+        """The recorded ``classify`` (4-42) against the real hunk at 48-52."""
+        self.assertFalse(self.module.spans_overlap("src/a.py", 4, 42, {"src/a.py": [(48, 52)]}))
+
+    def test_a_hunk_before_the_span_does_not_overlap(self) -> None:
+        """Symmetric case, so the comparison cannot be one-sided."""
+        self.assertFalse(self.module.spans_overlap("src/a.py", 40, 50, {"src/a.py": [(1, 3)]}))
+
+    def test_a_hunk_overlapping_the_first_line_counts(self) -> None:
+        """Boundary: the range ends exactly on the span's first line."""
+        self.assertTrue(self.module.spans_overlap("src/a.py", 10, 20, {"src/a.py": [(5, 10)]}))
+
+    def test_a_hunk_overlapping_the_last_line_counts(self) -> None:
+        """Boundary: the range starts exactly on the span's last line."""
+        self.assertTrue(self.module.spans_overlap("src/a.py", 10, 20, {"src/a.py": [(20, 25)]}))
+
+    def test_a_later_range_still_counts_after_an_earlier_miss(self) -> None:
+        """The scan must keep going instead of stopping at the first miss."""
+        self.assertTrue(self.module.spans_overlap("src/a.py", 10, 20, {"src/a.py": [(1, 2), (15, 16)]}))
+
+    def test_a_range_in_a_different_file_does_not_overlap(self) -> None:
+        """Keys are per-file; a same-numbered hunk elsewhere is irrelevant."""
+        self.assertFalse(self.module.spans_overlap("src/a.py", 1, 10, {"src/b.py": [(1, 10)]}))

--- a/tests/test_complexity_gate.py
+++ b/tests/test_complexity_gate.py
@@ -28,6 +28,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import List, Tuple
 
+from tests.newcode_scope_support import NewCodeScopeContract
+
 from scripts.quality import complexity_gate as gate
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -51,43 +53,10 @@ def _run(argv: List[str]) -> Tuple[int, str, str]:
     return code, out.getvalue(), err.getvalue()
 
 
-class NormalizePathTests(unittest.TestCase):
-    """Every recorded path convention must collapse to one repo-relative form."""
+class ComplexityScopeContractTests(NewCodeScopeContract, unittest.TestCase):
+    """Run the shared new-code scoping contract against THIS module's copy."""
 
-    def test_windows_backslash_form_becomes_posix(self) -> None:
-        """lizard on Windows records ``.\\src\\x.py``; CI compares against ``src/x.py``."""
-        self.assertEqual(gate.normalize_path(".\\src\\legacy_knot.py"), "src/legacy_knot.py")
-
-    def test_posix_dot_slash_prefix_is_stripped(self) -> None:
-        """lizard on Linux records ``./src/x.py``."""
-        self.assertEqual(gate.normalize_path("./src/clean.py"), "src/clean.py")
-
-    def test_repeated_dot_slash_prefixes_are_all_stripped(self) -> None:
-        """A doubled prefix must not survive as a mismatching key."""
-        self.assertEqual(gate.normalize_path("././src/clean.py"), "src/clean.py")
-
-    def test_already_relative_path_is_unchanged(self) -> None:
-        """The loop must also terminate immediately when there is no prefix."""
-        self.assertEqual(gate.normalize_path("src/clean.py"), "src/clean.py")
-
-    def test_surrounding_quotes_and_whitespace_are_stripped(self) -> None:
-        """Defensive: a hand-edited CSV can leave the quoting in the field."""
-        self.assertEqual(gate.normalize_path('  "src/clean.py"  '), "src/clean.py")
-
-    def test_absolute_path_is_made_relative_to_the_root(self) -> None:
-        """jscpd/lizard can emit absolute paths depending on how they are invoked."""
-        self.assertEqual(
-            gate.normalize_path("/home/runner/work/repo/repo/src/clean.py", root="/home/runner/work/repo/repo"),
-            "src/clean.py",
-        )
-
-    def test_absolute_path_outside_the_root_is_left_alone(self) -> None:
-        """A path the root does not prefix must not be silently truncated."""
-        self.assertEqual(gate.normalize_path("/elsewhere/src/clean.py", root="/home/runner"), "/elsewhere/src/clean.py")
-
-    def test_windows_root_is_normalized_before_comparison(self) -> None:
-        """A backslash root must still match a backslash path."""
-        self.assertEqual(gate.normalize_path("D:\\work\\repo\\src\\clean.py", root="D:\\work\\repo\\"), "src/clean.py")
+    module = gate
 
 
 class ParseLizardCsvTests(unittest.TestCase):
@@ -174,117 +143,6 @@ class ParseLizardCsvTests(unittest.TestCase):
         report = gate.parse_lizard_csv(text)
         self.assertEqual([f.name for f in report.functions], ["ok"])
         self.assertEqual(report.skipped_rows, 0)
-
-
-class ParseAddedRangesTests(unittest.TestCase):
-    """The diff parser decides what "new code" means; it must be exact."""
-
-    def test_real_diff_yields_one_range_per_hunk(self) -> None:
-        """The recorded diff has three files and one hunk each."""
-        ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
-        self.assertEqual(
-            ranges,
-            {
-                "src/legacy_knot.py": [(48, 52)],
-                "src/new_knot.go": [(1, 59)],
-                "src/new_settings.py": [(1, 32)],
-            },
-        )
-
-    def test_a_hunk_with_no_count_covers_a_single_line(self) -> None:
-        """``@@ -12 +12 @@`` is the one-line form."""
-        diff = "--- a/x.py\n+++ b/x.py\n@@ -12 +12 @@\n+value = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(12, 12)]})
-
-    def test_a_pure_deletion_hunk_adds_no_range(self) -> None:
-        """``+40,0`` added nothing, so it cannot make anything new code."""
-        diff = "--- a/x.py\n+++ b/x.py\n@@ -40,3 +40,0 @@\n-gone = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {})
-
-    def test_a_deleted_file_contributes_no_ranges(self) -> None:
-        """``+++ /dev/null`` has no new side to scope against."""
-        diff = "diff --git a/x.py b/x.py\ndeleted file mode 100644\n--- a/x.py\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-gone = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {})
-
-    def test_multiple_hunks_in_one_file_are_all_recorded(self) -> None:
-        """A realistic PR touches a file in several places."""
-        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+a = 1\n+b = 2\n@@ -20,0 +30,1 @@\n+c = 3\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 2), (30, 30)]})
-
-    def test_a_hunk_before_any_file_header_is_ignored(self) -> None:
-        """A truncated diff must not attribute lines to the wrong file."""
-        self.assertEqual(gate.parse_added_ranges("@@ -1,0 +1,2 @@\n+a = 1\n"), {})
-
-    def test_a_malformed_hunk_header_is_ignored(self) -> None:
-        """An unparseable ``@@`` line must not crash or invent a range."""
-        diff = "--- a/x.py\n+++ b/x.py\n@@ this is not a hunk @@\n+a = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {})
-
-    def test_an_added_line_that_looks_like_a_file_header_is_not_one(self) -> None:
-        """Adding a line whose text starts with ``++ `` renders as ``+++ ``.
-
-        Only a ``+++`` immediately following a ``---`` is a real file header, so
-        the content line must not silently retarget every following hunk.
-        """
-        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+++ not/a/header.py\n+a = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 2)]})
-
-    def test_paths_are_normalized_and_the_b_prefix_removed(self) -> None:
-        """``+++ b/src/x.py`` and a bare ``+++ src/x.py`` must key identically."""
-        with_prefix = gate.parse_added_ranges("--- a/src/x.py\n+++ b/src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
-        without_prefix = gate.parse_added_ranges("--- src/x.py\n+++ src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
-        self.assertEqual(with_prefix, {"src/x.py": [(1, 1)]})
-        self.assertEqual(without_prefix, {"src/x.py": [(1, 1)]})
-
-    def test_a_tab_separated_header_timestamp_is_dropped(self) -> None:
-        """``git diff`` omits it, but ``diff -u`` appends a tab and a timestamp."""
-        diff = "--- a/x.py\t2026-08-11\n+++ b/x.py\t2026-08-11\n@@ -0,0 +1,1 @@\n+a = 1\n"
-        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 1)]})
-
-    def test_crlf_diff_parses_identically(self) -> None:
-        """A diff captured on Windows carries CRLF."""
-        text = NEWCODE_DIFF.read_text(encoding="utf-8").replace("\n", "\r\n")
-        self.assertEqual(gate.parse_added_ranges(text)["src/new_knot.go"], [(1, 59)])
-
-
-class TouchesTests(unittest.TestCase):
-    """Span intersection is what makes the scope line-level."""
-
-    def _function(self, path: str, start: int, end: int) -> gate.FunctionMetric:
-        """Build a metric with only the fields intersection uses."""
-        return gate.FunctionMetric(path=path, name="f", ccn=99, start=start, end=end)
-
-    def test_a_function_with_no_ranges_in_its_file_is_untouched(self) -> None:
-        """The loop must terminate to ``False`` rather than raising."""
-        self.assertFalse(gate.touches(self._function("src/a.py", 1, 10), {}))
-
-    def test_a_hunk_inside_the_span_touches(self) -> None:
-        """The ordinary case: the PR edited the body of this function."""
-        self.assertTrue(gate.touches(self._function("src/a.py", 1, 10), {"src/a.py": [(5, 6)]}))
-
-    def test_a_hunk_after_the_span_does_not_touch(self) -> None:
-        """The recorded ``classify`` (4-42) vs the hunk at 48-52."""
-        self.assertFalse(gate.touches(self._function("src/a.py", 4, 42), {"src/a.py": [(48, 52)]}))
-
-    def test_a_hunk_before_the_span_does_not_touch(self) -> None:
-        """Symmetric case, so the comparison cannot be one-sided."""
-        self.assertFalse(gate.touches(self._function("src/a.py", 40, 50), {"src/a.py": [(1, 3)]}))
-
-    def test_a_hunk_overlapping_the_first_line_touches(self) -> None:
-        """Boundary: the range ends exactly on the function's first line."""
-        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(5, 10)]}))
-
-    def test_a_hunk_overlapping_the_last_line_touches(self) -> None:
-        """Boundary: the range starts exactly on the function's last line."""
-        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(20, 25)]}))
-
-    def test_a_later_range_still_touches_after_an_earlier_miss(self) -> None:
-        """The loop must keep scanning instead of returning on the first miss."""
-        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(1, 2), (15, 16)]}))
-
-    def test_a_range_in_a_different_file_does_not_touch(self) -> None:
-        """Keys are per-file; a same-numbered hunk elsewhere is irrelevant."""
-        self.assertFalse(gate.touches(self._function("src/a.py", 1, 10), {"src/b.py": [(1, 10)]}))
 
 
 class ClassifyTests(unittest.TestCase):

--- a/tests/test_complexity_gate.py
+++ b/tests/test_complexity_gate.py
@@ -1,0 +1,501 @@
+"""Tests for the gate-7 complexity floor (T1 new-code-only tiering).
+
+``scripts/quality/complexity_gate.py`` reads a ``lizard --csv`` report plus the
+unified diff of the pull request and splits the over-threshold functions into
+
+* **BLOCK** - the diff added or changed lines *inside* the function's own span, and
+* **T2** - everything else, which is still PRINTED (demoted, never hidden).
+
+The scope is deliberately LINE-level, not file-level. ``tests/fixtures/newcode/``
+was recorded to make that distinction fail loudly if it is ever weakened:
+``src/legacy_knot.py`` **is** a changed file, but the only hunk in it adds lines
+48-52, while the CCN=21 ``classify`` occupies lines 4-42. A file-level scope
+would block the PR on a legacy function it never touched - the exact treadmill
+the charter exists to avoid - so ``classify`` must land in T2 while the
+newly-added Go ``Knot`` (CCN=18) blocks.
+
+Both lizard fixtures are real ``lizard --csv`` output. They deliberately carry
+two different path conventions: ``lizard_mixed.csv`` holds the Windows form
+(``.\\src\\legacy_knot.py``, as recorded) and ``lizard_clean.csv`` the POSIX form
+(``src/clean.py``), because the recording ran on Windows and CI runs on Linux.
+"""
+
+from __future__ import absolute_import
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import List, Tuple
+
+from scripts.quality import complexity_gate as gate
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "newcode"
+MIXED_CSV = FIXTURES / "lizard_mixed.csv"
+CLEAN_CSV = FIXTURES / "lizard_clean.csv"
+NEWCODE_DIFF = FIXTURES / "newcode.diff"
+
+
+def _run(argv: List[str]) -> Tuple[int, str, str]:
+    """Invoke ``main`` and capture the exit code with both streams, kept APART.
+
+    Deliberately not the ``_run`` helpers in ``test_osv_severity_gate.py`` (which
+    concatenates the two streams) or ``test_apply_drift_pr.py`` (which returns a
+    call log): the passing path here asserts that stderr is *empty*, which a
+    concatenating helper cannot express.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        code = gate.main(argv)
+    return code, out.getvalue(), err.getvalue()
+
+
+class NormalizePathTests(unittest.TestCase):
+    """Every recorded path convention must collapse to one repo-relative form."""
+
+    def test_windows_backslash_form_becomes_posix(self) -> None:
+        """lizard on Windows records ``.\\src\\x.py``; CI compares against ``src/x.py``."""
+        self.assertEqual(gate.normalize_path(".\\src\\legacy_knot.py"), "src/legacy_knot.py")
+
+    def test_posix_dot_slash_prefix_is_stripped(self) -> None:
+        """lizard on Linux records ``./src/x.py``."""
+        self.assertEqual(gate.normalize_path("./src/clean.py"), "src/clean.py")
+
+    def test_repeated_dot_slash_prefixes_are_all_stripped(self) -> None:
+        """A doubled prefix must not survive as a mismatching key."""
+        self.assertEqual(gate.normalize_path("././src/clean.py"), "src/clean.py")
+
+    def test_already_relative_path_is_unchanged(self) -> None:
+        """The loop must also terminate immediately when there is no prefix."""
+        self.assertEqual(gate.normalize_path("src/clean.py"), "src/clean.py")
+
+    def test_surrounding_quotes_and_whitespace_are_stripped(self) -> None:
+        """Defensive: a hand-edited CSV can leave the quoting in the field."""
+        self.assertEqual(gate.normalize_path('  "src/clean.py"  '), "src/clean.py")
+
+    def test_absolute_path_is_made_relative_to_the_root(self) -> None:
+        """jscpd/lizard can emit absolute paths depending on how they are invoked."""
+        self.assertEqual(
+            gate.normalize_path("/home/runner/work/repo/repo/src/clean.py", root="/home/runner/work/repo/repo"),
+            "src/clean.py",
+        )
+
+    def test_absolute_path_outside_the_root_is_left_alone(self) -> None:
+        """A path the root does not prefix must not be silently truncated."""
+        self.assertEqual(gate.normalize_path("/elsewhere/src/clean.py", root="/home/runner"), "/elsewhere/src/clean.py")
+
+    def test_windows_root_is_normalized_before_comparison(self) -> None:
+        """A backslash root must still match a backslash path."""
+        self.assertEqual(gate.normalize_path("D:\\work\\repo\\src\\clean.py", root="D:\\work\\repo\\"), "src/clean.py")
+
+
+class ParseLizardCsvTests(unittest.TestCase):
+    """The CSV parser must read real lizard output, header-less and quoted."""
+
+    def test_real_mixed_report_yields_every_function(self) -> None:
+        """The recorded report holds nine functions across Python and Go."""
+        report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        self.assertEqual(len(report.functions), 9)
+        self.assertEqual(report.skipped_rows, 0)
+
+    def test_the_recorded_ccn_values_are_read_verbatim(self) -> None:
+        """These are the numbers the whole gate turns on; pin them."""
+        report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        by_name = {function.name: function for function in report.functions}
+        self.assertEqual(by_name["classify"].ccn, 21)
+        self.assertEqual(by_name["Knot"].ccn, 18)
+        self.assertEqual(by_name["load_settings"].ccn, 8)
+        self.assertEqual(by_name["read_config"].ccn, 8)
+        self.assertEqual(by_name["ok"].ccn, 1)
+
+    def test_spans_are_read_from_the_start_and_end_columns(self) -> None:
+        """Line-level scoping is only possible because lizard reports the span."""
+        report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        by_name = {function.name: function for function in report.functions}
+        self.assertEqual((by_name["classify"].start, by_name["classify"].end), (4, 42))
+        self.assertEqual((by_name["also_ok"].start, by_name["also_ok"].end), (50, 52))
+        self.assertEqual((by_name["Knot"].start, by_name["Knot"].end), (13, 59))
+
+    def test_paths_are_normalized_so_diff_keys_match(self) -> None:
+        """The recorded Windows paths must arrive as repo-relative POSIX keys."""
+        report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        self.assertEqual(
+            sorted({function.path for function in report.functions}),
+            ["src/clean.py", "src/legacy_knot.py", "src/legacy_settings.py", "src/new_knot.go", "src/new_settings.py"],
+        )
+
+    def test_a_signature_containing_commas_does_not_shift_columns(self) -> None:
+        """``classify( value , mode , ... )`` is quoted; naive splitting would misread it."""
+        report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        by_name = {function.name: function for function in report.functions}
+        self.assertEqual(by_name["classify"].path, "src/legacy_knot.py")
+        self.assertEqual(by_name["classify"].ccn, 21)
+
+    def test_clean_report_yields_one_trivial_function(self) -> None:
+        """The clean fixture is the PASS side of the both-states pair."""
+        report = gate.parse_lizard_csv(CLEAN_CSV.read_text(encoding="utf-8"))
+        self.assertEqual([(f.name, f.ccn, f.path) for f in report.functions], [("ok", 1, "src/clean.py")])
+
+    def test_empty_report_yields_no_functions(self) -> None:
+        """lizard on a tree with no functions emits an empty file."""
+        report = gate.parse_lizard_csv("")
+        self.assertEqual(report.functions, [])
+        self.assertEqual(report.skipped_rows, 0)
+
+    def test_blank_lines_are_not_counted_as_skipped_rows(self) -> None:
+        """The recorded files end with a newline; that is not a malformed row."""
+        report = gate.parse_lizard_csv("\n\n")
+        self.assertEqual(report.skipped_rows, 0)
+
+    def test_a_short_row_is_counted_as_skipped_not_silently_dropped(self) -> None:
+        """A truncated row means the report is suspect and must be reported."""
+        report = gate.parse_lizard_csv("1,2,3\n")
+        self.assertEqual(report.functions, [])
+        self.assertEqual(report.skipped_rows, 1)
+
+    def test_a_header_row_is_counted_as_skipped(self) -> None:
+        """lizard --csv emits no header, but a hand-made file might."""
+        header = "NLOC,CCN,token_count,param_count,length,name,file,function,signature,start,end\n"
+        report = gate.parse_lizard_csv(header)
+        self.assertEqual(report.functions, [])
+        self.assertEqual(report.skipped_rows, 1)
+
+    def test_a_row_with_a_non_numeric_span_is_skipped(self) -> None:
+        """Only the CCN and the span are load-bearing; both must be integers."""
+        row = '2,1,10,1,3,"ok@1-3@src/x.py","src/x.py","ok","ok( value )",one,3\n'
+        report = gate.parse_lizard_csv(row)
+        self.assertEqual(report.functions, [])
+        self.assertEqual(report.skipped_rows, 1)
+
+    def test_crlf_line_endings_parse_identically(self) -> None:
+        """The fixtures are stored LF but checked out CRLF on Windows."""
+        text = CLEAN_CSV.read_text(encoding="utf-8").replace("\n", "\r\n")
+        report = gate.parse_lizard_csv(text)
+        self.assertEqual([f.name for f in report.functions], ["ok"])
+        self.assertEqual(report.skipped_rows, 0)
+
+
+class ParseAddedRangesTests(unittest.TestCase):
+    """The diff parser decides what "new code" means; it must be exact."""
+
+    def test_real_diff_yields_one_range_per_hunk(self) -> None:
+        """The recorded diff has three files and one hunk each."""
+        ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+        self.assertEqual(
+            ranges,
+            {
+                "src/legacy_knot.py": [(48, 52)],
+                "src/new_knot.go": [(1, 59)],
+                "src/new_settings.py": [(1, 32)],
+            },
+        )
+
+    def test_a_hunk_with_no_count_covers_a_single_line(self) -> None:
+        """``@@ -12 +12 @@`` is the one-line form."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -12 +12 @@\n+value = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(12, 12)]})
+
+    def test_a_pure_deletion_hunk_adds_no_range(self) -> None:
+        """``+40,0`` added nothing, so it cannot make anything new code."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -40,3 +40,0 @@\n-gone = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {})
+
+    def test_a_deleted_file_contributes_no_ranges(self) -> None:
+        """``+++ /dev/null`` has no new side to scope against."""
+        diff = "diff --git a/x.py b/x.py\ndeleted file mode 100644\n--- a/x.py\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-gone = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {})
+
+    def test_multiple_hunks_in_one_file_are_all_recorded(self) -> None:
+        """A realistic PR touches a file in several places."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+a = 1\n+b = 2\n@@ -20,0 +30,1 @@\n+c = 3\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 2), (30, 30)]})
+
+    def test_a_hunk_before_any_file_header_is_ignored(self) -> None:
+        """A truncated diff must not attribute lines to the wrong file."""
+        self.assertEqual(gate.parse_added_ranges("@@ -1,0 +1,2 @@\n+a = 1\n"), {})
+
+    def test_a_malformed_hunk_header_is_ignored(self) -> None:
+        """An unparseable ``@@`` line must not crash or invent a range."""
+        diff = "--- a/x.py\n+++ b/x.py\n@@ this is not a hunk @@\n+a = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {})
+
+    def test_an_added_line_that_looks_like_a_file_header_is_not_one(self) -> None:
+        """Adding a line whose text starts with ``++ `` renders as ``+++ ``.
+
+        Only a ``+++`` immediately following a ``---`` is a real file header, so
+        the content line must not silently retarget every following hunk.
+        """
+        diff = "--- a/x.py\n+++ b/x.py\n@@ -1,0 +1,2 @@\n+++ not/a/header.py\n+a = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 2)]})
+
+    def test_paths_are_normalized_and_the_b_prefix_removed(self) -> None:
+        """``+++ b/src/x.py`` and a bare ``+++ src/x.py`` must key identically."""
+        with_prefix = gate.parse_added_ranges("--- a/src/x.py\n+++ b/src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
+        without_prefix = gate.parse_added_ranges("--- src/x.py\n+++ src/x.py\n@@ -0,0 +1,1 @@\n+a = 1\n")
+        self.assertEqual(with_prefix, {"src/x.py": [(1, 1)]})
+        self.assertEqual(without_prefix, {"src/x.py": [(1, 1)]})
+
+    def test_a_tab_separated_header_timestamp_is_dropped(self) -> None:
+        """``git diff`` omits it, but ``diff -u`` appends a tab and a timestamp."""
+        diff = "--- a/x.py\t2026-08-11\n+++ b/x.py\t2026-08-11\n@@ -0,0 +1,1 @@\n+a = 1\n"
+        self.assertEqual(gate.parse_added_ranges(diff), {"x.py": [(1, 1)]})
+
+    def test_crlf_diff_parses_identically(self) -> None:
+        """A diff captured on Windows carries CRLF."""
+        text = NEWCODE_DIFF.read_text(encoding="utf-8").replace("\n", "\r\n")
+        self.assertEqual(gate.parse_added_ranges(text)["src/new_knot.go"], [(1, 59)])
+
+
+class TouchesTests(unittest.TestCase):
+    """Span intersection is what makes the scope line-level."""
+
+    def _function(self, path: str, start: int, end: int) -> gate.FunctionMetric:
+        """Build a metric with only the fields intersection uses."""
+        return gate.FunctionMetric(path=path, name="f", ccn=99, start=start, end=end)
+
+    def test_a_function_with_no_ranges_in_its_file_is_untouched(self) -> None:
+        """The loop must terminate to ``False`` rather than raising."""
+        self.assertFalse(gate.touches(self._function("src/a.py", 1, 10), {}))
+
+    def test_a_hunk_inside_the_span_touches(self) -> None:
+        """The ordinary case: the PR edited the body of this function."""
+        self.assertTrue(gate.touches(self._function("src/a.py", 1, 10), {"src/a.py": [(5, 6)]}))
+
+    def test_a_hunk_after_the_span_does_not_touch(self) -> None:
+        """The recorded ``classify`` (4-42) vs the hunk at 48-52."""
+        self.assertFalse(gate.touches(self._function("src/a.py", 4, 42), {"src/a.py": [(48, 52)]}))
+
+    def test_a_hunk_before_the_span_does_not_touch(self) -> None:
+        """Symmetric case, so the comparison cannot be one-sided."""
+        self.assertFalse(gate.touches(self._function("src/a.py", 40, 50), {"src/a.py": [(1, 3)]}))
+
+    def test_a_hunk_overlapping_the_first_line_touches(self) -> None:
+        """Boundary: the range ends exactly on the function's first line."""
+        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(5, 10)]}))
+
+    def test_a_hunk_overlapping_the_last_line_touches(self) -> None:
+        """Boundary: the range starts exactly on the function's last line."""
+        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(20, 25)]}))
+
+    def test_a_later_range_still_touches_after_an_earlier_miss(self) -> None:
+        """The loop must keep scanning instead of returning on the first miss."""
+        self.assertTrue(gate.touches(self._function("src/a.py", 10, 20), {"src/a.py": [(1, 2), (15, 16)]}))
+
+    def test_a_range_in_a_different_file_does_not_touch(self) -> None:
+        """Keys are per-file; a same-numbered hunk elsewhere is irrelevant."""
+        self.assertFalse(gate.touches(self._function("src/a.py", 1, 10), {"src/b.py": [(1, 10)]}))
+
+
+class ClassifyTests(unittest.TestCase):
+    """The tiering decision, driven by the real recorded report."""
+
+    def setUp(self) -> None:
+        """Load the recorded report and diff once per test."""
+        self.functions = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8")).functions
+        self.ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+
+    def test_new_over_threshold_code_blocks(self) -> None:
+        """``Knot`` (CCN=18) is a brand-new Go function; it must block."""
+        verdict = gate.classify(self.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        self.assertEqual([function.name for function in verdict.blocking], ["Knot"])
+
+    def test_untouched_legacy_code_in_a_changed_file_is_demoted(self) -> None:
+        """THE crux: ``classify`` (CCN=21) lives in a changed FILE but untouched LINES."""
+        verdict = gate.classify(self.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        self.assertEqual([function.name for function in verdict.inventory], ["classify"])
+        self.assertNotIn("classify", [function.name for function in verdict.blocking])
+
+    def test_under_threshold_functions_appear_in_neither_tier(self) -> None:
+        """CCN=8 is well inside the bar; it is not debt and must not be listed."""
+        verdict = gate.classify(self.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        listed = [f.name for f in verdict.blocking] + [f.name for f in verdict.inventory]
+        self.assertNotIn("read_config", listed)
+        self.assertNotIn("load_settings", listed)
+        self.assertNotIn("also_ok", listed)
+
+    def test_unscoped_mode_demotes_everything(self) -> None:
+        """A push to main has no diff base, so nothing may block."""
+        verdict = gate.classify(self.functions, {}, gate.DEFAULT_MAX_CCN, scoped=False)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(sorted(f.name for f in verdict.inventory), ["Knot", "classify"])
+
+    def test_a_clean_report_produces_an_empty_verdict(self) -> None:
+        """The PASS side: nothing over threshold anywhere."""
+        clean = gate.parse_lizard_csv(CLEAN_CSV.read_text(encoding="utf-8")).functions
+        verdict = gate.classify(clean, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(verdict.inventory, [])
+
+    def test_lowering_the_threshold_pulls_more_functions_in(self) -> None:
+        """DETECTOR CONTROL: the threshold must actually be the comparison."""
+        verdict = gate.classify(self.functions, self.ranges, 7, scoped=True)
+        self.assertEqual(sorted(f.name for f in verdict.blocking), ["Knot", "read_config"])
+
+    def test_raising_the_threshold_above_the_worst_function_clears_it(self) -> None:
+        """The inverse control, so the comparison cannot be hardcoded."""
+        verdict = gate.classify(self.functions, self.ranges, 21, scoped=True)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(verdict.inventory, [])
+
+
+class ParseMaxCcnTests(unittest.TestCase):
+    """A threshold that cannot express a silent pass."""
+
+    def test_the_default_is_the_lizard_default(self) -> None:
+        """15 is lizard's own ``-C`` default and the estate's routing-table value."""
+        self.assertEqual(gate.DEFAULT_MAX_CCN, 15)
+
+    def test_a_plain_integer_is_accepted(self) -> None:
+        """The ordinary case."""
+        self.assertEqual(gate.parse_max_ccn("10"), 10)
+
+    def test_whitespace_is_tolerated(self) -> None:
+        """A workflow input can arrive padded."""
+        self.assertEqual(gate.parse_max_ccn(" 12 "), 12)
+
+    def test_zero_is_rejected(self) -> None:
+        """CCN is at least 1 for any real function, so 0 would block everything."""
+        with self.assertRaises(gate.ThresholdError):
+            gate.parse_max_ccn("0")
+
+    def test_a_negative_threshold_is_rejected(self) -> None:
+        """Nonsense input must be an error, not a silently inverted gate."""
+        with self.assertRaises(gate.ThresholdError):
+            gate.parse_max_ccn("-1")
+
+    def test_a_threshold_above_the_accepted_ceiling_is_rejected(self) -> None:
+        """An absurd bar is a switched-off gate wearing a threshold's clothes."""
+        with self.assertRaises(gate.ThresholdError):
+            gate.parse_max_ccn(str(gate.MAX_ACCEPTED_CCN + 1))
+
+    def test_the_ceiling_itself_is_accepted(self) -> None:
+        """The bound is inclusive; pin which side it falls on."""
+        self.assertEqual(gate.parse_max_ccn(str(gate.MAX_ACCEPTED_CCN)), gate.MAX_ACCEPTED_CCN)
+
+    def test_a_non_numeric_threshold_is_rejected(self) -> None:
+        """``--max-ccn high`` must not be read as "no limit"."""
+        with self.assertRaises(gate.ThresholdError):
+            gate.parse_max_ccn("high")
+
+    def test_a_float_threshold_is_rejected(self) -> None:
+        """CCN is a count; ``15.5`` means the caller misunderstood the knob."""
+        with self.assertRaises(gate.ThresholdError):
+            gate.parse_max_ccn("15.5")
+
+
+class RenderTests(unittest.TestCase):
+    """Demoted is not hidden: the T2 set must be printed in full."""
+
+    def setUp(self) -> None:
+        """Load the recorded report and diff once per test."""
+        self.report = gate.parse_lizard_csv(MIXED_CSV.read_text(encoding="utf-8"))
+        self.ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+
+    def test_the_demoted_function_is_named_with_its_span(self) -> None:
+        """A T2 row has to be actionable later, so it carries file, name and lines."""
+        verdict = gate.classify(self.report.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        text = gate.render_report(self.report, verdict, gate.DEFAULT_MAX_CCN)
+        self.assertIn("src/legacy_knot.py", text)
+        self.assertIn("classify", text)
+        self.assertIn("4-42", text)
+        self.assertIn("21", text)
+
+    def test_the_blocking_function_is_named(self) -> None:
+        """The blocking row must name the function the author has to simplify."""
+        verdict = gate.classify(self.report.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        text = gate.render_report(self.report, verdict, gate.DEFAULT_MAX_CCN)
+        self.assertIn("Knot", text)
+        self.assertIn("src/new_knot.go", text)
+
+    def test_an_empty_verdict_says_so_explicitly(self) -> None:
+        """Silence would be indistinguishable from a gate that did not run."""
+        clean = gate.parse_lizard_csv(CLEAN_CSV.read_text(encoding="utf-8"))
+        verdict = gate.classify(clean.functions, self.ranges, gate.DEFAULT_MAX_CCN, scoped=True)
+        text = gate.render_report(clean, verdict, gate.DEFAULT_MAX_CCN)
+        self.assertIn("1 function", text)
+        self.assertIn("0 over", text)
+
+    def test_unscoped_mode_is_labelled_as_inventory_only(self) -> None:
+        """The reader must be able to tell a T2-only run from a scoped one."""
+        verdict = gate.classify(self.report.functions, {}, gate.DEFAULT_MAX_CCN, scoped=False)
+        text = gate.render_report(self.report, verdict, gate.DEFAULT_MAX_CCN)
+        self.assertIn("inventory only", text)
+
+    def test_skipped_rows_are_disclosed(self) -> None:
+        """A partially-unreadable report must not look like a clean one."""
+        report = gate.parse_lizard_csv("1,2,3\n")
+        verdict = gate.classify(report.functions, {}, gate.DEFAULT_MAX_CCN, scoped=False)
+        self.assertIn("1 unreadable row", gate.render_report(report, verdict, gate.DEFAULT_MAX_CCN))
+
+    def test_a_fully_readable_report_does_not_mention_skipped_rows(self) -> None:
+        """The disclosure must be conditional, or it is noise."""
+        verdict = gate.classify(self.report.functions, {}, gate.DEFAULT_MAX_CCN, scoped=False)
+        self.assertNotIn("unreadable row", gate.render_report(self.report, verdict, gate.DEFAULT_MAX_CCN))
+
+
+class MainTests(unittest.TestCase):
+    """End-to-end: the four both-states directions, through the real CLI."""
+
+    def test_new_over_threshold_code_exits_blocked(self) -> None:
+        """BOTH-STATES 1/4: an over-threshold new function FAILS the lane."""
+        code, out, err = _run(["--csv", str(MIXED_CSV), "--diff", str(NEWCODE_DIFF)])
+        self.assertEqual(code, gate.EXIT_BLOCKED)
+        self.assertIn("FAIL gate-complexity", err)
+        self.assertIn("Knot", out)
+
+    def test_clean_new_code_exits_ok(self) -> None:
+        """BOTH-STATES 2/4: a clean report PASSES the lane."""
+        code, out, err = _run(["--csv", str(CLEAN_CSV), "--diff", str(NEWCODE_DIFF)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("PASS gate-complexity", out)
+        self.assertEqual(err, "")
+
+    def test_the_demoted_set_is_printed_on_the_passing_path(self) -> None:
+        """T2 must be visible even when the gate is green."""
+        code, out, _ = _run(["--csv", str(MIXED_CSV), "--max-ccn", "21"])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("PASS gate-complexity", out)
+
+    def test_without_a_diff_the_gate_never_blocks(self) -> None:
+        """A push to main has no base; it emits inventory and passes."""
+        code, out, err = _run(["--csv", str(MIXED_CSV)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("inventory only", out)
+        self.assertIn("classify", out)
+        self.assertIn("Knot", out)
+        self.assertEqual(err, "")
+
+    def test_an_explicit_threshold_is_honoured(self) -> None:
+        """DETECTOR CONTROL through the CLI, not just the pure function."""
+        code, out, _ = _run(["--csv", str(MIXED_CSV), "--diff", str(NEWCODE_DIFF), "--max-ccn", "7"])
+        self.assertEqual(code, gate.EXIT_BLOCKED)
+        self.assertIn("read_config", out)
+
+    def test_a_bad_threshold_is_a_config_error_not_a_pass(self) -> None:
+        """Exit 2 is distinguishable from both 0 and 1 by the workflow."""
+        code, _, err = _run(["--csv", str(MIXED_CSV), "--max-ccn", "0"])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-complexity", err)
+
+    def test_a_missing_csv_is_a_config_error(self) -> None:
+        """An unmeasured tree must never be reported as a clean one."""
+        code, _, err = _run(["--csv", str(FIXTURES / "does_not_exist.csv")])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-complexity", err)
+
+    def test_a_missing_diff_file_is_a_config_error(self) -> None:
+        """If the workflow promised a diff, an unreadable one is not "no scope"."""
+        code, _, err = _run(["--csv", str(MIXED_CSV), "--diff", str(FIXTURES / "nope.diff")])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-complexity", err)
+
+    def test_the_root_option_relativizes_absolute_paths(self) -> None:
+        """CI can invoke lizard in a way that records absolute paths."""
+        code, out, _ = _run(["--csv", str(MIXED_CSV), "--root", str(ROOT)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("src/legacy_knot.py", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_duplication_gate.py
+++ b/tests/test_duplication_gate.py
@@ -1,0 +1,360 @@
+"""Tests for the gate-8 duplication floor (T1 new-code-only tiering).
+
+``scripts/quality/duplication_gate.py`` reads a ``jscpd --reporters json`` report
+plus the change's unified diff and splits the detected clone pairs into
+
+* **BLOCK** - at least one side of the pair sits on lines this change added or
+  modified, i.e. the change introduced a copy, and
+* **T2** - clone pairs entirely on untouched lines, which are still PRINTED
+  (demoted, never hidden).
+
+"At least one side" is the rule, and the recorded fixture is exactly why: the
+clone pair is ``src/legacy_settings.py`` (untouched) against
+``src/new_settings.py`` (a brand-new file that copy-pasted it). Requiring BOTH
+sides to be new would let every copy-paste-from-legacy through - the single most
+common way duplication actually enters a codebase.
+
+Both jscpd fixtures are real ``jscpd@4.0.5 --reporters json`` output.
+"""
+
+from __future__ import absolute_import
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from tests.newcode_scope_support import NewCodeScopeContract
+
+from scripts.quality import duplication_gate as gate
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "newcode"
+MIXED_JSON = FIXTURES / "jscpd_mixed.json"
+CLEAN_JSON = FIXTURES / "jscpd_clean.json"
+NEWCODE_DIFF = FIXTURES / "newcode.diff"
+
+
+def _run(argv: List[str]) -> Tuple[int, str, str]:
+    """Invoke ``main`` and capture the exit code with both streams, kept APART.
+
+    The passing path asserts that stderr is *empty*, which the concatenating
+    ``_run`` in ``test_osv_severity_gate.py`` cannot express.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        code = gate.main(argv)
+    return code, out.getvalue(), err.getvalue()
+
+
+def _side(name: str, start: int, end: int) -> Dict[str, Any]:
+    """Build one side of a synthetic clone pair."""
+    return {"name": name, "start": start, "end": end}
+
+
+def _document(duplicates: List[Dict[str, Any]], clones: Any = None) -> str:
+    """Serialise a synthetic jscpd document, mirroring the real shape."""
+    total = {"clones": len(duplicates) if clones is None else clones}
+    return json.dumps({"duplicates": duplicates, "statistics": {"total": total}})
+
+
+def _pair(first: str, second: str, start: int = 6, end: int = 27) -> Dict[str, Any]:
+    """Build a synthetic clone pair between two files."""
+    return {
+        "firstFile": _side(first, start, end),
+        "secondFile": _side(second, start, end),
+        "lines": end - start + 1,
+        "tokens": 116,
+        "format": "python",
+    }
+
+
+class DuplicationScopeContractTests(NewCodeScopeContract, unittest.TestCase):
+    """Run the shared new-code scoping contract against THIS module's copy."""
+
+    module = gate
+
+
+class ParseJscpdJsonTests(unittest.TestCase):
+    """The parser must read real jscpd output, including its path convention."""
+
+    def test_real_report_yields_the_recorded_clone_pair(self) -> None:
+        """One python clone pair, legacy against the new copy."""
+        report = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(len(report.clones), 1)
+        clone = report.clones[0]
+        self.assertEqual(clone.first.path, "src/legacy_settings.py")
+        self.assertEqual(clone.second.path, "src/new_settings.py")
+
+    def test_the_recorded_spans_are_read_verbatim(self) -> None:
+        """Line-level scoping is only possible because jscpd reports both spans."""
+        clone = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8")).clones[0]
+        self.assertEqual((clone.first.start, clone.first.end), (6, 27))
+        self.assertEqual((clone.second.start, clone.second.end), (6, 27))
+
+    def test_the_size_and_language_are_carried_for_reporting(self) -> None:
+        """A T2 row must be actionable later, so it records how big the clone is."""
+        clone = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8")).clones[0]
+        self.assertEqual(clone.lines, 22)
+        self.assertEqual(clone.tokens, 116)
+        self.assertEqual(clone.language, "python")
+
+    def test_windows_separators_in_jscpd_names_are_normalized(self) -> None:
+        """jscpd recorded ``src\\legacy_settings.py``; the diff says ``src/...``."""
+        raw = json.loads(MIXED_JSON.read_text(encoding="utf-8"))
+        self.assertIn("\\", raw["duplicates"][0]["firstFile"]["name"])
+        report = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(report.clones[0].first.path, "src/legacy_settings.py")
+
+    def test_absolute_names_are_relativized_against_the_root(self) -> None:
+        """``jscpd --absolute`` emits absolute paths that would never match a diff key."""
+        document = _document([_pair("/w/repo/src/a.py", "/w/repo/src/b.py")])
+        report = gate.parse_jscpd_json(document, root="/w/repo")
+        self.assertEqual(report.clones[0].first.path, "src/a.py")
+        self.assertEqual(report.clones[0].second.path, "src/b.py")
+
+    def test_the_clean_report_yields_no_clones(self) -> None:
+        """The PASS side of the both-states pair."""
+        report = gate.parse_jscpd_json(CLEAN_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(report.clones, [])
+        self.assertEqual(report.skipped_entries, 0)
+
+    def test_the_reported_total_is_captured_for_cross_checking(self) -> None:
+        """jscpd's own count is an independent signal against a truncated report."""
+        self.assertEqual(gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8")).reported_clones, 1)
+        self.assertEqual(gate.parse_jscpd_json(CLEAN_JSON.read_text(encoding="utf-8")).reported_clones, 0)
+
+    def test_a_report_without_statistics_has_no_reported_total(self) -> None:
+        """The cross-check is optional; its absence must not crash the gate."""
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": []}))
+        self.assertIsNone(report.reported_clones)
+
+    def test_a_non_numeric_reported_total_is_ignored(self) -> None:
+        """A malformed statistics block must not be read as a real count."""
+        document = json.dumps({"duplicates": [], "statistics": {"total": {"clones": "many"}}})
+        self.assertIsNone(gate.parse_jscpd_json(document).reported_clones)
+
+    def test_a_statistics_block_of_the_wrong_type_is_ignored(self) -> None:
+        """Defensive: ``statistics`` or ``total`` may not be objects."""
+        self.assertIsNone(gate.parse_jscpd_json(json.dumps({"duplicates": [], "statistics": []})).reported_clones)
+        self.assertIsNone(
+            gate.parse_jscpd_json(json.dumps({"duplicates": [], "statistics": {"total": 5}})).reported_clones
+        )
+
+    def test_invalid_json_is_rejected(self) -> None:
+        """A truncated report is not an empty one."""
+        with self.assertRaises(gate.ReportError):
+            gate.parse_jscpd_json("{not json")
+
+    def test_a_non_object_document_is_rejected(self) -> None:
+        """A JSON array at the top level is not a jscpd report."""
+        with self.assertRaises(gate.ReportError):
+            gate.parse_jscpd_json("[]")
+
+    def test_a_missing_duplicates_key_is_rejected(self) -> None:
+        """No ``duplicates`` key means nothing was measured, which is not clean."""
+        with self.assertRaises(gate.ReportError):
+            gate.parse_jscpd_json(json.dumps({"statistics": {}}))
+
+    def test_a_non_list_duplicates_value_is_rejected(self) -> None:
+        """The shape has to be the shape, or the count means nothing."""
+        with self.assertRaises(gate.ReportError):
+            gate.parse_jscpd_json(json.dumps({"duplicates": {}}))
+
+    def test_an_entry_missing_a_side_is_counted_as_skipped(self) -> None:
+        """A pair we cannot locate must be disclosed, never silently dropped."""
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": [{"firstFile": _side("src/a.py", 1, 5)}]}))
+        self.assertEqual(report.clones, [])
+        self.assertEqual(report.skipped_entries, 1)
+
+    def test_an_entry_with_a_non_numeric_span_is_counted_as_skipped(self) -> None:
+        """Spans are load-bearing for scoping; a bad one cannot be guessed."""
+        broken = {"firstFile": _side("src/a.py", "x", 5), "secondFile": _side("src/b.py", 1, 5)}
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": [broken]}))
+        self.assertEqual(report.skipped_entries, 1)
+
+    def test_an_entry_missing_a_name_is_counted_as_skipped(self) -> None:
+        """Without a path there is nothing to compare against the diff."""
+        broken = {"firstFile": {"start": 1, "end": 5}, "secondFile": _side("src/b.py", 1, 5)}
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": [broken]}))
+        self.assertEqual(report.skipped_entries, 1)
+
+    def test_an_entry_that_is_not_an_object_is_counted_as_skipped(self) -> None:
+        """Defensive: the list may hold anything."""
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": ["nope"]}))
+        self.assertEqual(report.skipped_entries, 1)
+
+    def test_optional_reporting_fields_default_instead_of_skipping(self) -> None:
+        """``lines``/``tokens``/``format`` are report-only; their absence is tolerable."""
+        minimal = {"firstFile": _side("src/a.py", 1, 5), "secondFile": _side("src/b.py", 1, 5)}
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": [minimal]}))
+        self.assertEqual(report.skipped_entries, 0)
+        self.assertEqual((report.clones[0].lines, report.clones[0].tokens), (0, 0))
+        self.assertEqual(report.clones[0].language, "unknown")
+
+    def test_a_non_numeric_optional_field_falls_back_to_the_default(self) -> None:
+        """A junk ``lines`` value must not take down a locatable clone."""
+        entry = {"firstFile": _side("src/a.py", 1, 5), "secondFile": _side("src/b.py", 1, 5), "lines": "lots"}
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": [entry]}))
+        self.assertEqual(report.clones[0].lines, 0)
+
+
+class ClassifyTests(unittest.TestCase):
+    """The tiering decision, driven by the real recorded report."""
+
+    def setUp(self) -> None:
+        """Load the recorded report and diff once per test."""
+        self.report = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8"))
+        self.ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+
+    def test_a_copy_paste_into_a_new_file_blocks(self) -> None:
+        """THE case: only the SECOND side is new, and that is enough to block."""
+        verdict = gate.classify(self.report.clones, self.ranges, scoped=True)
+        self.assertEqual(len(verdict.blocking), 1)
+        self.assertEqual(verdict.inventory, [])
+
+    def test_a_clone_touched_only_on_the_first_side_also_blocks(self) -> None:
+        """The rule must be symmetric, or side order would decide the verdict."""
+        verdict = gate.classify(self.report.clones, {"src/legacy_settings.py": [(6, 10)]}, scoped=True)
+        self.assertEqual(len(verdict.blocking), 1)
+
+    def test_a_clone_on_untouched_lines_is_demoted(self) -> None:
+        """Pre-existing duplication must never block; that is the treadmill."""
+        verdict = gate.classify(self.report.clones, {"src/new_settings.py": [(100, 120)]}, scoped=True)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(len(verdict.inventory), 1)
+
+    def test_unscoped_mode_demotes_everything(self) -> None:
+        """A push to main has no diff base, so nothing may block."""
+        verdict = gate.classify(self.report.clones, {}, scoped=False)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(len(verdict.inventory), 1)
+
+    def test_a_clean_report_produces_an_empty_verdict(self) -> None:
+        """The PASS side: no clone pairs at all."""
+        clean = gate.parse_jscpd_json(CLEAN_JSON.read_text(encoding="utf-8"))
+        verdict = gate.classify(clean.clones, self.ranges, scoped=True)
+        self.assertEqual(verdict.blocking, [])
+        self.assertEqual(verdict.inventory, [])
+
+
+class RenderTests(unittest.TestCase):
+    """Demoted is not hidden: the T2 set must be printed in full."""
+
+    def setUp(self) -> None:
+        """Load the recorded report and diff once per test."""
+        self.report = gate.parse_jscpd_json(MIXED_JSON.read_text(encoding="utf-8"))
+        self.ranges = gate.parse_added_ranges(NEWCODE_DIFF.read_text(encoding="utf-8"))
+
+    def test_a_blocking_row_names_both_sides_with_their_spans(self) -> None:
+        """The author has to be able to find both copies from the log alone."""
+        verdict = gate.classify(self.report.clones, self.ranges, scoped=True)
+        text = gate.render_report(self.report, verdict)
+        self.assertIn("src/new_settings.py:6-27", text)
+        self.assertIn("src/legacy_settings.py:6-27", text)
+        self.assertIn("22 line", text)
+
+    def test_a_demoted_row_is_printed_too(self) -> None:
+        """T2 visible on the green path, or the gate hides what it did not enforce."""
+        verdict = gate.classify(self.report.clones, {}, scoped=False)
+        text = gate.render_report(self.report, verdict)
+        self.assertIn("T2 INVENTORY (1)", text)
+        self.assertIn("src/legacy_settings.py:6-27", text)
+
+    def test_an_empty_report_says_so_explicitly(self) -> None:
+        """Silence is indistinguishable from a gate that never ran."""
+        clean = gate.parse_jscpd_json(CLEAN_JSON.read_text(encoding="utf-8"))
+        verdict = gate.classify(clean.clones, self.ranges, scoped=True)
+        self.assertIn("0 clone pair(s)", gate.render_report(clean, verdict))
+
+    def test_unscoped_mode_is_labelled_as_inventory_only(self) -> None:
+        """A reader must be able to tell a T2-only run from a scoped one."""
+        verdict = gate.classify(self.report.clones, {}, scoped=False)
+        self.assertIn("inventory only", gate.render_report(self.report, verdict))
+
+    def test_scoped_mode_is_labelled(self) -> None:
+        """The scope line must state which definition of new code was applied."""
+        verdict = gate.classify(self.report.clones, self.ranges, scoped=True)
+        self.assertIn("T1 new-code-only", gate.render_report(self.report, verdict))
+
+    def test_skipped_entries_are_disclosed(self) -> None:
+        """A partially-unreadable report must not read as a clean one."""
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": ["nope"]}))
+        verdict = gate.classify(report.clones, {}, scoped=False)
+        self.assertIn("1 unreadable entr", gate.render_report(report, verdict))
+
+    def test_a_count_mismatch_against_jscpd_own_total_is_disclosed(self) -> None:
+        """Two independent signals disagreeing means the report is not trustworthy."""
+        report = gate.parse_jscpd_json(_document([_pair("src/a.py", "src/b.py")], clones=5))
+        verdict = gate.classify(report.clones, {}, scoped=False)
+        self.assertIn("jscpd reported 5", gate.render_report(report, verdict))
+
+    def test_a_matching_count_is_not_flagged(self) -> None:
+        """The disclosure must be conditional, or it is noise on every run."""
+        verdict = gate.classify(self.report.clones, {}, scoped=False)
+        self.assertNotIn("jscpd reported", gate.render_report(self.report, verdict))
+
+    def test_a_report_without_a_total_is_not_flagged(self) -> None:
+        """No cross-check available is not the same as a failed cross-check."""
+        report = gate.parse_jscpd_json(json.dumps({"duplicates": []}))
+        verdict = gate.classify(report.clones, {}, scoped=False)
+        self.assertNotIn("jscpd reported", gate.render_report(report, verdict))
+
+
+class MainTests(unittest.TestCase):
+    """End-to-end: the four both-states directions, through the real CLI."""
+
+    def test_a_copy_pasted_block_exits_blocked(self) -> None:
+        """BOTH-STATES 3/4: a new copy-paste FAILS the lane."""
+        code, out, err = _run(["--json", str(MIXED_JSON), "--diff", str(NEWCODE_DIFF)])
+        self.assertEqual(code, gate.EXIT_BLOCKED)
+        self.assertIn("FAIL gate-duplication", err)
+        self.assertIn("src/new_settings.py:6-27", out)
+
+    def test_unique_code_exits_ok(self) -> None:
+        """BOTH-STATES 4/4: a report with no clones PASSES the lane."""
+        code, out, err = _run(["--json", str(CLEAN_JSON), "--diff", str(NEWCODE_DIFF)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("PASS gate-duplication", out)
+        self.assertEqual(err, "")
+
+    def test_without_a_diff_the_gate_never_blocks(self) -> None:
+        """A push to main has no base; it emits inventory and passes."""
+        code, out, err = _run(["--json", str(MIXED_JSON)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("inventory only", out)
+        self.assertIn("src/legacy_settings.py:6-27", out)
+        self.assertEqual(err, "")
+
+    def test_a_missing_report_is_a_config_error(self) -> None:
+        """An unmeasured tree must never be reported as a clean one."""
+        code, _, err = _run(["--json", str(FIXTURES / "does_not_exist.json")])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-duplication", err)
+
+    def test_a_malformed_report_is_a_config_error(self) -> None:
+        """Exit 2 is distinguishable from both 0 and 1 by the workflow."""
+        broken = FIXTURES / "does_not_exist_broken.json"
+        self.addCleanup(broken.unlink, missing_ok=True)
+        broken.write_text("{not json", encoding="utf-8")
+        code, _, err = _run(["--json", str(broken)])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-duplication", err)
+
+    def test_a_missing_diff_file_is_a_config_error(self) -> None:
+        """If the workflow promised a diff, an unreadable one is not "no scope"."""
+        code, _, err = _run(["--json", str(MIXED_JSON), "--diff", str(FIXTURES / "nope.diff")])
+        self.assertEqual(code, gate.EXIT_CONFIG_ERROR)
+        self.assertIn("ERROR gate-duplication", err)
+
+    def test_the_root_option_is_accepted(self) -> None:
+        """CI can invoke jscpd with --absolute; the gate must cope."""
+        code, out, _ = _run(["--json", str(MIXED_JSON), "--root", str(ROOT)])
+        self.assertEqual(code, gate.EXIT_OK)
+        self.assertIn("src/legacy_settings.py", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the headline gap: the lean gate had **no complexity lane and no duplication lane** — the two things you originally named — because they were Codacy''s job and retiring Codacy removed them with nothing in their place.

> **Read the title.** This adds the two gates as tested, working modules. It does **not** wire them into `reusable-quality.yml`. Gates 7 and 8 do not run in CI yet. Wiring is the remaining step and is deliberately not in this PR.

## What is here

1954 lines: `complexity_gate.py` (lizard) and `duplication_gate.py` (jscpd), their tests, a shared new-code scoping contract, and recorded real tool output as hermetic fixtures so the tests never invoke lizard or jscpd.

**T1, new-code-only, by design.** Scoped to `git diff origin/<base>...HEAD`. Repo-wide complexity-zero on legacy code is unreachable and would rebuild exactly the treadmill you escaped. New code must be clean; legacy debt is inventoried and printed, never blocking.

## Both-states, run against the built gates rather than asserted

```
COMPLEXITY (gate 7)
  over-CCN function inside the diff   -> 1   BLOCKS
  clean function inside the diff      -> 0   PASSES
  over-CCN function, no diff at all   -> 0   unscoped never blocks
DUPLICATION (gate 8)
  clone touching new code             -> 1   BLOCKS
  no clones at all                    -> 0   PASSES
  clones present, no diff             -> 0   unscoped never blocks
  unreadable --diff                   -> 2   CONFIG ERROR, not a silent pass
```

The third row of each is the property that makes the target reachable. The last row is the silent-pass guard: degrading a broken `--diff` to "no scope" would make the run unscoped, and unscoped blocks nothing — so a misinvocation would present as a permanent pass.

## Provenance — three agents died on this

The first two committed nothing; their output was unrecoverable. The third carried a commit-after-every-milestone mandate, banked the fixtures and the complexity module, then died mid-refactor with 954 lines uncommitted. I established death by three independent signals (branch static for hours, zero worktree writes in 30 minutes, transcript silent 2h44m), committed the salvage as an explicitly-red checkpoint so a fourth death could not cost it, then fixed forward.

Three defects the interrupted refactor left, all closed:

1. `NameError` on `scoped` — resolved from the code''s own evidence (the docstring, the tests passing `scoped=False`, and the guard that only blocks when scoped), not guessed.
2. The shared scoping block had **drifted** between the two gates. Caught by `test_newcode_scope_parity.py`, a guard the original agent wrote itself: *"Two gates disagreeing on the scope would be a silent tiering bug."*
3. Fixing (2) then dropped coverage to 99.77%, which exposed the real defect: `duplication_gate.main()` never called the shared `load_added_ranges` — it **reimplemented** it inline, same semantics, same error text, sitting just *below* the `jscpd:ignore` marker where the parity guard could not see it. Rather than test dead code, `main()` now calls the shared function. The two gates can no longer diverge on what "new code" means.

Worth noting the order: the coverage gate is what caught (3). The parity test went green after the sync and would have let a dead import through on its own.

## Verification

`bash scripts/verify` → exit **0**, `Ran 1777 tests`, `OK (skipped=1)`, 18 repo profiles validated, working tree clean, coverage 100%.

## Next step, not done here

Wiring into `reusable-quality.yml`: pinned lizard + jscpd installs, `fetch-depth: 0` so `origin/main...HEAD` resolves (checkout defaults to depth 1), the two gate steps, and a workflow-contract test. Kept separate because it touches the file every governed repo executes.